### PR TITLE
Silence warnings that should be muted

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -1182,7 +1182,7 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/cache.ts:96:7 - (ae-forgotten-export) The symbol "MaybeMasked" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:93:7 - (ae-forgotten-export) The symbol "MaybeMasked" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:93:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:162:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -2648,8 +2648,8 @@ export function wrapQueryRef<TData, TVariables extends OperationVariables>(inter
 // src/react/hooks/useBackgroundQuery.ts:52:3 - (ae-forgotten-export) The symbol "FetchMoreFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useBackgroundQuery.ts:76:4 - (ae-forgotten-export) The symbol "RefetchFunction" needs to be exported by the entry point index.d.ts
 // src/react/hooks/useSuspenseFragment.ts:70:5 - (ae-forgotten-export) The symbol "From" needs to be exported by the entry point index.d.ts
-// src/react/query-preloader/createQueryPreloader.ts:81:5 - (ae-forgotten-export) The symbol "PreloadQueryFetchPolicy" needs to be exported by the entry point index.d.ts
-// src/react/query-preloader/createQueryPreloader.ts:121:3 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
+// src/react/query-preloader/createQueryPreloader.ts:78:5 - (ae-forgotten-export) The symbol "PreloadQueryFetchPolicy" needs to be exported by the entry point index.d.ts
+// src/react/query-preloader/createQueryPreloader.ts:118:3 - (ae-forgotten-export) The symbol "RefetchWritePolicy" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -835,6 +835,9 @@ interface DeleteModifier {
 // @public (undocumented)
 const _deleteModifier: unique symbol;
 
+// @public (undocumented)
+export type DeprecationName = keyof PossibleDeprecations | NonNullable<PossibleDeprecations[keyof PossibleDeprecations]>[number];
+
 // @public @deprecated (undocumented)
 export const DEV: boolean;
 
@@ -1978,6 +1981,11 @@ type MutationUpdaterFunction<TData, TVariables, TContext, TCache extends ApolloC
     variables?: TVariables;
 }) => void;
 
+// Warning: (ae-forgotten-export) The symbol "WithValueArgs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export function muteDeprecations<TResult, TArgs extends any[], TThis = any>(name: DeprecationName | DeprecationName[], ...args: WithValueArgs<TResult, TArgs, TThis>): TResult;
+
 // @public
 enum NetworkStatus {
     error = 8,
@@ -2221,6 +2229,85 @@ class Policies {
     // (undocumented)
     readonly usingPossibleTypes = false;
 }
+
+// @public (undocumented)
+export type PossibleDeprecations = {
+    "cache.readQuery": ["canonizeResults"];
+    "cache.readFragment": ["canonizeResults"];
+    "cache.updateQuery": ["canonizeResults"];
+    "cache.updateFragment": ["canonizeResults"];
+    InMemoryCache: ["addTypename", "canonizeResults"];
+    "cache.read": ["canonizeResults"];
+    "cache.diff": ["canonizeResults"];
+    "cache.gc": ["resetResultIdentities"];
+    ApolloClient: [
+    "connectToDevTools",
+    "uri",
+    "credentials",
+    "headers",
+    "name",
+    "version",
+    "typeDefs"
+    ];
+    "client.watchQuery": ["canonizeResults", "partialRefetch"];
+    "client.query": ["canonizeResults", "notifyOnNetworkStatusChange"];
+    setOptions: ["canonizeResults"];
+    useBackgroundQuery: ["canonizeResults"];
+    useFragment: ["canonizeResults"];
+    useLazyQuery: [
+    "canonizeResults",
+    "variables",
+    "context",
+    "onCompleted",
+    "onError",
+    "defaultOptions",
+    "initialFetchPolicy",
+    "partialRefetch"
+    ];
+    "useLazyQuery.execute": [
+    "initialFetchPolicy",
+    "onCompleted",
+    "onError",
+    "defaultOptions",
+    "partialRefetch",
+    "canonizeResults",
+    "query",
+    "ssr",
+    "client",
+    "fetchPolicy",
+    "nextFetchPolicy",
+    "refetchWritePolicy",
+    "errorPolicy",
+    "pollInterval",
+    "notifyOnNetworkStatusChange",
+    "returnPartialData",
+    "skipPollAttempt"
+    ];
+    useLoadableQuery: ["canonizeResults"];
+    useMutation: ["ignoreResults"];
+    useQuery: [
+    "canonizeResults",
+    "partialRefetch",
+    "defaultOptions",
+    "onCompleted",
+    "onError"
+    ];
+    useSuspenseQuery: ["canonizeResults"];
+    preloadQuery: ["canonizeResults"];
+    MockedProvider: ["connectToDevTools", "addTypename"];
+    ObservableQuery: [
+    "observableQuery.result",
+    "getLastResult",
+    "getLastError",
+    "resetLastResults",
+    "setOptions"
+    ];
+    HOC: [
+    "graphql" | "withQuery" | "withMutation" | "withSubscription",
+    "parser"
+    ];
+    RenderProps: ["<Query />" | "<Mutation />" | "<Subscription />"];
+};
 
 // @public (undocumented)
 type PossibleTypesMap = {
@@ -2917,6 +3004,12 @@ export function valueToObjectRepresentation(argObj: any, name: NameNode, value: 
 // @public (undocumented)
 export type VariableValue = (node: VariableNode) => any;
 
+// @public (undocumented)
+export function warnDeprecated(name: DeprecationName, cb: () => void): void;
+
+// @public (undocumented)
+export function warnRemovedOption<TOptions extends Record<string, any>, CallSite extends keyof PossibleDeprecations>(options: TOptions, name: keyof TOptions & PossibleDeprecations[CallSite][number], callSite: CallSite, recommendation?: string): void;
+
 // @public
 interface WatchFragmentOptions<TData, TVars> {
     fragment: DocumentNode | TypedDocumentNode<TData, TVars>;
@@ -2947,6 +3040,13 @@ type WatchQueryFetchPolicy = FetchPolicy | "cache-and-network";
 interface WatchQueryOptions<TVariables extends OperationVariables = OperationVariables, TData = any> extends SharedWatchQueryOptions<TVariables, TData> {
     query: DocumentNode | TypedDocumentNode<TData, TVariables>;
 }
+
+// @public (undocumented)
+type WithValueArgs<TResult, TArgs extends any[], TThis> = [
+callback: (this: TThis, ...args: TArgs) => TResult,
+args?: TArgs | undefined,
+thisArg?: TThis | undefined
+];
 
 // @public (undocumented)
 export function wrapPromiseWithState<TValue>(promise: Promise<TValue>): PromiseWithState<TValue>;

--- a/.changeset/calm-kangaroos-tie.md
+++ b/.changeset/calm-kangaroos-tie.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue where muting a deprecation from one entrypoint would not mute the warning when checked in a different entrypoint. This caused some rogue deprecation warnings to appear in the console even though the warnings should have been muted.

--- a/.changeset/two-rings-work.md
+++ b/.changeset/two-rings-work.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure deprecation warnings are properly silenced in React hooks when globally disabled.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,4 +1,4 @@
 {
-  "dist/apollo-client.min.cjs": 42779,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 34818
+  "dist/apollo-client.min.cjs": 42819,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 34866
 }

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -493,6 +493,7 @@ Array [
   "mergeDeepArray",
   "mergeIncrementalData",
   "mergeOptions",
+  "muteDeprecations",
   "offsetLimitPagination",
   "omitDeep",
   "preventUnhandledRejection",
@@ -509,6 +510,8 @@ Array [
   "stringifyForDisplay",
   "stripTypename",
   "valueToObjectRepresentation",
+  "warnDeprecated",
+  "warnRemovedOption",
   "wrapPromiseWithState",
 ]
 `;

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -36,10 +36,7 @@ import type {
   MaybeMasked,
   Unmasked,
 } from "../../masking/index.js";
-import {
-  muteDeprecations,
-  warnRemovedOption,
-} from "../../utilities/deprecation/index.js";
+import { muteDeprecations, warnRemovedOption } from "../../utilities/index.js";
 
 export type Transaction<T> = (c: ApolloCache<T>) => void;
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -34,10 +34,7 @@ import { Policies } from "./policies.js";
 import { hasOwn, normalizeConfig, shouldCanonizeResults } from "./helpers.js";
 import type { OperationVariables } from "../../core/index.js";
 import { getInMemoryCacheMemoryInternals } from "../../utilities/caching/getMemoryInternals.js";
-import {
-  muteDeprecations,
-  warnRemovedOption,
-} from "../../utilities/deprecation/index.js";
+import { muteDeprecations, warnRemovedOption } from "../../utilities/index.js";
 
 type BroadcastOptions = Pick<
   Cache.BatchOptions<InMemoryCache>,

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -294,7 +294,7 @@ import type {
   WatchFragmentResult,
 } from "../cache/core/cache.js";
 import type { MaybeMasked, Unmasked } from "../masking/index.js";
-import { warnRemovedOption } from "../utilities/deprecation/index.js";
+import { warnRemovedOption } from "../utilities/index.js";
 export { mergeOptions };
 
 /**

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -46,7 +46,7 @@ import {
   muteDeprecations,
   warnDeprecated,
   warnRemovedOption,
-} from "../utilities/deprecation/index.js";
+} from "../utilities/index.js";
 
 const { assign, hasOwnProperty } = Object;
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -16,7 +16,7 @@ import { NetworkStatus } from "./networkStatus.js";
 import type { ApolloError } from "../errors/index.js";
 import type { QueryManager } from "./QueryManager.js";
 import type { Unmasked } from "../masking/index.js";
-import { muteDeprecations } from "../utilities/deprecation/index.js";
+import { muteDeprecations } from "../utilities/index.js";
 
 export type QueryStoreValue = Pick<
   QueryInfo,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -110,7 +110,7 @@ import { Trie } from "@wry/trie";
 import { AutoCleanedWeakCache, cacheSizes } from "../utilities/index.js";
 import { maskFragment, maskOperation } from "../masking/index.js";
 import type { MaybeMasked, Unmasked } from "../masking/index.js";
-import { muteDeprecations } from "../utilities/deprecation/index.js";
+import { muteDeprecations } from "../utilities/index.js";
 
 interface MaskFragmentOptions<TData> {
   fragment: DocumentNode;

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -26,11 +26,12 @@ import { expectTypeOf } from "expect-type";
 
 import { SubscriptionObserver } from "zen-observable-ts";
 import { waitFor } from "@testing-library/react";
-import { ObservableStream, spyOnConsole } from "../../testing/internal";
 import {
-  muteDeprecations,
-  withDisabledDeprecations,
-} from "../../utilities/deprecation";
+  ObservableStream,
+  spyOnConsole,
+  withMutedDeprecations,
+} from "../../testing/internal";
+import { muteDeprecations } from "../../utilities/deprecation";
 
 export const mockFetchQuery = (queryManager: QueryManager<any>) => {
   const fetchConcastWithInfo = queryManager["fetchConcastWithInfo"];
@@ -1830,7 +1831,7 @@ describe("ObservableQuery", () => {
 
       it("should warn if passed { variables } and query does not declare $variables", async () => {
         using _ = spyOnConsole("warn");
-        using __ = withDisabledDeprecations();
+        using __ = withMutedDeprecations();
 
         const queryWithVarsVar = gql`
           query QueryWithVarsVar($vars: [String!]) {

--- a/src/link/core/ApolloLink.ts
+++ b/src/link/core/ApolloLink.ts
@@ -14,7 +14,7 @@ import {
   createOperation,
   transformOperation,
 } from "../utils/index.js";
-import { warnDeprecated } from "../../utilities/deprecation/index.js";
+import { warnDeprecated } from "../../utilities/index.js";
 
 function passthrough(op: Operation, forward: NextLink) {
   return (forward ? forward(op) : Observable.of()) as Observable<FetchResult>;

--- a/src/react/hoc/graphql.tsx
+++ b/src/react/hoc/graphql.tsx
@@ -8,10 +8,7 @@ import { withSubscription } from "./subscription-hoc.js";
 import type { OperationOption, DataProps, MutateProps } from "./types.js";
 import type { OperationVariables } from "../../core/index.js";
 import { invariant } from "../../utilities/globals/index.js";
-import {
-  muteDeprecations,
-  warnDeprecated,
-} from "../../utilities/deprecation/index.js";
+import { muteDeprecations, warnDeprecated } from "../../utilities/index.js";
 
 /**
  * @deprecated

--- a/src/react/hoc/mutation-hoc.tsx
+++ b/src/react/hoc/mutation-hoc.tsx
@@ -16,10 +16,7 @@ import {
 } from "./hoc-utils.js";
 import type { OperationOption, OptionProps, MutateProps } from "./types.js";
 import type { ApolloCache } from "../../core/index.js";
-import {
-  muteDeprecations,
-  warnDeprecated,
-} from "../../utilities/deprecation/index.js";
+import { muteDeprecations, warnDeprecated } from "../../utilities/index.js";
 import { invariant } from "../../utilities/globals/index.js";
 
 /**

--- a/src/react/hoc/query-hoc.tsx
+++ b/src/react/hoc/query-hoc.tsx
@@ -15,10 +15,7 @@ import {
 } from "./hoc-utils.js";
 import type { OperationOption, OptionProps, DataProps } from "./types.js";
 import invariant from "ts-invariant";
-import {
-  muteDeprecations,
-  warnDeprecated,
-} from "../../utilities/deprecation/index.js";
+import { muteDeprecations, warnDeprecated } from "../../utilities/index.js";
 
 /**
  * @deprecated

--- a/src/react/hoc/subscription-hoc.tsx
+++ b/src/react/hoc/subscription-hoc.tsx
@@ -14,10 +14,7 @@ import {
   defaultMapPropsToSkip,
 } from "./hoc-utils.js";
 import type { OperationOption, OptionProps, DataProps } from "./types.js";
-import {
-  muteDeprecations,
-  warnDeprecated,
-} from "../../utilities/deprecation/index.js";
+import { muteDeprecations, warnDeprecated } from "../../utilities/index.js";
 import { invariant } from "../../utilities/globals/index.js";
 
 /**

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -31,7 +31,12 @@ import {
 import { QueryResult } from "../../types/types";
 import { useQuery } from "../useQuery";
 import { useMutation } from "../useMutation";
-import { setupPaginatedCase, spyOnConsole } from "../../../testing/internal";
+import {
+  createClientWrapper,
+  setupPaginatedCase,
+  spyOnConsole,
+  withMutedDeprecations,
+} from "../../../testing/internal";
 import { useLazyQuery } from "../useLazyQuery";
 import { mockFetchQuery } from "../../../core/__tests__/ObservableQuery";
 import { InvariantError } from "../../../utilities/globals";
@@ -13605,6 +13610,41 @@ describe("useQuery Hook", () => {
         });
       }
     });
+  });
+});
+
+describe("deprecations", () => {
+  test("does not warn on deprecated options when deprecations are globally disabled", async () => {
+    using _ = spyOnConsole("warn");
+    using __ = withMutedDeprecations();
+
+    const query = gql`
+      query {
+        greeting
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new ApolloLink(() => new Observable(() => {})),
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
+      () =>
+        useQuery(query, {
+          canonizeResults: true,
+          partialRefetch: true,
+          defaultOptions: {},
+          onCompleted: () => {},
+          onError: () => {},
+        }),
+      { wrapper: createClientWrapper(client) }
+    );
+
+    await expect(takeSnapshot).toRerender();
+
+    expect(console.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/react/hooks/internal/useWarnRemoved.ts
+++ b/src/react/hooks/internal/useWarnRemoved.ts
@@ -1,6 +1,6 @@
 import * as React from "rehackt";
-import type { DeprecationName } from "../../../utilities/deprecation/index.js";
-import { warnDeprecated } from "../../../utilities/deprecation/index.js";
+import type { DeprecationName } from "../../../utilities/index.js";
+import { warnDeprecated } from "../../../utilities/index.js";
 
 export function useWarnRemoved(name: DeprecationName, cb: () => void) {
   "use no memo";

--- a/src/react/hooks/internal/useWarnRemovedOption.ts
+++ b/src/react/hooks/internal/useWarnRemovedOption.ts
@@ -1,6 +1,6 @@
 import * as React from "rehackt";
-import type { PossibleDeprecations } from "../../../utilities/deprecation/index.js";
-import { warnRemovedOption } from "../../../utilities/deprecation/index.js";
+import type { PossibleDeprecations } from "../../../utilities/index.js";
+import { warnRemovedOption } from "../../../utilities/index.js";
 
 // Remove with Apollo Client 4.0
 export function useWarnRemovedOption<

--- a/src/react/hooks/internal/useWarnRemovedOption.ts
+++ b/src/react/hooks/internal/useWarnRemovedOption.ts
@@ -1,24 +1,26 @@
 import * as React from "rehackt";
-import { invariant } from "../../../utilities/globals/index.js";
+import type { PossibleDeprecations } from "../../../utilities/deprecation/index.js";
+import { warnRemovedOption } from "../../../utilities/deprecation/index.js";
 
 // Remove with Apollo Client 4.0
-export function useWarnRemovedOption<TOptions extends Record<string, any>>(
+export function useWarnRemovedOption<
+  TOptions extends Record<string, any>,
+  CallSite extends keyof PossibleDeprecations,
+>(
   options: TOptions,
-  name: keyof TOptions,
-  callSite: string,
+  name: keyof TOptions & PossibleDeprecations[CallSite][number],
+  callSite: CallSite,
   recommendation: string = "Please remove this option."
 ) {
   "use no memo";
   const didWarn = React.useRef(false);
 
-  if (name in options && !didWarn.current) {
-    invariant.warn(
-      "[%s]: `%s` is a deprecated hook option and will be removed in Apollo Client 4.0. %s",
-      callSite,
-      name,
-      recommendation
-    );
-    // eslint-disable-next-line react-compiler/react-compiler
-    didWarn.current = true;
+  if (__DEV__) {
+    if (!didWarn.current) {
+      warnRemovedOption(options, name, callSite, recommendation);
+
+      // eslint-disable-next-line react-compiler/react-compiler
+      didWarn.current = true;
+    }
   }
 }

--- a/src/react/hooks/internal/useWarnRemovedOption.ts
+++ b/src/react/hooks/internal/useWarnRemovedOption.ts
@@ -16,7 +16,7 @@ export function useWarnRemovedOption<
   const didWarn = React.useRef(false);
 
   if (__DEV__) {
-    if (!didWarn.current) {
+    if (name in options && !didWarn.current) {
       warnRemovedOption(options, name, callSite, recommendation);
 
       // eslint-disable-next-line react-compiler/react-compiler

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -22,7 +22,7 @@ import type { FetchMoreFunction, RefetchFunction } from "./useSuspenseQuery.js";
 import { canonicalStringify } from "../../cache/index.js";
 import type { DeepPartial } from "../../utilities/index.js";
 import type { SkipToken } from "./constants.js";
-import { muteDeprecations } from "../../utilities/deprecation/index.js";
+import { muteDeprecations } from "../../utilities/index.js";
 
 export type UseBackgroundQueryResult<
   TData = unknown,

--- a/src/react/hooks/useFragment.ts
+++ b/src/react/hooks/useFragment.ts
@@ -19,7 +19,7 @@ import {
 } from "./internal/index.js";
 import equal from "@wry/equality";
 import type { FragmentType, MaybeMasked } from "../../masking/index.js";
-import { muteDeprecations } from "../../utilities/deprecation/index.js";
+import { muteDeprecations } from "../../utilities/index.js";
 
 export interface UseFragmentOptions<TData, TVars>
   extends Omit<

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -29,7 +29,7 @@ import {
 import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.js";
 import { useWarnRemovedOption } from "./internal/useWarnRemovedOption.js";
 import { invariant } from "../../utilities/globals/invariantWrappers.js";
-import { warnRemovedOption } from "../../utilities/deprecation/index.js";
+import { warnRemovedOption } from "../../utilities/index.js";
 import { useRenderGuard } from "./internal/index.js";
 
 // The following methods, when called will execute the query, regardless of

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -33,7 +33,7 @@ import type {
   OnlyRequiredProperties,
 } from "../../utilities/index.js";
 import { invariant } from "../../utilities/globals/index.js";
-import { muteDeprecations } from "../../utilities/deprecation/index.js";
+import { muteDeprecations } from "../../utilities/index.js";
 
 export type LoadQueryFunction<TVariables extends OperationVariables> = (
   // Use variadic args to handle cases where TVariables is type `never`, in

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -55,7 +55,7 @@ import {
 import { useWarnRemovedOption, wrapHook } from "./internal/index.js";
 import type { RenderPromises } from "../ssr/RenderPromises.js";
 import type { MaybeMasked } from "../../masking/index.js";
-import { muteDeprecations } from "../../utilities/deprecation/index.js";
+import { muteDeprecations } from "../../utilities/index.js";
 
 const {
   prototype: { hasOwnProperty },

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -214,7 +214,7 @@ function useInternalState<
         (renderPromises &&
           renderPromises.getSSRObservable(makeWatchQueryOptions())) ||
         ObservableQuery["inactiveOnCreation"].withValue(!renderPromises, () =>
-          muteDeprecations("canonizeResults", () => {
+          muteDeprecations(["canonizeResults", "partialRefetch"], () => {
             return client.watchQuery(
               getObsQueryOptions(
                 void 0,

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -27,7 +27,7 @@ import {
   useWarnRemovedOption,
   wrapHook,
 } from "./internal/index.js";
-import { muteDeprecations } from "../../utilities/deprecation/index.js";
+import { muteDeprecations } from "../../utilities/index.js";
 import { getSuspenseCache } from "../internal/index.js";
 import { canonicalStringify } from "../../cache/index.js";
 import { skipToken } from "./constants.js";

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -18,7 +18,7 @@ import type { QueryKey } from "./types.js";
 import { wrapPromiseWithState } from "../../../utilities/index.js";
 import { invariant } from "../../../utilities/globals/invariantWrappers.js";
 import type { MaybeMasked } from "../../../masking/index.js";
-import { muteDeprecations } from "../../../utilities/deprecation/index.js";
+import { muteDeprecations } from "../../../utilities/index.js";
 
 type QueryRefPromise<TData> = PromiseWithState<
   ApolloQueryResult<MaybeMasked<TData>>

--- a/src/react/parser/index.ts
+++ b/src/react/parser/index.ts
@@ -12,10 +12,7 @@ import {
   defaultCacheSizes,
 } from "../../utilities/index.js";
 import { registerGlobalCache } from "../../utilities/caching/getMemoryInternals.js";
-import {
-  muteDeprecations,
-  warnDeprecated,
-} from "../../utilities/deprecation/index.js";
+import { muteDeprecations, warnDeprecated } from "../../utilities/index.js";
 
 export enum DocumentType {
   Query,

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -17,10 +17,7 @@ import { InternalQueryReference, wrapQueryRef } from "../internal/index.js";
 import type { PreloadedQueryRef } from "../internal/index.js";
 import type { NoInfer, VariablesOption } from "../index.js";
 import { wrapHook } from "../hooks/internal/index.js";
-import {
-  muteDeprecations,
-  warnRemovedOption,
-} from "../../utilities/deprecation/index.js";
+import { muteDeprecations, warnRemovedOption } from "../../utilities/index.js";
 
 export type PreloadQueryFetchPolicy = Extract<
   WatchQueryFetchPolicy,

--- a/src/testing/internal/disposables/index.ts
+++ b/src/testing/internal/disposables/index.ts
@@ -2,3 +2,4 @@ export { spyOnConsole } from "./spyOnConsole.js";
 export { withCleanup } from "./withCleanup.js";
 export { enableFakeTimers } from "./enableFakeTimers.js";
 export { withProdMode } from "./withProdMode.js";
+export { withMutedDeprecations } from "./withMutedDeprecations.js";

--- a/src/testing/internal/disposables/withMutedDeprecations.ts
+++ b/src/testing/internal/disposables/withMutedDeprecations.ts
@@ -1,0 +1,14 @@
+import { withCleanup } from "./withCleanup.js";
+import { global as untypedGlobal } from "../../../utilities/globals/index.js";
+
+const muteAllDeprecations = Symbol.for("apollo.deprecations");
+const global = untypedGlobal as { [muteAllDeprecations]?: boolean };
+
+export function withMutedDeprecations() {
+  const prev = { prevMuted: global[muteAllDeprecations] };
+  global[muteAllDeprecations] = true;
+
+  return withCleanup(prev, ({ prevMuted }) => {
+    global[muteAllDeprecations] = prevMuted;
+  });
+}

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -10,10 +10,7 @@ import type { ApolloLink } from "../../link/core/index.js";
 import type { Resolvers } from "../../core/index.js";
 import type { ApolloCache } from "../../cache/index.js";
 import type { DevtoolsOptions } from "../../core/ApolloClient.js";
-import {
-  warnRemovedOption,
-  muteDeprecations,
-} from "../../utilities/deprecation/index.js";
+import { warnRemovedOption, muteDeprecations } from "../../utilities/index.js";
 
 export interface MockedProviderProps<TSerializedCache = {}> {
   mocks?: ReadonlyArray<MockedResponse<any, any>>;

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -11,7 +11,7 @@ import { QueryResult } from "../../../react/types/types";
 import { ApolloLink, FetchResult } from "../../../link/core";
 import { Observable } from "zen-observable-ts";
 import { ApolloError } from "../../../errors";
-import { withDisabledDeprecations } from "../../../utilities/deprecation";
+import { withMutedDeprecations } from "../../internal";
 
 const variables = {
   username: "mock_username",
@@ -872,7 +872,7 @@ describe("General use", () => {
   it("shows a warning in the console when there is no matched mock", async () => {
     const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
-    using _ = withDisabledDeprecations();
+    using _ = withMutedDeprecations();
     let finished = false;
     function Component({ ...variables }: Variables) {
       const { loading } = useQuery<Data, Variables>(query, { variables });
@@ -918,7 +918,7 @@ describe("General use", () => {
 
   it("silences console warning for unmatched mocks when `showWarnings` is `false`", async () => {
     const consoleSpy = jest.spyOn(console, "warn");
-    using _ = withDisabledDeprecations();
+    using _ = withMutedDeprecations();
     let finished = false;
     function Component({ ...variables }: Variables) {
       const { loading } = useQuery<Data, Variables>(query, { variables });
@@ -961,7 +961,7 @@ describe("General use", () => {
 
   it("silences console warning for unmatched mocks when passing `showWarnings` to `MockLink` directly", async () => {
     const consoleSpy = jest.spyOn(console, "warn");
-    using _ = withDisabledDeprecations();
+    using _ = withMutedDeprecations();
     let finished = false;
     function Component({ ...variables }: Variables) {
       const { loading } = useQuery<Data, Variables>(query, { variables });

--- a/src/utilities/deprecation/index.ts
+++ b/src/utilities/deprecation/index.ts
@@ -131,13 +131,3 @@ export function warnDeprecated(name: DeprecationName, cb: () => void) {
     cb();
   }
 }
-
-export function withDisabledDeprecations() {
-  const prev = global[muteAllDeprecations];
-  global[muteAllDeprecations] = true;
-  return {
-    [Symbol.dispose]() {
-      global[muteAllDeprecations] = prev;
-    },
-  };
-}

--- a/src/utilities/deprecation/index.ts
+++ b/src/utilities/deprecation/index.ts
@@ -1,10 +1,17 @@
 import { Slot } from "optimism";
 import { invariant, global as untypedGlobal } from "../globals/index.js";
 
-const muteAllDeprecations = Symbol.for("apollo.deprecations");
-const global = untypedGlobal as { [muteAllDeprecations]?: boolean };
+type SlotType<T> =
+  typeof Slot<T> extends new (...args: any[]) => infer T ? T : unknown;
 
-const slot = new Slot<string[]>();
+const muteAllDeprecations = Symbol.for("apollo.deprecations");
+const deprecationsSlot = Symbol.for("apollo.deprecations.slot");
+const global = untypedGlobal as {
+  [muteAllDeprecations]?: boolean;
+  [deprecationsSlot]?: SlotType<string[]>;
+};
+
+const slot = (global[deprecationsSlot] ??= new Slot());
 
 type WithValueArgs<TResult, TArgs extends any[], TThis> = [
   callback: (this: TThis, ...args: TArgs) => TResult,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -149,3 +149,13 @@ export {
   defaultCacheSizes,
 } from "./caching/index.js";
 export type { CacheSizes } from "./caching/index.js";
+
+export {
+  muteDeprecations,
+  warnRemovedOption,
+  warnDeprecated,
+} from "./deprecation/index.js";
+export type {
+  DeprecationName,
+  PossibleDeprecations,
+} from "./deprecation/index.js";


### PR DESCRIPTION
Fixes #13149
Fixes #12917
Fixes #13057

Fixes issues where some deprecation warnings from React hooks were not properly muted even when muted globally. Also fixes some issues where rogue deprecation warnings were emitted even when the internal implementation muted them. This was due to a bundling issue where a copy of the slot was created in each entrypoint since we imported from the file directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deprecation warnings appearing across multiple entry points—muting a deprecation from one entry point now correctly suppresses warnings everywhere.
  * Fixed deprecation warnings in React hooks not being properly silenced when globally disabled.

* **New Features**
  * Deprecation management utilities are now available from the main utilities module for centralized access and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->