### PR TITLE
Update `useSubscription` documentation examples

### DIFF
--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -192,7 +192,7 @@ export declare namespace useSubscription {
  *   const [accumulatedData, setAccumulatedData] = useState([]);
  *   const { data, error, loading } = useSubscription(query, {
  *     onData({ data }) {
- *       setAccumulatedData((prev) => [...prev, data]);
+ *       setAccumulatedData((prev) => [...prev, data.data]);
  *     },
  *   });
  *


### PR DESCRIPTION
## Description

The `data` option in `onData` is an `OnDataResult` object, i.e. { loading, data, error }, so for this example to be consistent with the `useEffect` comparision made before, we have to read the subscription data using `data.data` here. 

I'm opening this PR because was confused while implementing a subscription using `onData` callback,  because thought this `data` object in the `onData` options was the same `data` returned by subscription result, based on those examples.

Maybe the `data` option in `onData` could be renamed to `result` instead? To make it clear it refers to a `Result` type object instead of the subscription data itself. (just a suggestion) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example documentation for `useSubscription` callback to reflect the correct data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->