### PR TITLE
Tweak migration guide for refetchQueries with all/active meaning

### DIFF
--- a/docs/source/migrating/apollo-client-4-migration.mdx
+++ b/docs/source/migrating/apollo-client-4-migration.mdx
@@ -999,7 +999,7 @@ A query is in standby if it is skipped with the `skip` option or `skipToken` in 
 
 </Note>
 
-This change affects the queries returned by `client.getObservableQueries` or the queries fetched by `refetchQueries` as these no longer include `ObservableQuery` instances without subscribers.
+This change affects the queries returned by `client.getObservableQueries` or the queries fetched by `refetchQueries` when using the `"active"` or `"all"` keywords, as these no longer include `ObservableQuery` instances without subscribers.
 
 ### Removal of the `canonizeResults` option
 


### PR DESCRIPTION
This was brought up in https://github.com/apollographql/apollo-client/issues/13175. Adding an explicit reference to "all" and "active" keywords to avoid confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified migration guide to specify when query behavior changes apply when using "active" or "all" keywords, improving guidance on how ObservableQuery instances are affected during migration to Apollo Client 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->