### PR TITLE
Patch zx type reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "typedoc": "0.25.0",
         "typescript": "5.7.3",
         "web-streams-polyfill": "4.0.0",
-        "zx": "^8.3.0"
+        "zx": "8.3.2"
       },
       "peerDependencies": {
         "graphql": "^16.0.0",
@@ -7927,6 +7927,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -8168,6 +8180,17 @@
       "version": "0.0.29",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/lodash": {
       "version": "4.17.7",
@@ -24979,9 +25002,9 @@
       }
     },
     "node_modules/zx": {
-      "version": "8.8.5",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.5.tgz",
-      "integrity": "sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.3.2.tgz",
+      "integrity": "sha512-qjTunv1NClO05jDaUjrNZfpqC9yvNCchge/bzOcQevsh1aM5qE3TG6MY24kuQKlOWx+7vNuhqO2wa9nQCIGvZA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -24989,6 +25012,10 @@
       },
       "engines": {
         "node": ">= 12.17.0"
+      },
+      "optionalDependencies": {
+        "@types/fs-extra": ">=11",
+        "@types/node": ">=20"
       }
     },
     "scripts/codemods/ac3-to-ac4": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "typedoc": "0.25.0",
         "typescript": "5.7.3",
         "web-streams-polyfill": "4.0.0",
-        "zx": "8.3.2"
+        "zx": "8.8.5"
       },
       "peerDependencies": {
         "graphql": "^16.0.0",
@@ -7927,18 +7927,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -8180,17 +8168,6 @@
       "version": "0.0.29",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
-      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/lodash": {
       "version": "4.17.7",
@@ -25002,9 +24979,9 @@
       }
     },
     "node_modules/zx": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-8.3.2.tgz",
-      "integrity": "sha512-qjTunv1NClO05jDaUjrNZfpqC9yvNCchge/bzOcQevsh1aM5qE3TG6MY24kuQKlOWx+7vNuhqO2wa9nQCIGvZA==",
+      "version": "8.8.5",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.5.tgz",
+      "integrity": "sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -25012,10 +24989,6 @@
       },
       "engines": {
         "node": ">= 12.17.0"
-      },
-      "optionalDependencies": {
-        "@types/fs-extra": ">=11",
-        "@types/node": ">=20"
       }
     },
     "scripts/codemods/ac3-to-ac4": {

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "typedoc": "0.25.0",
     "typescript": "5.7.3",
     "web-streams-polyfill": "4.0.0",
-    "zx": "^8.3.0"
+    "zx": "8.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "typedoc": "0.25.0",
     "typescript": "5.7.3",
     "web-streams-polyfill": "4.0.0",
-    "zx": "8.3.2"
+    "zx": "8.8.5"
   },
   "publishConfig": {
     "access": "public"

--- a/patches/zx+8.8.5.patch
+++ b/patches/zx+8.8.5.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/zx/build/core.d.ts b/node_modules/zx/build/core.d.ts
+index ba4a0cb..817452f 100644
+--- a/node_modules/zx/build/core.d.ts
++++ b/node_modules/zx/build/core.d.ts
+@@ -1,5 +1,4 @@
+ /// <reference types="node" />
+-/// <reference types="fs-extra" />
+ 
+ import { Buffer } from 'node:buffer';
+ import cp, { type ChildProcess, type IOType, type StdioOptions } from 'node:child_process';
+diff --git a/node_modules/zx/build/index.d.ts b/node_modules/zx/build/index.d.ts
+index cc8f579..7b9bad4 100644
+--- a/node_modules/zx/build/index.d.ts
++++ b/node_modules/zx/build/index.d.ts
+@@ -1,5 +1,4 @@
+ /// <reference types="node" />
+-/// <reference types="fs-extra" />
+ 
+ import { type ProcessPromise } from './core.js';
+ export * from './core.js';
+diff --git a/node_modules/zx/build/vendor.d.ts b/node_modules/zx/build/vendor.d.ts
+index bb2a1d1..ec6584e 100644
+--- a/node_modules/zx/build/vendor.d.ts
++++ b/node_modules/zx/build/vendor.d.ts
+@@ -1,5 +1,4 @@
+ /// <reference types="node" />
+-/// <reference types="fs-extra" />
+ 
+ export * from './vendor-core.js';
+ export * from './vendor-extra.js';


### PR DESCRIPTION
https://github.com/google/zx/pull/1102 changed the types to include a triple slash reference to `fs-extra`, however we don't have those types installed so CI fails. This adds a patch to remove that triple-slash directive to allow CI to pass while maintaining the upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development dependencies to improve tooling stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->