### PR TITLE
Use new `CallSignatureDetails` to unblock docs build

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -167,6 +167,18 @@ export namespace ApolloClient {
     // (undocumented)
     export namespace DocumentationTypes {
         // (undocumented)
+        export interface DefaultOptions {
+            // (undocumented)
+            mutate?: Partial<ApolloClient.MutateOptions<any, any, any>>;
+            // (undocumented)
+            query?: Partial<ApolloClient.QueryOptions<any, any>>;
+            // (undocumented)
+            watchQuery?: Partial<ApolloClient.WatchQueryOptions<any, any>>;
+        }
+    }
+    // (undocumented)
+    export namespace DocumentationTypes {
+        // (undocumented)
         export interface ReadQueryOptions<TData, TVariables extends OperationVariables> extends Base.ReadQueryOptions<TData, TVariables> {
             variables?: TVariables;
         }
@@ -1271,7 +1283,7 @@ export type WatchQueryOptions<TVariables extends OperationVariables = OperationV
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:583:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:591:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:371:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -256,16 +256,16 @@ export namespace useBackgroundQuery {
     }
     // (undocumented)
     export namespace DocumentationTypes {
+        // (undocumented)
         export interface useBackgroundQuery {
-            // (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<TVariables>): [
             QueryRef_2<TData, TVariables> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
         }
-        // @deprecated (undocumented)
+        // (undocumented)
         export interface useBackgroundQuery_Deprecated {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<TVariables>): [
             QueryRef_2<TData, TVariables> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
@@ -287,14 +287,13 @@ export namespace useBackgroundQuery {
     queryRef: TOptions extends any ? TOptions extends SkipToken ? undefined : QueryRef_2<TData, TVariables, "complete" | "streaming" | ((OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"))> | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends false ? never : undefined) : never,
     result: useBackgroundQuery.Result<TData, TVariables>
     ];
-    // (undocumented)
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
-        // (undocumented)
+        // @deprecated (undocumented)
         export interface Classic {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
                 fetchPolicy: "no-cache";
@@ -302,7 +301,7 @@ export namespace useBackgroundQuery {
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
                 errorPolicy: "ignore" | "all";
@@ -310,7 +309,7 @@ export namespace useBackgroundQuery {
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
                 errorPolicy: "ignore" | "all";
@@ -318,14 +317,14 @@ export namespace useBackgroundQuery {
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial" | "empty">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: false;
@@ -333,7 +332,7 @@ export namespace useBackgroundQuery {
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: boolean;
@@ -341,58 +340,58 @@ export namespace useBackgroundQuery {
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): [undefined, useBackgroundQuery.Result<TData, TVariables>];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
             })): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             })): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>
             ] : [options: useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>
             ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
@@ -400,17 +399,12 @@ export namespace useBackgroundQuery {
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
-        // (undocumented)
         export interface Modern {
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useBackgroundQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
@@ -562,13 +556,13 @@ export namespace useLazyQuery {
     }
     // (undocumented)
     export namespace DocumentationTypes {
+        // (undocumented)
         export interface useLazyQuery {
-            // (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<TData, TVariables>): useLazyQuery.ResultTuple<TData, TVariables>;
         }
-        // @deprecated (undocumented)
+        // (undocumented)
         export interface useLazyQuery_Deprecated {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<TData, TVariables>): useLazyQuery.ResultTuple<TData, TVariables>;
         }
     }
@@ -609,31 +603,27 @@ export namespace useLazyQuery {
     execute: ExecFunction<TData, TVariables>,
     result: useLazyQuery.Result<TData, TVariables, TStates>
     ];
-    // (undocumented)
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
-        // (undocumented)
+        // @deprecated (undocumented)
         export interface Classic {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
-        // (undocumented)
         export interface Modern {
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode | TypedDocumentNode<TData, TVariables>): useLazyQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 variables?: {
                     [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
@@ -653,13 +643,13 @@ export namespace useLoadableQuery {
     }
     // (undocumented)
     export namespace DocumentationTypes {
+        // (undocumented)
         export interface useLoadableQuery {
-            // (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options): useLoadableQuery.Result<TData, TVariables>;
         }
-        // @deprecated (undocumented)
+        // (undocumented)
         export interface useLoadableQuery_Deprecated {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options): useLoadableQuery.Result<TData, TVariables>;
         }
     }
@@ -693,36 +683,32 @@ export namespace useLoadableQuery {
     ];
     // (undocumented)
     export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options> = Result<TData, TVariables, "complete" | "streaming" | (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends ("none") ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial")>;
-    // (undocumented)
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
-        // (undocumented)
+        // @deprecated (undocumented)
         export interface Classic {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
                 errorPolicy: "ignore" | "all";
             }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 errorPolicy: "ignore" | "all";
             }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
             }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useLoadableQuery.Options): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
-        // (undocumented)
         export interface Modern {
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>): useLoadableQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends useLoadableQuery.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: TOptions): useLoadableQuery.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
@@ -940,13 +926,13 @@ export namespace useQuery {
     }
     // (undocumented)
     export namespace DocumentationTypes {
+        // (undocumented)
         export interface useQuery {
-            // (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<TData, TVariables>): useQuery.Result<TData, TVariables>;
         }
-        // @deprecated (undocumented)
+        // (undocumented)
         export interface useQuery_Deprecated {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<TData, TVariables>): useQuery.Result<TData, TVariables>;
         }
     }
@@ -956,36 +942,35 @@ export namespace useQuery {
     export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables> = Base.Result<TData, TVariables, TReturnVariables> & GetDataState<MaybeMasked_2<TData>, TStates>;
     // (undocumented)
     export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never)>>;
-    // (undocumented)
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
-        // (undocumented)
+        // @deprecated (undocumented)
         export interface Classic {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
             ] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
             ] : [
@@ -996,13 +981,9 @@ export namespace useQuery {
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
-        // (undocumented)
         export interface Modern {
-            // (undocumented)
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends SkipToken>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
@@ -1010,7 +991,6 @@ export namespace useQuery {
             ] extends [never] ? [options: never] : {} extends TVariables ? [options?: TOptions] : [
             options: TOptions
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
@@ -1293,13 +1273,13 @@ export namespace useSuspenseQuery {
     }
     // (undocumented)
     export namespace DocumentationTypes {
+        // (undocumented)
         export interface useSuspenseQuery {
-            // (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useSuspenseQuery.Options<TVariables>): useSuspenseQuery.Result<TData, TVariables>;
         }
-        // @deprecated (undocumented)
+        // (undocumented)
         export interface useSuspenseQuery_Deprecated {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useSuspenseQuery.Options<TVariables>): useSuspenseQuery.Result<TData, TVariables>;
         }
     }
@@ -1313,63 +1293,57 @@ export namespace useSuspenseQuery {
     export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TVariables> | SkipToken> = Result<TData, TVariables, "complete" | "streaming" | (TOptions extends any ? TOptions extends SkipToken ? "empty" : (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends (false) ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial") : never) | ([TOptions] extends [SkipToken] ? DefaultOptions extends {
         returnPartialData: false;
     } ? never : "partial" : never)>;
-    // (undocumented)
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
-        // (undocumented)
+        // @deprecated (undocumented)
         export interface Classic {
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
                 errorPolicy: "ignore" | "all";
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: true;
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>
             ] : [options: useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>
             ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            // (undocumented)
+            // @deprecated (undocumented)
             <TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
-        // (undocumented)
         export interface Modern {
-            // (undocumented)
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useSuspenseQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
-            // (undocumented)
             <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -208,6 +208,18 @@ export namespace ApolloClient {
     // (undocumented)
     export namespace DocumentationTypes {
         // (undocumented)
+        export interface DefaultOptions {
+            // (undocumented)
+            mutate?: Partial<ApolloClient.MutateOptions<any, any, any>>;
+            // (undocumented)
+            query?: Partial<ApolloClient.QueryOptions<any, any>>;
+            // (undocumented)
+            watchQuery?: Partial<ApolloClient.WatchQueryOptions<any, any>>;
+        }
+    }
+    // (undocumented)
+    export namespace DocumentationTypes {
+        // (undocumented)
         export interface ReadQueryOptions<TData, TVariables extends OperationVariables> extends Base.ReadQueryOptions<TData, TVariables> {
             variables?: TVariables;
         }
@@ -2973,8 +2985,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:183:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:583:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:191:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:591:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:371:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/docs/source/api/core/ApolloClient.mdx
+++ b/docs/source/api/core/ApolloClient.mdx
@@ -29,11 +29,11 @@ For more information on the `defaultOptions` object, see the [Default Options](#
   headingLevel={3}
 />
 <FunctionDetails
-  canonicalReference="@apollo/client!ApolloClient#query:member"
+  canonicalReference="@apollo/client!ApolloClient.DocumentationTypes.query:function(1)"
   headingLevel={3}
 />
 <FunctionDetails
-  canonicalReference="@apollo/client!ApolloClient#mutate:member"
+  canonicalReference="@apollo/client!ApolloClient.DocumentationTypes.mutate:function(1)"
   headingLevel={3}
 />
 <FunctionDetails

--- a/docs/source/api/core/ApolloClient.mdx
+++ b/docs/source/api/core/ApolloClient.mdx
@@ -123,7 +123,7 @@ For more information on the `defaultOptions` object, see the [Default Options](#
 />
 
 <InterfaceDetails
-  canonicalReference="@apollo/client!~ApolloClient.DefaultOptions:interface"
+  canonicalReference="@apollo/client!ApolloClient.DocumentationTypes.DefaultOptions:interface"
   headingLevel={3}
   displayName="ApolloClient.DefaultOptions"
 />

--- a/docs/source/api/react/useBackgroundQuery.mdx
+++ b/docs/source/api/react/useBackgroundQuery.mdx
@@ -5,7 +5,7 @@ description: Apollo Client API reference
 
 {/* @import {MDXProvidedComponents} from '../../../shared/MdxProvidedComponents.js' */}
 
-<FunctionDetails
+<CallSignatureDetails
   canonicalReference="@apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)"
   headingLevel={2}
 >
@@ -41,6 +41,6 @@ A tuple of two values:
     </ManualTupleItem>
 
   </ManualTuple>
-</FunctionDetails>
+</CallSignatureDetails>
 
 If no query has been executed yet and you skip the query, the hook will return `undefined` instead of a `queryRef`.

--- a/docs/source/api/react/useLazyQuery.mdx
+++ b/docs/source/api/react/useLazyQuery.mdx
@@ -5,7 +5,7 @@ description: Apollo Client API reference
 
 {/* @import {MDXProvidedComponents} from '../../../shared/MdxProvidedComponents.js' */}
 
-<FunctionDetails canonicalReference="@apollo/client/react!useLazyQuery.DocumentationTypes.useLazyQuery:call(1)" headingLevel={2}>
+<CallSignatureDetails canonicalReference="@apollo/client/react!useLazyQuery.DocumentationTypes.useLazyQuery:call(1)" headingLevel={2}>
   ```ts
   [execute: LazyQueryExecFunction<TData, TVariables>, result: QueryResult<TData, TVariables>]
   ```
@@ -27,4 +27,4 @@ A tuple of two values:
       The result of the query. See the `useQuery` hook for more details.
     </ManualTupleItem>
   </ManualTuple>
-</FunctionDetails>
+</CallSignatureDetails>

--- a/docs/source/api/react/useLoadableQuery.mdx
+++ b/docs/source/api/react/useLoadableQuery.mdx
@@ -3,7 +3,7 @@ title: useLoadableQuery
 description: Apollo Client API reference
 ---
 
-<FunctionDetails
+<CallSignatureDetails
   canonicalReference="@apollo/client/react!useLoadableQuery.DocumentationTypes.useLoadableQuery:call(1)"
   headingLevel={2}
 >
@@ -45,4 +45,4 @@ A tuple of three values:
       Additional handlers used for the query, such as `refetch`.
     </ManualTupleItem>
   </ManualTuple>
-</FunctionDetails>
+</CallSignatureDetails>

--- a/docs/source/api/react/useMutation.mdx
+++ b/docs/source/api/react/useMutation.mdx
@@ -5,7 +5,7 @@ description: Apollo Client API reference
 
 {/* @import {MDXProvidedComponents} from '../../../shared/MdxProvidedComponents.js' */}
 
-<FunctionDetails
+<CallSignatureDetails
   canonicalReference="@apollo/client/react!useMutation.DocumentationTypes.useMutation:call(1)"
   headingLevel={2}
 >
@@ -52,4 +52,4 @@ description: Apollo Client API reference
     </ManualTupleItem>
 
   </ManualTuple>
-</FunctionDetails>
+</CallSignatureDetails>

--- a/docs/source/api/react/useQuery.mdx
+++ b/docs/source/api/react/useQuery.mdx
@@ -5,7 +5,7 @@ description: Apollo Client API reference
 
 {/* @import {MDXProvidedComponents} from '../../../shared/MdxProvidedComponents.js' */}
 
-<FunctionDetails
+<CallSignatureDetails
   canonicalReference="@apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)"
   headingLevel={2}
 />

--- a/docs/source/api/react/useSuspenseQuery.mdx
+++ b/docs/source/api/react/useSuspenseQuery.mdx
@@ -5,7 +5,7 @@ description: Apollo Client API reference
 
 {/* @import {MDXProvidedComponents} from '../../../shared/MdxProvidedComponents.js' */}
 
-<FunctionDetails
+<CallSignatureDetails
   canonicalReference="@apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)"
   headingLevel={2}
 />

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -84,6 +84,14 @@ export interface ReferenceToAvoidDroppingImportOnBuild {
 export declare namespace ApolloClient {
   export type { DeclareDefaultOptions, DefaultOptions };
 
+  export namespace DocumentationTypes {
+    export interface DefaultOptions {
+      watchQuery?: Partial<ApolloClient.WatchQueryOptions<any, any>>;
+      query?: Partial<ApolloClient.QueryOptions<any, any>>;
+      mutate?: Partial<ApolloClient.MutateOptions<any, any, any>>;
+    }
+  }
+
   export interface Options extends InternalTypes.DefaultOptionsParentObject {
     /**
      * An `ApolloLink` instance to serve as Apollo Client's network layer. For more information, see [Advanced HTTP networking](https://www.apollographql.com/docs/react/networking/advanced-http-networking/).

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -173,68 +173,68 @@ export declare namespace useBackgroundQuery {
   ];
 
   export namespace DocumentationTypes {
-    /**
-     * For a detailed explanation of useBackgroundQuery, see the [fetching with Suspense reference](https://www.apollographql.com/docs/react/data/suspense).
-     *
-     * @returns A tuple containing:
-     *
-     * 1.  A `QueryRef` that can be passed to `useReadQuery` to read the query result. The `queryRef` is `undefined` if the query is skipped.
-     * 2.  An object containing helper functions for the query:
-     *     - `refetch`: A function to re-execute the query
-     *     - `fetchMore`: A function to fetch more results for pagination
-     *     - `subscribeToMore`: A function to subscribe to updates
-     *
-     * @example
-     *
-     * ```jsx
-     * import { Suspense } from "react";
-     * import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
-     * import { useBackgroundQuery, useReadQuery } from "@apollo/client/react";
-     *
-     * const query = gql`
-     *   foo {
-     *     bar
-     *   }
-     * `;
-     *
-     * const client = new ApolloClient({
-     *   link: new HttpLink({ uri: "http://localhost:4000/graphql" }),
-     *   cache: new InMemoryCache(),
-     * });
-     *
-     * function SuspenseFallback() {
-     *   return <div>Loading...</div>;
-     * }
-     *
-     * function Child({ queryRef }) {
-     *   const { data } = useReadQuery(queryRef);
-     *
-     *   return <div>{data.foo.bar}</div>;
-     * }
-     *
-     * function Parent() {
-     *   const [queryRef] = useBackgroundQuery(query);
-     *
-     *   return (
-     *     <Suspense fallback={<SuspenseFallback />}>
-     *       <Child queryRef={queryRef} />
-     *     </Suspense>
-     *   );
-     * }
-     *
-     * function App() {
-     *   return (
-     *     <ApolloProvider client={client}>
-     *       <Parent />
-     *     </ApolloProvider>
-     *   );
-     * }
-     * ```
-     *
-     * @param query - A GraphQL query document parsed into an AST by `gql`.
-     * @param options - An optional object containing options for the query. Instead of passing a `useBackgroundQuery.Options` object into the hook, you can also pass a [`skipToken`](#skiptoken) to prevent the `useBackgroundQuery` hook from executing the query or suspending.
-     */
     export interface useBackgroundQuery {
+      /**
+       * For a detailed explanation of useBackgroundQuery, see the [fetching with Suspense reference](https://www.apollographql.com/docs/react/data/suspense).
+       *
+       * @returns A tuple containing:
+       *
+       * 1.  A `QueryRef` that can be passed to `useReadQuery` to read the query result. The `queryRef` is `undefined` if the query is skipped.
+       * 2.  An object containing helper functions for the query:
+       *     - `refetch`: A function to re-execute the query
+       *     - `fetchMore`: A function to fetch more results for pagination
+       *     - `subscribeToMore`: A function to subscribe to updates
+       *
+       * @example
+       *
+       * ```jsx
+       * import { Suspense } from "react";
+       * import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
+       * import { useBackgroundQuery, useReadQuery } from "@apollo/client/react";
+       *
+       * const query = gql`
+       *   foo {
+       *     bar
+       *   }
+       * `;
+       *
+       * const client = new ApolloClient({
+       *   link: new HttpLink({ uri: "http://localhost:4000/graphql" }),
+       *   cache: new InMemoryCache(),
+       * });
+       *
+       * function SuspenseFallback() {
+       *   return <div>Loading...</div>;
+       * }
+       *
+       * function Child({ queryRef }) {
+       *   const { data } = useReadQuery(queryRef);
+       *
+       *   return <div>{data.foo.bar}</div>;
+       * }
+       *
+       * function Parent() {
+       *   const [queryRef] = useBackgroundQuery(query);
+       *
+       *   return (
+       *     <Suspense fallback={<SuspenseFallback />}>
+       *       <Child queryRef={queryRef} />
+       *     </Suspense>
+       *   );
+       * }
+       *
+       * function App() {
+       *   return (
+       *     <ApolloProvider client={client}>
+       *       <Parent />
+       *     </ApolloProvider>
+       *   );
+       * }
+       * ```
+       *
+       * @param query - A GraphQL query document parsed into an AST by `gql`.
+       * @param options - An optional object containing options for the query. Instead of passing a `useBackgroundQuery.Options` object into the hook, you can also pass a [`skipToken`](#skiptoken) to prevent the `useBackgroundQuery` hook from executing the query or suspending.
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,
@@ -247,13 +247,13 @@ export declare namespace useBackgroundQuery {
       ];
     }
 
-    /**
-     * @deprecated Avoid manually specifying generics on `useBackgroundQuery`.
-     * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
-     *
-     * {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)}
-     */
     export interface useBackgroundQuery_Deprecated {
+      /**
+       * @deprecated Avoid manually specifying generics on `useBackgroundQuery`.
+       * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
+       *
+       * {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)}
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -252,42 +252,42 @@ export declare namespace useLazyQuery {
   >;
 
   namespace DocumentationTypes {
-    /**
-     * A hook for imperatively executing queries in an Apollo application, e.g. in response to user interaction.
-     *
-     * > Refer to the [Queries - Manual execution with useLazyQuery](https://www.apollographql.com/docs/react/data/queries#manual-execution-with-uselazyquery) section for a more in-depth overview of `useLazyQuery`.
-     *
-     * @example
-     *
-     * ```jsx
-     * import { gql } from "@apollo/client";
-     * import { useLazyQuery } from "@apollo/client/react";
-     *
-     * const GET_GREETING = gql`
-     *   query GetGreeting($language: String!) {
-     *     greeting(language: $language) {
-     *       message
-     *     }
-     *   }
-     * `;
-     *
-     * function Hello() {
-     *   const [loadGreeting, { called, loading, data }] = useLazyQuery(GET_GREETING, {
-     *     variables: { language: "english" },
-     *   });
-     *   if (called && loading) return <p>Loading ...</p>;
-     *   if (!called) {
-     *     return <button onClick={() => loadGreeting()}>Load greeting</button>;
-     *   }
-     *   return <h1>Hello {data.greeting.message}!</h1>;
-     * }
-     * ```
-     *
-     * @param query - A GraphQL query document parsed into an AST by `gql`.
-     * @param options - Default options to control how the query is executed.
-     * @returns A tuple in the form of `[execute, result]`
-     */
     export interface useLazyQuery {
+      /**
+       * A hook for imperatively executing queries in an Apollo application, e.g. in response to user interaction.
+       *
+       * > Refer to the [Queries - Manual execution with useLazyQuery](https://www.apollographql.com/docs/react/data/queries#manual-execution-with-uselazyquery) section for a more in-depth overview of `useLazyQuery`.
+       *
+       * @example
+       *
+       * ```jsx
+       * import { gql } from "@apollo/client";
+       * import { useLazyQuery } from "@apollo/client/react";
+       *
+       * const GET_GREETING = gql`
+       *   query GetGreeting($language: String!) {
+       *     greeting(language: $language) {
+       *       message
+       *     }
+       *   }
+       * `;
+       *
+       * function Hello() {
+       *   const [loadGreeting, { called, loading, data }] = useLazyQuery(GET_GREETING, {
+       *     variables: { language: "english" },
+       *   });
+       *   if (called && loading) return <p>Loading ...</p>;
+       *   if (!called) {
+       *     return <button onClick={() => loadGreeting()}>Load greeting</button>;
+       *   }
+       *   return <h1>Hello {data.greeting.message}!</h1>;
+       * }
+       * ```
+       *
+       * @param query - A GraphQL query document parsed into an AST by `gql`.
+       * @param options - Default options to control how the query is executed.
+       * @returns A tuple in the form of `[execute, result]`
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,
@@ -297,13 +297,13 @@ export declare namespace useLazyQuery {
       ): useLazyQuery.ResultTuple<TData, TVariables>;
     }
 
-    /**
-     * @deprecated Avoid manually specifying generics on `useLazyQuery`.
-     * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
-     *
-     * {@inheritDoc @apollo/client/react!useLazyQuery.DocumentationTypes.useLazyQuery:call(1)}
-     */
     export interface useLazyQuery_Deprecated {
+      /**
+       * @deprecated Avoid manually specifying generics on `useLazyQuery`.
+       * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
+       *
+       * {@inheritDoc @apollo/client/react!useLazyQuery.DocumentationTypes.useLazyQuery:call(1)}
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -131,52 +131,52 @@ export declare namespace useLoadableQuery {
   >;
 
   export namespace DocumentationTypes {
-    /**
-     * A hook for imperatively loading a query, such as responding to a user
-     * interaction.
-     *
-     * > Refer to the [Suspense - Fetching in response to user interaction](https://www.apollographql.com/docs/react/data/suspense#fetching-in-response-to-user-interaction) section for a more in-depth overview of `useLoadableQuery`.
-     *
-     * @example
-     *
-     * ```jsx
-     * import { gql, useLoadableQuery } from "@apollo/client";
-     *
-     * const GET_GREETING = gql`
-     *   query GetGreeting($language: String!) {
-     *     greeting(language: $language) {
-     *       message
-     *     }
-     *   }
-     * `;
-     *
-     * function App() {
-     *   const [loadGreeting, queryRef] = useLoadableQuery(GET_GREETING);
-     *
-     *   return (
-     *     <>
-     *       <button onClick={() => loadGreeting({ language: "english" })}>
-     *         Load greeting
-     *       </button>
-     *       <Suspense fallback={<div>Loading...</div>}>
-     *         {queryRef && <Hello queryRef={queryRef} />}
-     *       </Suspense>
-     *     </>
-     *   );
-     * }
-     *
-     * function Hello({ queryRef }) {
-     *   const { data } = useReadQuery(queryRef);
-     *
-     *   return <div>{data.greeting.message}</div>;
-     * }
-     * ```
-     *
-     * @param query - A GraphQL query document parsed into an AST by `gql`.
-     * @param options - Options to control how the query is executed.
-     * @returns A tuple in the form of `[loadQuery, queryRef, handlers]`
-     */
     export interface useLoadableQuery {
+      /**
+       * A hook for imperatively loading a query, such as responding to a user
+       * interaction.
+       *
+       * > Refer to the [Suspense - Fetching in response to user interaction](https://www.apollographql.com/docs/react/data/suspense#fetching-in-response-to-user-interaction) section for a more in-depth overview of `useLoadableQuery`.
+       *
+       * @example
+       *
+       * ```jsx
+       * import { gql, useLoadableQuery } from "@apollo/client";
+       *
+       * const GET_GREETING = gql`
+       *   query GetGreeting($language: String!) {
+       *     greeting(language: $language) {
+       *       message
+       *     }
+       *   }
+       * `;
+       *
+       * function App() {
+       *   const [loadGreeting, queryRef] = useLoadableQuery(GET_GREETING);
+       *
+       *   return (
+       *     <>
+       *       <button onClick={() => loadGreeting({ language: "english" })}>
+       *         Load greeting
+       *       </button>
+       *       <Suspense fallback={<div>Loading...</div>}>
+       *         {queryRef && <Hello queryRef={queryRef} />}
+       *       </Suspense>
+       *     </>
+       *   );
+       * }
+       *
+       * function Hello({ queryRef }) {
+       *   const { data } = useReadQuery(queryRef);
+       *
+       *   return <div>{data.greeting.message}</div>;
+       * }
+       * ```
+       *
+       * @param query - A GraphQL query document parsed into an AST by `gql`.
+       * @param options - Options to control how the query is executed.
+       * @returns A tuple in the form of `[loadQuery, queryRef, handlers]`
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,
@@ -186,13 +186,13 @@ export declare namespace useLoadableQuery {
       ): useLoadableQuery.Result<TData, TVariables>;
     }
 
-    /**
-     * @deprecated Avoid manually specifying generics on `useLoadableQuery`.
-     * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
-     *
-     * {@inheritDoc @apollo/client/react!useLoadableQuery.DocumentationTypes.useLoadableQuery:call(1)}
-     */
     export interface useLoadableQuery_Deprecated {
+      /**
+       * @deprecated Avoid manually specifying generics on `useLoadableQuery`.
+       * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
+       *
+       * {@inheritDoc @apollo/client/react!useLoadableQuery.DocumentationTypes.useLoadableQuery:call(1)}
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -232,43 +232,43 @@ export declare namespace useQuery {
   }
 
   export namespace DocumentationTypes {
-    /**
-     * A hook for executing queries in an Apollo application.
-     *
-     * To run a query within a React component, call `useQuery` and pass it a GraphQL query document.
-     *
-     * When your component renders, `useQuery` returns an object from Apollo Client that contains `loading`, `error`, `dataState`, and `data` properties you can use to render your UI.
-     *
-     * > Refer to the [Queries](https://www.apollographql.com/docs/react/data/queries) section for a more in-depth overview of `useQuery`.
-     *
-     * @example
-     *
-     * ```jsx
-     * import { gql } from "@apollo/client";
-     * import { useQuery } from "@apollo/client/react";
-     *
-     * const GET_GREETING = gql`
-     *   query GetGreeting($language: String!) {
-     *     greeting(language: $language) {
-     *       message
-     *     }
-     *   }
-     * `;
-     *
-     * function Hello() {
-     *   const { loading, error, data } = useQuery(GET_GREETING, {
-     *     variables: { language: "english" },
-     *   });
-     *   if (loading) return <p>Loading ...</p>;
-     *   return <h1>Hello {data.greeting.message}!</h1>;
-     * }
-     * ```
-     *
-     * @param query - A GraphQL query document parsed into an AST by `gql`.
-     * @param options - Options to control how the query is executed.
-     * @returns Query result object
-     */
     export interface useQuery {
+      /**
+       * A hook for executing queries in an Apollo application.
+       *
+       * To run a query within a React component, call `useQuery` and pass it a GraphQL query document.
+       *
+       * When your component renders, `useQuery` returns an object from Apollo Client that contains `loading`, `error`, `dataState`, and `data` properties you can use to render your UI.
+       *
+       * > Refer to the [Queries](https://www.apollographql.com/docs/react/data/queries) section for a more in-depth overview of `useQuery`.
+       *
+       * @example
+       *
+       * ```jsx
+       * import { gql } from "@apollo/client";
+       * import { useQuery } from "@apollo/client/react";
+       *
+       * const GET_GREETING = gql`
+       *   query GetGreeting($language: String!) {
+       *     greeting(language: $language) {
+       *       message
+       *     }
+       *   }
+       * `;
+       *
+       * function Hello() {
+       *   const { loading, error, data } = useQuery(GET_GREETING, {
+       *     variables: { language: "english" },
+       *   });
+       *   if (loading) return <p>Loading ...</p>;
+       *   return <h1>Hello {data.greeting.message}!</h1>;
+       * }
+       * ```
+       *
+       * @param query - A GraphQL query document parsed into an AST by `gql`.
+       * @param options - Options to control how the query is executed.
+       * @returns Query result object
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -278,13 +278,13 @@ export declare namespace useQuery {
       ): useQuery.Result<TData, TVariables>;
     }
 
-    /**
-     * @deprecated Avoid manually specifying generics on `useQuery`.
-     * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
-     *
-     * {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)}
-     */
     export interface useQuery_Deprecated {
+      /**
+       * @deprecated Avoid manually specifying generics on `useQuery`.
+       * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
+       *
+       * {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)}
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -207,48 +207,48 @@ export declare namespace useSuspenseQuery {
     }
   }
   export namespace DocumentationTypes {
-    /**
-     * For a detailed explanation of `useSuspenseQuery`, see the [fetching with Suspense reference](https://www.apollographql.com/docs/react/data/suspense).
-     *
-     * @example
-     *
-     * ```jsx
-     * import { Suspense } from "react";
-     * import { useSuspenseQuery } from "@apollo/client";
-     *
-     * const listQuery = gql`
-     *   query {
-     *     list {
-     *       id
-     *     }
-     *   }
-     * `;
-     *
-     * function App() {
-     *   return (
-     *     <Suspense fallback={<Spinner />}>
-     *       <List />
-     *     </Suspense>
-     *   );
-     * }
-     *
-     * function List() {
-     *   const { data } = useSuspenseQuery(listQuery);
-     *
-     *   return (
-     *     <ol>
-     *       {data.list.map((item) => (
-     *         <Item key={item.id} id={item.id} />
-     *       ))}
-     *     </ol>
-     *   );
-     * }
-     * ```
-     *
-     * @param query - A GraphQL query document parsed into an AST by `gql`.
-     * @param options - An optional object containing options for the query. Instead of passing a `useSuspenseQuery.Options` object into the hook, you can also pass a [`skipToken`](#skiptoken) to prevent the `useSuspenseQuery` hook from executing the query or suspending.
-     */
     export interface useSuspenseQuery {
+      /**
+       * For a detailed explanation of `useSuspenseQuery`, see the [fetching with Suspense reference](https://www.apollographql.com/docs/react/data/suspense).
+       *
+       * @example
+       *
+       * ```jsx
+       * import { Suspense } from "react";
+       * import { useSuspenseQuery } from "@apollo/client";
+       *
+       * const listQuery = gql`
+       *   query {
+       *     list {
+       *       id
+       *     }
+       *   }
+       * `;
+       *
+       * function App() {
+       *   return (
+       *     <Suspense fallback={<Spinner />}>
+       *       <List />
+       *     </Suspense>
+       *   );
+       * }
+       *
+       * function List() {
+       *   const { data } = useSuspenseQuery(listQuery);
+       *
+       *   return (
+       *     <ol>
+       *       {data.list.map((item) => (
+       *         <Item key={item.id} id={item.id} />
+       *       ))}
+       *     </ol>
+       *   );
+       * }
+       * ```
+       *
+       * @param query - A GraphQL query document parsed into an AST by `gql`.
+       * @param options - An optional object containing options for the query. Instead of passing a `useSuspenseQuery.Options` object into the hook, you can also pass a [`skipToken`](#skiptoken) to prevent the `useSuspenseQuery` hook from executing the query or suspending.
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,
@@ -258,13 +258,13 @@ export declare namespace useSuspenseQuery {
       ): useSuspenseQuery.Result<TData, TVariables>;
     }
 
-    /**
-     * @deprecated Avoid manually specifying generic arguments on `useSuspenseQuery`.
-     * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
-     *
-     * {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)}
-     */
     export interface useSuspenseQuery_Deprecated {
+      /**
+       * @deprecated Avoid manually specifying generic arguments on `useSuspenseQuery`.
+       * Instead, rely on TypeScript's type inference along with a correctly typed `TypedDocumentNode` to get accurate types for your query results.
+       *
+       * {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)}
+       */
       <
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,


### PR DESCRIPTION
Fix docs build to use new `CallSignatureDetails` component to document updated types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference documentation structure and formatting across React hooks (useQuery, useLazyQuery, useLoadableQuery, useMutation, useBackgroundQuery, useSuspenseQuery) and ApolloClient for enhanced clarity and consistency.

* **Refactor**
  * Reorganized documentation comments within type declarations for improved association and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->