### PR TITLE
fix(DeepMerger): harden against prototype chain disruption via __proto__ and constructor keys

### DIFF
--- a/.changeset/fix-deep-merger-prototype-pollution.md
+++ b/.changeset/fix-deep-merger-prototype-pollution.md
@@ -1,0 +1,9 @@
+---
+"@apollo/client": patch
+---
+
+Fix prototype chain manipulation vulnerability in DeepMerger
+
+When merging server-controlled data containing a `"__proto__"` key (e.g. from `JSON.parse`), `DeepMerger` would call `target["__proto__"] = value`, which invokes the `__proto__` setter and silently replaces the target object's `[[Prototype]]`. This could allow a malicious or compromised GraphQL server to inject arbitrary properties into cached objects via prototype chain manipulation.
+
+The fix skips `__proto__` and `constructor` keys during merging to prevent prototype chain manipulation.

--- a/src/utilities/internal/DeepMerger.ts
+++ b/src/utilities/internal/DeepMerger.ts
@@ -87,6 +87,10 @@ export class DeepMerger {
 
     if (isNonNullObject(source) && isNonNullObject(target)) {
       Object.keys(source).forEach((sourceKey) => {
+        // Skip keys that could manipulate the prototype chain.
+        if (sourceKey === "__proto__" || sourceKey === "constructor") {
+          return;
+        }
         if (hasOwnProperty.call(target, sourceKey)) {
           const targetValue = target[sourceKey];
           if (source[sourceKey] !== targetValue) {

--- a/src/utilities/internal/DeepMerger.ts
+++ b/src/utilities/internal/DeepMerger.ts
@@ -57,13 +57,19 @@ export class DeepMerger {
 
     if (atPath?.length) {
       const [head, ...tail] = atPath;
-      if (head === "__proto__" || head === "constructor") {
+      if (head === "__proto__") {
         return target;
       }
       if (target === undefined) {
         target = objForKey(head);
       }
-      let nestedTarget = target[head];
+      // Only follow own properties to prevent prototype chain traversal
+      // (e.g. target["constructor"] on a plain object would otherwise
+      // return the Object constructor and allow mutations to Object.prototype)
+      let nestedTarget =
+        isNonNullObject(target) && hasOwnProperty.call(target, head)
+          ? target[head]
+          : undefined;
       if (nestedTarget === undefined && tail.length) {
         nestedTarget = objForKey(tail[0]);
       }
@@ -90,8 +96,11 @@ export class DeepMerger {
 
     if (isNonNullObject(source) && isNonNullObject(target)) {
       Object.keys(source).forEach((sourceKey) => {
-        // Skip keys that could manipulate the prototype chain.
-        if (sourceKey === "__proto__" || sourceKey === "constructor") {
+        // __proto__ is an own enumerable property after JSON.parse and its
+        // assignment invokes the [[Prototype]] setter, so skip it.
+        // constructor is a valid GraphQL field name, so it must not be skipped;
+        // assigning it as an own property is safe and does not affect Object.prototype.
+        if (sourceKey === "__proto__") {
           return;
         }
         if (hasOwnProperty.call(target, sourceKey)) {

--- a/src/utilities/internal/DeepMerger.ts
+++ b/src/utilities/internal/DeepMerger.ts
@@ -57,6 +57,9 @@ export class DeepMerger {
 
     if (atPath?.length) {
       const [head, ...tail] = atPath;
+      if (head === "__proto__" || head === "constructor") {
+        return target;
+      }
       if (target === undefined) {
         target = objForKey(head);
       }

--- a/src/utilities/internal/__tests__/DeepMerger.test.ts
+++ b/src/utilities/internal/__tests__/DeepMerger.test.ts
@@ -84,5 +84,25 @@ test("ignores constructor key to prevent prototype pollution", () => {
   const result = merger.merge(target, malicious);
 
   expect((Object.prototype as any).polluted).toBeUndefined();
+  expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
   expect(result).toEqual({ a: 1 });
+});
+
+test("ignores __proto__ and constructor in atPath to prevent prototype pollution", () => {
+  const merger = new DeepMerger();
+  const target = { a: 1 };
+
+  const resultProto = merger.merge(target, { polluted: true }, {
+    atPath: ["__proto__"],
+  });
+  expect((Object.prototype as any).polluted).toBeUndefined();
+  expect(Object.getPrototypeOf(resultProto)).toBe(Object.prototype);
+  expect(resultProto).toEqual({ a: 1 });
+
+  const resultCtor = merger.merge(target, { polluted: true }, {
+    atPath: ["constructor"],
+  });
+  expect((Object.prototype as any).polluted).toBeUndefined();
+  expect(Object.getPrototypeOf(resultCtor)).toBe(Object.prototype);
+  expect(resultCtor).toEqual({ a: 1 });
 });

--- a/src/utilities/internal/__tests__/DeepMerger.test.ts
+++ b/src/utilities/internal/__tests__/DeepMerger.test.ts
@@ -76,33 +76,63 @@ test("ignores __proto__ key to prevent prototype pollution", () => {
   expect(result).toEqual({ a: 1 });
 });
 
-test("ignores constructor key to prevent prototype pollution", () => {
+test("merges constructor key as own property without prototype pollution", () => {
   const merger = new DeepMerger();
   const target = { a: 1 };
-  const malicious = JSON.parse('{"constructor": {"prototype": {"polluted": true}}}');
+  // constructor is a valid GraphQL field name and must not be silently dropped
+  const source = JSON.parse('{"constructor": {"prototype": {"polluted": true}}}');
 
-  const result = merger.merge(target, malicious);
+  const result = merger.merge(target, source);
 
+  // Object.prototype must not be affected
+  expect((Object.prototype as any).polluted).toBeUndefined();
+  expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  // constructor should be present as an own property with the source value
+  expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(true);
+  expect(result).toEqual({ a: 1, constructor: { prototype: { polluted: true } } });
+});
+
+test("ignores __proto__ in atPath to prevent prototype pollution", () => {
+  const merger = new DeepMerger();
+  const target = { a: 1 };
+
+  const result = merger.merge(target, { polluted: true }, {
+    atPath: ["__proto__"],
+  });
   expect((Object.prototype as any).polluted).toBeUndefined();
   expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
   expect(result).toEqual({ a: 1 });
 });
 
-test("ignores __proto__ and constructor in atPath to prevent prototype pollution", () => {
+test("handles constructor in atPath without prototype pollution", () => {
   const merger = new DeepMerger();
   const target = { a: 1 };
 
-  const resultProto = merger.merge(target, { polluted: true }, {
-    atPath: ["__proto__"],
-  });
-  expect((Object.prototype as any).polluted).toBeUndefined();
-  expect(Object.getPrototypeOf(resultProto)).toBe(Object.prototype);
-  expect(resultProto).toEqual({ a: 1 });
-
-  const resultCtor = merger.merge(target, { polluted: true }, {
+  // constructor is a valid GraphQL field name; @defer/@stream paths may include it
+  const result = merger.merge(target, { polluted: true }, {
     atPath: ["constructor"],
   });
+  // Object.prototype must not be modified
   expect((Object.prototype as any).polluted).toBeUndefined();
-  expect(Object.getPrototypeOf(resultCtor)).toBe(Object.prototype);
-  expect(resultCtor).toEqual({ a: 1 });
+  expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  // The data should be written to an own "constructor" property, not dropped
+  expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(true);
+  expect(result).toEqual({ a: 1, constructor: { polluted: true } });
+});
+
+test("handles constructor.prototype path in atPath without prototype pollution", () => {
+  const merger = new DeepMerger();
+  const target = { a: 1 };
+
+  const result = merger.merge(target, true, {
+    atPath: ["constructor", "prototype", "isAdmin"],
+  });
+  // Object.prototype must not be modified
+  expect((Object.prototype as any).isAdmin).toBeUndefined();
+  expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  // Data is written as own properties, not into Object.prototype
+  expect(result).toEqual({
+    a: 1,
+    constructor: { prototype: { isAdmin: true } },
+  });
 });

--- a/src/utilities/internal/__tests__/DeepMerger.test.ts
+++ b/src/utilities/internal/__tests__/DeepMerger.test.ts
@@ -62,3 +62,27 @@ test("maintains source length when using truncate arrayMerge when source is long
 
   expect(result).toEqual([{ a: 2, b: { c: 2 } }, { e: 2 }]);
 });
+
+test("ignores __proto__ key to prevent prototype pollution", () => {
+  const merger = new DeepMerger();
+  const target = { a: 1 };
+  // JSON.parse creates __proto__ as an own enumerable property
+  const malicious = JSON.parse('{"__proto__": {"polluted": true}}');
+
+  const result = merger.merge(target, malicious);
+
+  expect((Object.prototype as any).polluted).toBeUndefined();
+  expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  expect(result).toEqual({ a: 1 });
+});
+
+test("ignores constructor key to prevent prototype pollution", () => {
+  const merger = new DeepMerger();
+  const target = { a: 1 };
+  const malicious = JSON.parse('{"constructor": {"prototype": {"polluted": true}}}');
+
+  const result = merger.merge(target, malicious);
+
+  expect((Object.prototype as any).polluted).toBeUndefined();
+  expect(result).toEqual({ a: 1 });
+});


### PR DESCRIPTION
## Summary

- `DeepMerger.merge()` now skips `__proto__` keys during object merging to prevent prototype chain disruption
- Guards the `atPath` navigation path against `__proto__` segments (used in `@defer`/`@stream` incremental responses)
- Adds `hasOwnProperty` check in the `atPath` branch to prevent traversal of inherited properties such as `constructor`
- `constructor` is kept as a valid GraphQL field name and merged as an own property
- Added tests that verify `Object.prototype` is not polluted and individual result objects retain the correct prototype

## Motivation

`DeepMerger` is an internal utility, but it sits in the **critical path of every cache write operation**. When Apollo Client processes a GraphQL response, data flows through:

```
client.query() / client.mutate() / cache.write()
  → StoreWriter.writeToStore()
  → EntityStore.merge(dataId, incomingFields)
  → new DeepMerger().merge(existing, incoming)
```

### `__proto__` as a data key (Object.keys path)

`JSON.parse` produces objects where `"__proto__"` is an own enumerable data property rather than the prototype accessor. Without this fix, `Object.keys(source)` includes `"__proto__"` and the merge loop executes:

```ts
target = this.shallowCopyForMerge(target);
target["__proto__"] = source["__proto__"]; // invokes the [[Prototype]] setter
```

This calls `Object.setPrototypeOf(target, { isAdmin: true })`, silently replacing the prototype of the **individual result object**. The result object appears to have the injected property via its prototype chain, while the property is not an own property:

```typescript
const maliciousData = JSON.parse('{"id":"1","__proto__":{"isAdmin":true}}');
// merge result (without fix):
//   result.isAdmin === true          ← via corrupted [[Prototype]]
//   Object.hasOwn(result, "isAdmin") === false
//   Object.prototype.isAdmin === undefined  ← global Object.prototype is NOT affected
//   Object.getPrototypeOf(result) !== Object.prototype  ← individual object is affected
```

Note: `({}).isAdmin` remains `undefined`; global `Object.prototype` is **not** polluted. The existing `shallowCopyForMerge` mechanism (which copies objects via spread rather than mutating in place) prevents that. However, the prototype chain of individual result objects **is** disrupted, which can break `instanceof` checks, inherited method calls, and serialization on response data.

Note: GraphQL field names follow the pattern `[_A-Za-z][_0-9A-Za-z]*`, so `__proto__` is a **valid GraphQL field name** — a malicious or compromised server could expose it without triggering schema validation errors.

### `__proto__` as a path segment (atPath branch)

The `@defer`/`@stream` incremental response handlers (`src/incremental/`) pass server-controlled `path` arrays as `atPath` to `DeepMerger.merge()`. Without the fix, a path segment of `"__proto__"` causes:

```ts
let nestedTarget = target["__proto__"]; // returns Object.prototype via getter
// … merge proceeds with Object.prototype as the recursive target …
target = this.shallowCopyForMerge(target);
target["__proto__"] = nestedSource;     // replaces result's [[Prototype]]
```

Again, `shallowCopyForMerge` prevents in-place mutation of the real `Object.prototype`, but the result object ends up with a null-prototype copy as its `[[Prototype]]`, breaking its prototype chain.

### `constructor` in the atPath branch

Without a `hasOwnProperty` check, a path of `["constructor", "prototype", "anyKey"]` traverses inherited properties: `target["constructor"]` returns the `Object` function, and `Object["prototype"]` reaches `Object.prototype`. `shallowCopyForMerge` again prevents direct mutation, but the traversal is unintended and causes the result object's `constructor` own property to be replaced with a detached copy of the `Object` function.

## Test plan

- [x] Run `npm test -- --testPathPatterns="DeepMerger.test"` and verify all tests pass
- [x] Verify `Object.prototype` remains unpolluted after merging a server payload containing `__proto__` or `constructor` keys
- [x] Verify `Object.getPrototypeOf(result) === Object.prototype` (individual result objects retain the correct prototype)