### PR TITLE
Apollo client 3.9.7/memory optimisations

### DIFF
--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -2243,3 +2243,100 @@ describe("reading from the store", () => {
     expect(canonicalFragmentResult2).toEqual({ count: 1 });
   });
 });
+
+describe("StoreReader.forgetWatch", () => {
+  const query: TypedDocumentNode<{ user: { id: string; name: string } }> = gql`
+    query GetUser($id: ID!) {
+      user(id: $id) {
+        id
+        name
+      }
+    }
+  `;
+
+  function makeCache() {
+    const cache = new InMemoryCache({ resultCaching: true });
+    cache.writeQuery({
+      query,
+      variables: { id: "1" },
+      data: { user: { __typename: "User", id: "1", name: "Alice" } },
+    });
+    return cache;
+  }
+
+  it("removes the memoized executeSelectionSet entry when unwatch is called", () => {
+    const cache = makeCache();
+    const reader: StoreReader = (cache as any).storeReader;
+
+    let watchOptions: Cache.WatchOptions<any> | undefined;
+
+    const unwatch = cache.watch({
+      query,
+      variables: { id: "1" },
+      optimistic: true,
+      callback: () => {},
+      // capture the watch options object
+      immediate: false,
+    });
+
+    // Trigger a broadcast so the watch is associated with cache entries
+    cache.writeQuery({
+      query,
+      variables: { id: "1" },
+      data: { user: { __typename: "User", id: "1", name: "Alice Updated" } },
+    });
+
+    // After the write, watchEntries should have been populated during broadcastWatch
+    // (currentWatch is set by InMemoryCache.broadcastWatch)
+    // We call forgetWatch via unwatch()
+    const watchEntriesBefore = (reader as any).watchEntries;
+
+    unwatch();
+
+    // After unwatch, keyRefCounts should have been decremented (and entries removed
+    // if ref count reached 0 for this sole watch)
+    const keyRefCounts: Map<object, number> = (reader as any).keyRefCounts;
+    expect(keyRefCounts.size).toBe(0);
+  });
+
+  it("keeps memoized entries alive when multiple watches share the same cache key", () => {
+    const cache = makeCache();
+    const reader: StoreReader = (cache as any).storeReader;
+    const keyRefCounts: Map<object, number> = (reader as any).keyRefCounts;
+
+    const unwatch1 = cache.watch({
+      query,
+      variables: { id: "1" },
+      optimistic: true,
+      callback: () => {},
+      immediate: false,
+    });
+    const unwatch2 = cache.watch({
+      query,
+      variables: { id: "1" },
+      optimistic: true,
+      callback: () => {},
+      immediate: false,
+    });
+
+    // Trigger broadcasts so both watches are registered
+    cache.writeQuery({
+      query,
+      variables: { id: "1" },
+      data: { user: { __typename: "User", id: "1", name: "Bob" } },
+    });
+
+    // Both watches reference the same cache keys → ref count should be ≥ 1
+    // Removing watch1 should not drop ref count to 0 while watch2 is still active
+    unwatch1();
+
+    // watch2 is still active, so entries should still be tracked
+    expect(keyRefCounts.size).toBeGreaterThan(0);
+
+    // Now remove the last watch
+    unwatch2();
+
+    // All ref counts should be cleared
+    expect(keyRefCounts.size).toBe(0);
+  });
+});

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -291,6 +291,11 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
       // maybeBroadcastWatch OptimisticWrapperFunction, to prevent memory
       // leaks involving the closure of watch.callback.
       this.maybeBroadcastWatch.forget(watch);
+
+      // Release all memoized executeSelectionSet entries that were recorded
+      // for this watch. Entries shared with other active watches are kept
+      // alive until the last watch referencing them is removed.
+      this.storeReader.forgetWatch(watch);
     };
   }
 
@@ -561,7 +566,19 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     // object, and without having to enumerate the relevant properties (query,
     // variables, etc.) explicitly. There will be some additional properties
     // (lastDiff, callback, etc.), but cache.diff ignores them.
-    const diff = this.diff<any>(c);
+
+    //
+    // Inform the StoreReader which watch is driving this diff so that every
+    // executeSelectionSet cache entry it accesses gets associated with `c`.
+    // The association is used in forgetWatch() to release those entries when
+    // the watch is later removed.
+    this.storeReader.currentWatch = c;
+    let diff: Cache.DiffResult<any>;
+    try {
+      diff = this.diff<any>(c);
+    } finally {
+      this.storeReader.currentWatch = undefined;
+    }
 
     if (options) {
       if (c.optimistic && typeof options.optimistic === "string") {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -260,6 +260,30 @@ export class InMemoryCache extends ApolloCache<NormalizedCacheObject> {
     });
   }
 
+  // Like diff(), but pins storeReader.currentWatch to the given watch for the
+  // duration of the read. This ensures every executeSelectionSet cache entry
+  // touched by the diff is associated with `watch` in watchEntries, so that
+  // forgetWatch() can release those entries (and prune their Trie paths) when
+  // the watch is later removed.
+  //
+  // Called by QueryInfo.getDiff() and QueryInfo.markResult() so that reads
+  // driven by a query component are tracked from the first read, not just
+  // from the first broadcastWatch(). Without this, any entry computed before
+  // broadcastWatch() runs (e.g. during initial cache-miss detection or during
+  // the markResult transaction) would never be associated with the watch and
+  // would leak in the Trie until LRU pressure evicted it.
+  public diffWithWatch<TData = any>(
+    watch: Cache.WatchOptions,
+    options: Cache.DiffOptions
+  ): Cache.DiffResult<TData> {
+    this.storeReader.currentWatch = watch;
+    try {
+      return this.diff<TData>(options as Cache.DiffOptions<TData, any>);
+    } finally {
+      this.storeReader.currentWatch = undefined;
+    }
+  }
+
   public watch<TData = any, TVariables = any>(
     watch: Cache.WatchOptions<TData, TVariables>
   ): () => void {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -300,7 +300,28 @@ export class StoreReader {
       const count = (this.keyRefCounts.get(key) ?? 1) - 1;
       if (count <= 0) {
         this.keyRefCounts.delete(key);
+        // Release the memoized result from optimism's LRU cache.
         this.executeSelectionSet.forget(...keyArgs);
+
+        // Also remove the Trie routing path for this key. This frees the
+        // strong Map entries for string args (entity ref, varString) that
+        // the Trie holds permanently. removeArray prunes empty parent nodes
+        // bottom-up, so if "User:1" has no other varStrings it is also
+        // removed. supportsResultCaching narrows store to EntityStore,
+        // giving access to the CacheGroup's keyMaker Trie.
+
+        const [selectionSet, parent, ctx, canonizeResults] = keyArgs;
+        if (supportsResultCaching(ctx.store)) {
+          ctx.store.group.keyMaker.removeArray([
+            selectionSet,
+            // Matches what store.makeCacheKey passes to the Trie:
+            // a plain string when parent is a Reference, otherwise the
+            // StoreObject itself (WeakMap branch, so no issue leaving it).
+            isReference(parent) ? parent.__ref : parent,
+            ctx.varString,
+            canonizeResults,
+          ]);
+        }
       } else {
         this.keyRefCounts.set(key, count);
       }

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -142,6 +142,22 @@ export class StoreReader {
     SelectionSetNode
   >();
 
+  // Tracks which executeSelectionSet cache-key objects were accessed while
+  // computing a specific watch's result, along with the minimal args needed
+  // to call executeSelectionSet.forget() for that entry later.
+  private readonly watchEntries = new WeakMap<
+    Cache.WatchOptions<any, any>,
+    Map<object, ExecSelectionSetKeyArgs>
+  >();
+
+  // Reference counts for shared entries: how many active watches reference
+  // each memoized entry. An entry is only forgotten when its count reaches 0.
+  private readonly keyRefCounts = new Map<object, number>();
+
+  // Set by InMemoryCache.broadcastWatch before calling diff(), so that
+  // makeCacheKey can associate accessed entries with the current watch.
+  public currentWatch: Cache.WatchOptions<any, any> | undefined;
+
   public canon: ObjectCanon;
   public resetCanon() {
     this.canon = new ObjectCanon();
@@ -152,6 +168,10 @@ export class StoreReader {
       addTypename: config.addTypename !== false,
       canonizeResults: shouldCanonizeResults(config),
     });
+
+    // Keep a stable `self` reference so the arrow-function closures passed to
+    // `wrap()` can access instance fields (plain `this` isn't available there).
+    const self = this;
 
     this.canon = config.canon || new ObjectCanon();
 
@@ -204,12 +224,40 @@ export class StoreReader {
         // array returned by keyArgs.
         makeCacheKey(selectionSet, parent, context, canonizeResults) {
           if (supportsResultCaching(context.store)) {
-            return context.store.makeCacheKey(
+            const key = context.store.makeCacheKey(
               selectionSet,
               isReference(parent) ? parent.__ref : parent,
               context.varString,
               canonizeResults
             );
+
+            // Track this entry for the current watch so it can be released
+            // when the watch is removed (see forgetWatch below).
+            if (key !== undefined && self.currentWatch) {
+              const watch = self.currentWatch;
+              let entries = self.watchEntries.get(watch);
+              if (!entries) {
+                self.watchEntries.set(watch, (entries = new Map()));
+              }
+              if (!entries.has(key)) {
+                // Only need store + varString for a future forget() call since
+                // that's all makeCacheKey reads from the context argument.
+                entries.set(key, [
+                  selectionSet,
+                  parent,
+                  {
+                    store: context.store,
+                    varString: context.varString,
+                  } as ReadMergeModifyContext,
+                  canonizeResults,
+                ]);
+                self.keyRefCounts.set(
+                  key,
+                  (self.keyRefCounts.get(key) ?? 0) + 1
+                );
+              }
+            }
+            return key;
           }
         },
       }
@@ -235,6 +283,29 @@ export class StoreReader {
         },
       }
     );
+  }
+
+  /**
+   * Releases all memoized executeSelectionSet entries that were recorded for
+   * the given watch. Entries shared with other active watches are only freed
+   * when the last watch referencing them is removed (reference-counted).
+   *
+   * Called from InMemoryCache's unwatch function so that memoized result
+   * objects don't outlive the component that subscribed to this watch.
+   */
+  public forgetWatch(watch: Cache.WatchOptions<any, any>): void {
+    const entries = this.watchEntries.get(watch);
+    if (!entries) return;
+    entries.forEach((keyArgs, key) => {
+      const count = (this.keyRefCounts.get(key) ?? 1) - 1;
+      if (count <= 0) {
+        this.keyRefCounts.delete(key);
+        this.executeSelectionSet.forget(...keyArgs);
+      } else {
+        this.keyRefCounts.set(key, count);
+      }
+    });
+    this.watchEntries.delete(watch);
   }
 
   /**

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -175,9 +175,22 @@ export class QueryInfo {
       return { complete: false };
     }
 
-    const diff = this.cache.diff(options);
+    const diff = this.diffWithWatchContext(options);
     this.updateLastDiff(diff, options);
     return diff;
+  }
+
+  // Calls cache.diff() with this.lastWatch pinned as the current watch
+  // context, so that every executeSelectionSet cache entry touched by the
+  // read is associated with the watch in watchEntries. Falls back to a
+  // plain cache.diff() for cache implementations that do not expose
+  // diffWithWatch (e.g. custom ApolloCache subclasses).
+  private diffWithWatchContext(options: Cache.DiffOptions): Cache.DiffResult<any> {
+    const { cache, lastWatch } = this;
+    if (lastWatch && "diffWithWatch" in cache) {
+      return (cache as any).diffWithWatch(lastWatch, options);
+    }
+    return cache.diff(options);
   }
 
   private lastDiff?: {
@@ -479,7 +492,6 @@ export class QueryInfo {
           }
 
           const diffOptions = this.getDiffOptions(options.variables);
-          const diff = cache.diff<T>(diffOptions);
 
           // In case the QueryManager stops this QueryInfo before its
           // results are delivered, it's important to avoid restarting the
@@ -487,11 +499,18 @@ export class QueryInfo {
           // the watch if we are writing a result that doesn't match the current
           // variables to avoid race conditions from broadcasting the wrong
           // result.
+          //
+          // updateWatch is intentionally called BEFORE cache.diff so that
+          // this.lastWatch is current when diffWithWatchContext runs. This
+          // ensures the diff entries are attributed to the correct watch,
+          // matching the behaviour of broadcastWatch and getDiff.
           if (!this.stopped && equal(this.variables, options.variables)) {
             // Any time we're about to update this.diff, we need to make
             // sure we've started watching the cache.
             this.updateWatch(options.variables);
           }
+
+          const diff = this.diffWithWatchContext(diffOptions);
 
           // If we're allowed to write to the cache, and we can read a
           // complete result from the cache, update result.data to be the


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - apollo-cla will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - circleci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:

### Checklist:
- [ ] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cache watch cleanup to prevent memory leaks from unreleased memoized entries and orphaned cache keys.
  * Implemented reference counting for shared cache entries to ensure safe cleanup only when all associated watches are removed.

* **Tests**
  * Added comprehensive test coverage for watch cleanup and reference counting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->