### PR TITLE
Fix RxJS interop issue with observable returned in `WebSocketLink`

### DIFF
--- a/.api-reports/api-report-link_ws.api.md
+++ b/.api-reports/api-report-link_ws.api.md
@@ -6,7 +6,7 @@
 
 import { ApolloLink } from '@apollo/client/link';
 import type { ClientOptions } from 'subscriptions-transport-ws';
-import type { Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 
 // @public (undocumented)

--- a/.changeset/lemon-beds-destroy.md
+++ b/.changeset/lemon-beds-destroy.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix RxJS interop issue with the observable returned by `WebSocketLink`.

--- a/src/link/ws/__tests__/webSocketLink.ts
+++ b/src/link/ws/__tests__/webSocketLink.ts
@@ -55,7 +55,6 @@ describe("WebSocketLink", () => {
     const link = new WebSocketLink(client);
 
     const obs = execute(link, { query });
-    expect(obs).toEqual(observable);
 
     const stream = new ObservableStream(obs);
 
@@ -73,7 +72,6 @@ describe("WebSocketLink", () => {
     const link = new WebSocketLink(client);
 
     const obs = execute(link, { query: mutation });
-    expect(obs).toEqual(observable);
 
     const stream = new ObservableStream(obs);
 
@@ -91,7 +89,6 @@ describe("WebSocketLink", () => {
     const link = new WebSocketLink(client);
 
     const obs = execute(link, { query: subscription });
-    expect(obs).toEqual(observable);
 
     const stream = new ObservableStream(obs);
 

--- a/src/link/ws/index.ts
+++ b/src/link/ws/index.ts
@@ -1,4 +1,4 @@
-import type { Observable } from "rxjs";
+import { Observable } from "rxjs";
 import type { ClientOptions } from "subscriptions-transport-ws";
 import { SubscriptionClient } from "subscriptions-transport-ws";
 
@@ -115,8 +115,14 @@ export class WebSocketLink extends ApolloLink {
   public request(
     operation: ApolloLink.Operation
   ): Observable<ApolloLink.Result> {
-    return this.subscriptionClient.request(
-      operation
-    ) as Observable<ApolloLink.Result>;
+    return new Observable((observer) => {
+      const subscription = this.subscriptionClient
+        .request(operation)
+        .subscribe(observer);
+
+      return () => {
+        subscription.unsubscribe();
+      };
+    });
   }
 }


### PR DESCRIPTION
Closes #13186

The observable returned from `WebSocketLink` is a [hand-written observable](https://github.com/apollographql/subscriptions-transport-ws/blob/36f3f6f780acc1a458b768db13fd39c65e5e6518/src/client.ts#L196-L232) (since it just forwards the observable returned by the client) which is incompatible with RxJS. `QueryManager` uses `.pipe` on the returned observable which is currently throwing an error since `.pipe` doesn't exist on the `WebSocketLink` observable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebSocket observable handling to ensure proper subscription cleanup and improved RxJS interoperability.
* **Tests**
  * Updated tests to align with the revised observable behavior.
* **Chore**
  * Published a patch update for the client package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->