### PR TITLE
Fix IntelliSense suggestions for options object in hooks that use skipToken

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -404,10 +404,10 @@ export namespace useBackgroundQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useBackgroundQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
             <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
             <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
@@ -989,7 +989,6 @@ export namespace useQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends SkipToken>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
             <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
@@ -997,6 +996,7 @@ export namespace useQuery {
             ] extends [never] ? [options: never] : {} extends TVariables ? [options?: TOptions] : [
             options: TOptions
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends SkipToken>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
             <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
@@ -1347,10 +1347,10 @@ export namespace useSuspenseQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useSuspenseQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
             <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
             <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
                 [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
             }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;

--- a/.changeset/fix-modern-autocomplete.md
+++ b/.changeset/fix-modern-autocomplete.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure the options object for the `useQuery`, `useSuspenseQuery`, and `useBackgroundQuery` hooks provide proper IntelliSense suggestions.

--- a/integration-tests/type-tests/signatures/modern/useQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useQuery.ts
@@ -55,7 +55,7 @@ test("NoInfer prevents adding arbitrary additional variables", () => {
       nonExistingVariable: "string",
     },
   });
-  // @ts-expect-error
+
   const x: number = variables?.bar;
   // @ts-expect-error
   const y: string = variables?.nonExistingVariable;

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -525,6 +525,7 @@ export declare namespace useBackgroundQuery {
       <
         TData,
         TVariables extends OperationVariables,
+        // this overload should never be manually defined, it should always be inferred
         TOptions extends useBackgroundQuery.Options<NoInfer<TVariables>> &
           VariablesOption<
             TVariables & {

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -525,18 +525,6 @@ export declare namespace useBackgroundQuery {
       <
         TData,
         TVariables extends OperationVariables,
-        // this overload should never be manually defined, it should always be inferred
-        TOptions extends never,
-      >(
-        query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        skipToken: SkipToken
-      ): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
-
-      /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
-      <
-        TData,
-        TVariables extends OperationVariables,
-        // this overload should never be manually defined, it should always be inferred
         TOptions extends useBackgroundQuery.Options<NoInfer<TVariables>> &
           VariablesOption<
             TVariables & {
@@ -551,6 +539,17 @@ export declare namespace useBackgroundQuery {
         ...[options]: {} extends TVariables ? [options?: TOptions]
         : [options: TOptions]
       ): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
+
+      /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
+      <
+        TData,
+        TVariables extends OperationVariables,
+        // this overload should never be manually defined, it should always be inferred
+        TOptions extends never,
+      >(
+        query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+        skipToken: SkipToken
+      ): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
       <

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -435,17 +435,6 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends SkipToken,
-      >(
-        query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options: SkipToken
-      ): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-
-      /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
-      <
-        TData,
-        TVariables extends OperationVariables,
-        // this overload should never be manually defined, it should always be inferred
         TOptions extends useQuery.Options<TData, NoInfer<TVariables>> &
           VariablesOption<
             TVariables & {
@@ -465,6 +454,17 @@ export declare namespace useQuery {
         : // variables required
           [options: TOptions]
       ): useQuery.ResultForOptions<TData, TVariables, TOptions>;
+
+      /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
+      <
+        TData,
+        TVariables extends OperationVariables,
+        // this overload should never be manually defined, it should always be inferred
+        TOptions extends SkipToken,
+      >(
+        query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+        options: SkipToken
+      ): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
       <

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -439,18 +439,6 @@ export declare namespace useSuspenseQuery {
       <
         TData,
         TVariables extends OperationVariables,
-        // this overload should never be manually defined, it should always be inferred
-        TOptions extends never,
-      >(
-        query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        skipToken: SkipToken
-      ): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
-
-      /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
-      <
-        TData,
-        TVariables extends OperationVariables,
-        // this overload should never be manually defined, it should always be inferred
         TOptions extends useSuspenseQuery.Options<NoInfer<TVariables>> &
           VariablesOption<
             TVariables & {
@@ -465,6 +453,17 @@ export declare namespace useSuspenseQuery {
         ...[options]: {} extends TVariables ? [options?: TOptions]
         : [options: TOptions]
       ): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
+
+      /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
+      <
+        TData,
+        TVariables extends OperationVariables,
+        // this overload should never be manually defined, it should always be inferred
+        TOptions extends never,
+      >(
+        query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+        skipToken: SkipToken
+      ): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
       <

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -439,6 +439,7 @@ export declare namespace useSuspenseQuery {
       <
         TData,
         TVariables extends OperationVariables,
+        // this overload should never be manually defined, it should always be inferred
         TOptions extends useSuspenseQuery.Options<NoInfer<TVariables>> &
           VariablesOption<
             TVariables & {


### PR DESCRIPTION
IntelliSense suggestions were not provided for the options object for hooks that use `skipToken` (`useQuery`, `useBackgroundQuery`, and `useSuspenseQuery`). This was due to the `SkipToken` overload provided before the options overload, so the editor was trying to autocomplete on the symbol properties. Reordering the overloads so that the options overload preceded the skip token overload fixes the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IntelliSense and autocomplete accuracy for `useQuery`, `useSuspenseQuery`, and `useBackgroundQuery` hooks when configuring options objects. Developers now receive better type suggestions and more accurate parameter hints.

* **Tests**
  * Updated type-level test annotations for Modern hook signature patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->