### PR TITLE
Fix refetchOn evaluation when refetchOn is an object and default refetchOn is non-object

### DIFF
--- a/.changeset/slimy-dots-beam.md
+++ b/.changeset/slimy-dots-beam.md
@@ -1,0 +1,25 @@
+---
+"@apollo/client": patch
+---
+
+Fix `refetchOn` merging when `defaultOptions.watchQuery.refetchOn` is set to a non-object value (`false`, `true`, or a function) and the per-query `refetchOn` is an object. Previously the per-query object completely replaced the default so unspecified events fell back to "enabled" regardless of the default.
+
+The `defaultOptions` value now applies to any event the per-query object does not explicitly configure:
+
+- `false` - unspecified events stay disabled
+- `true` - unspecified events refetch
+- Callback function - the function is called for unspecified events to determine whether to refetch
+
+```ts
+const client = new ApolloClient({
+  // ...
+  defaultOptions: {
+    watchQuery: {
+      refetchOn: false,
+    },
+  },
+});
+
+// Only `windowFocus` refetches. Other events stay disabled per the default.
+useQuery(QUERY, { refetchOn: { windowFocus: true } });
+```

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1264,6 +1264,22 @@ export class ApolloClient {
   >(
     options: ApolloClient.WatchQueryOptions<TData, TVariables>
   ): ObservableQuery<TData, TVariables> {
+    const warnOnUnknownSources = (refetchOn: Record<string, any>) => {
+      if (this.refetchEventManager) {
+        for (const source of Object.keys(refetchOn)) {
+          if (
+            !this.refetchEventManager.hasSource(source as keyof RefetchEvents)
+          ) {
+            invariant.warn(
+              "`refetchOn` references the '%s' event on query '%s' but no source is configured for it on the `RefetchEventManager`. This event will never fire. Add a source for the event to the `sources` option or call `setEventSource` on the refetch event manager.",
+              source,
+              getOperationName(options.query, "(anonymous)")
+            );
+          }
+        }
+      }
+    };
+
     if (this.defaultOptions.watchQuery) {
       const defaultRefetchOn = this.defaultOptions.watchQuery.refetchOn;
       const { refetchOn } = options;
@@ -1291,6 +1307,12 @@ export class ApolloClient {
 
             return value;
           };
+
+          // We need to warn here instead of the __DEV__ check below since we
+          // overwrite options.refetchOn to a function type.
+          if (__DEV__) {
+            warnOnUnknownSources(refetchOn);
+          }
         }
       }
 
@@ -1317,15 +1339,7 @@ export class ApolloClient {
             operationName
           );
         } else if (typeof refetchOn === "object") {
-          Object.keys(refetchOn).forEach((source) => {
-            if (!refetchEventManager.hasSource(source as keyof RefetchEvents)) {
-              invariant.warn(
-                "`refetchOn` references the '%s' event on query '%s' but no source is configured for it on the `RefetchEventManager`. This event will never fire. Add a source for the event to the `sources` option or call `setEventSource` on the refetch event manager.",
-                source,
-                operationName
-              );
-            }
-          });
+          warnOnUnknownSources(refetchOn);
         }
       }
     }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1266,15 +1266,33 @@ export class ApolloClient {
   ): ObservableQuery<TData, TVariables> {
     if (this.defaultOptions.watchQuery) {
       const defaultRefetchOn = this.defaultOptions.watchQuery.refetchOn;
-      const mergedRefetchOn =
-        (
-          options.refetchOn &&
-          typeof options.refetchOn === "object" &&
-          defaultRefetchOn &&
-          typeof defaultRefetchOn === "object"
-        ) ?
-          { ...defaultRefetchOn, ...options.refetchOn }
-        : undefined;
+      const { refetchOn } = options;
+      let mergedRefetchOn: RefetchOn.Option | undefined;
+
+      if (refetchOn && typeof refetchOn === "object") {
+        if (typeof defaultRefetchOn === "object") {
+          mergedRefetchOn = { ...defaultRefetchOn, ...refetchOn };
+        } else if (defaultRefetchOn != null) {
+          // Capture the default `refetchOn` at the time of the `watchQuery`
+          // call so that it is unaffected even if defaultOptions.refetchOn is
+          // mutated later.
+          //
+          // We set the merged `refetchOn` option to a callback function in case
+          // the client hasn't connected to a RefetchEventManager yet, or
+          // sources are added to the manager after watchQuery is called. This
+          // ensures we can handle any registered source regardless of when it
+          // was registered.
+          mergedRefetchOn = (ctx) => {
+            const value = refetchOn[ctx.source] ?? defaultRefetchOn;
+
+            if (typeof value === "function") {
+              return value(ctx as any);
+            }
+
+            return value;
+          };
+        }
+      }
 
       options = mergeOptions(
         this.defaultOptions.watchQuery as typeof options,

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1264,25 +1264,10 @@ export class ApolloClient {
   >(
     options: ApolloClient.WatchQueryOptions<TData, TVariables>
   ): ObservableQuery<TData, TVariables> {
-    const warnOnUnknownSources = (refetchOn: Record<string, any>) => {
-      if (this.refetchEventManager) {
-        for (const source of Object.keys(refetchOn)) {
-          if (
-            !this.refetchEventManager.hasSource(source as keyof RefetchEvents)
-          ) {
-            invariant.warn(
-              "`refetchOn` references the '%s' event on query '%s' but no source is configured for it on the `RefetchEventManager`. This event will never fire. Add a source for the event to the `sources` option or call `setEventSource` on the refetch event manager.",
-              source,
-              getOperationName(options.query, "(anonymous)")
-            );
-          }
-        }
-      }
-    };
+    const { refetchOn } = options;
 
     if (this.defaultOptions.watchQuery) {
       const defaultRefetchOn = this.defaultOptions.watchQuery.refetchOn;
-      const { refetchOn } = options;
       let mergedRefetchOn: RefetchOn.Option | undefined;
 
       if (refetchOn && typeof refetchOn === "object") {
@@ -1307,12 +1292,6 @@ export class ApolloClient {
 
             return value;
           };
-
-          // We need to warn here instead of the __DEV__ check below since we
-          // overwrite options.refetchOn to a function type.
-          if (__DEV__) {
-            warnOnUnknownSources(refetchOn);
-          }
         }
       }
 
@@ -1327,9 +1306,11 @@ export class ApolloClient {
     }
 
     if (__DEV__) {
-      const { refetchOn, query } = options;
+      const { query } = options;
       const { refetchEventManager } = this;
 
+      // Note: refetchOn evaluates the original refetchOn value, not the merged
+      // refetchOn value.
       if (refetchOn) {
         const operationName = getOperationName(query, "(anonymous)");
 
@@ -1339,7 +1320,15 @@ export class ApolloClient {
             operationName
           );
         } else if (typeof refetchOn === "object") {
-          warnOnUnknownSources(refetchOn);
+          Object.keys(refetchOn).forEach((source) => {
+            if (!refetchEventManager.hasSource(source as keyof RefetchEvents)) {
+              invariant.warn(
+                "`refetchOn` references the '%s' event on query '%s' but no source is configured for it on the `RefetchEventManager`. This event will never fire. Add a source for the event to the `sources` option or call `setEventSource` on the refetch event manager.",
+                source,
+                operationName
+              );
+            }
+          });
         }
       }
     }

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1295,7 +1295,7 @@ export class ApolloClient {
 
         if (!refetchEventManager) {
           invariant.warn(
-            "`refetchOn` was set on query '%s' but no `RefetchEventManager` is configured on this `ApolloClient` instance. This option has no effect. Pass a `RefetchEventManager` instance to the `refetchEventManager` option on the `ApolloClient` constructor.",
+            "`refetchOn` was set on query '%s' but no `RefetchEventManager` is configured on this `ApolloClient` instance. This option has no effect until a RefetchEventManager is connected to this client. Pass a `RefetchEventManager` instance to the `refetchEventManager` option on the `ApolloClient` constructor.",
             operationName
           );
         } else if (typeof refetchOn === "object") {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1267,6 +1267,9 @@ export class ApolloClient {
     const { refetchOn } = options;
 
     if (this.defaultOptions.watchQuery) {
+      // Capture the default `refetchOn` at the time of the `watchQuery`
+      // call so that it is unaffected even if defaultOptions.refetchOn is
+      // mutated later.
       const defaultRefetchOn = this.defaultOptions.watchQuery.refetchOn;
       let mergedRefetchOn: RefetchOn.Option | undefined;
 
@@ -1274,10 +1277,6 @@ export class ApolloClient {
         if (typeof defaultRefetchOn === "object") {
           mergedRefetchOn = { ...defaultRefetchOn, ...refetchOn };
         } else if (defaultRefetchOn != null) {
-          // Capture the default `refetchOn` at the time of the `watchQuery`
-          // call so that it is unaffected even if defaultOptions.refetchOn is
-          // mutated later.
-          //
           // We set the merged `refetchOn` option to a callback function in case
           // the client hasn't connected to a RefetchEventManager yet, or
           // sources are added to the manager after watchQuery is called. This

--- a/src/core/RefetchEventManager.ts
+++ b/src/core/RefetchEventManager.ts
@@ -253,7 +253,7 @@ export class RefetchEventManager {
     const handler: RefetchEventManager.EventHandler<any> =
       this.handlers[source] ?? defaultHandler;
 
-    function matchesRefetchOn(oq: ObservableQuery<any>) {
+    const matchesRefetchOn = (oq: ObservableQuery<any>) => {
       const ctx: RefetchOn.Context<any> = { source, payload };
       const refetchOn = oq.options.refetchOn;
 
@@ -265,12 +265,16 @@ export class RefetchEventManager {
         return refetchOn(ctx);
       }
 
-      if (typeof refetchOn?.[source] === "function") {
-        return refetchOn[source](ctx as any);
+      const refetchOnForEvent =
+        refetchOn?.[source] ??
+        this.client?.defaultOptions.watchQuery?.refetchOn;
+
+      if (typeof refetchOnForEvent === "function") {
+        return refetchOnForEvent(ctx as any);
       }
 
-      return refetchOn?.[source] !== false;
-    }
+      return refetchOnForEvent !== false;
+    };
 
     handler({ client: this.client, source, payload, matchesRefetchOn });
   }

--- a/src/core/RefetchEventManager.ts
+++ b/src/core/RefetchEventManager.ts
@@ -253,7 +253,7 @@ export class RefetchEventManager {
     const handler: RefetchEventManager.EventHandler<any> =
       this.handlers[source] ?? defaultHandler;
 
-    const matchesRefetchOn = (oq: ObservableQuery<any>) => {
+    function matchesRefetchOn(oq: ObservableQuery<any>) {
       const ctx: RefetchOn.Context<any> = { source, payload };
       const refetchOn = oq.options.refetchOn;
 
@@ -270,7 +270,7 @@ export class RefetchEventManager {
       }
 
       return refetchOn?.[source] !== false;
-    };
+    }
 
     handler({ client: this.client, source, payload, matchesRefetchOn });
   }

--- a/src/core/RefetchEventManager.ts
+++ b/src/core/RefetchEventManager.ts
@@ -265,15 +265,11 @@ export class RefetchEventManager {
         return refetchOn(ctx);
       }
 
-      const refetchOnForEvent =
-        refetchOn?.[source] ??
-        this.client?.defaultOptions.watchQuery?.refetchOn;
-
-      if (typeof refetchOnForEvent === "function") {
-        return refetchOnForEvent(ctx as any);
+      if (typeof refetchOn?.[source] === "function") {
+        return refetchOn[source](ctx as any);
       }
 
-      return refetchOnForEvent !== false;
+      return refetchOn?.[source] !== false;
     };
 
     handler({ client: this.client, source, payload, matchesRefetchOn });

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -1382,6 +1382,87 @@ test("per-query refetchOn object only enables specified events when defaultOptio
   await expect(stream).not.toEmitAnything();
 });
 
+test("handles defaultOptions refetchOn when manager connects after watchQuery is called", async () => {
+  const counts: Record<string, number> = {};
+
+  const refetchEventManager = new RefetchEventManager({
+    sources: {
+      test: () => of(),
+      windowFocus: () => of(),
+    },
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        refetchOn: false,
+      },
+    },
+    link: new MockLink([
+      {
+        request: { query, variables: () => true },
+        result: ({ id }) => {
+          counts[id] ??= 0;
+
+          return { data: { count: ++counts[id] } };
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      variables: { id: "a" },
+      refetchOn: { test: true },
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  refetchEventManager.connect(client);
+
+  refetchEventManager.emit("windowFocus", new Event("visibilitychange"));
+
+  await expect(stream).not.toEmitAnything();
+
+  refetchEventManager.emit("test");
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test("per-query refetchOn object refetches unspecified events when defaultOptions has refetchOn: true", async () => {
   const counts: Record<string, number> = {};
 

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -2749,3 +2749,37 @@ test("warns when refetchOn is provided but the source is not configured in Refet
     "CountQuery"
   );
 });
+
+test("warns when per-query refetchOn references unknown sources and defaultOptions refetchOn is a non-object value", async () => {
+  using _ = spyOnConsole("warn");
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        refetchOn: false,
+      },
+    },
+    link: new MockLink([]),
+    refetchEventManager: new RefetchEventManager({
+      sources: { test: true },
+    }),
+  });
+
+  client.watchQuery({
+    query,
+    variables: { id: "1" },
+    refetchOn: {
+      test: true,
+      // @ts-ignore
+      unknownSource: true,
+    },
+  });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    "`refetchOn` references the '%s' event on query '%s' but no source is configured for it on the `RefetchEventManager`. This event will never fire. Add a source for the event to the `sources` option or call `setEventSource` on the refetch event manager.",
+    "unknownSource",
+    "CountQuery"
+  );
+});

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -1625,6 +1625,68 @@ test("mutating client.defaultOptions.watchQuery.refetchOn does not affect existi
   await expect(stream).not.toEmitAnything();
 });
 
+test("mutating non-object client.defaultOptions.watchQuery.refetchOn does not affect existing queries with object refetchOn", async () => {
+  const counts: Record<string, number> = {};
+
+  const refetchEventManager = new RefetchEventManager({
+    sources: {
+      test: () => of(),
+      windowFocus: () => of(),
+    },
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        refetchOn: false,
+      },
+    },
+    link: new MockLink([
+      {
+        request: { query, variables: () => true },
+        result: ({ id }) => {
+          counts[id] ??= 0;
+
+          return { data: { count: ++counts[id] } };
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+    refetchEventManager,
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      variables: { id: "a" },
+      refetchOn: { test: true },
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  client.defaultOptions.watchQuery!.refetchOn = true;
+
+  refetchEventManager.emit("windowFocus", new Event("visibilitychange"));
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test("per-query refetchOn: false replaces a partial defaultOptions refetchOn object", async () => {
   const refetchEventManager = new RefetchEventManager({
     sources: {

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -1303,6 +1303,84 @@ test("per-query refetchOn merges with defaultOptions.watchQuery.refetchOn", asyn
   await expect(stream).not.toEmitAnything();
 });
 
+test("per-query refetchOn object only enables specified events when defaultOptions has refetchOn: false", async () => {
+  const counts: Record<string, number> = {};
+
+  const refetchEventManager = new RefetchEventManager({
+    sources: {
+      test: () => of(),
+      windowFocus: () => of(),
+    },
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        refetchOn: false,
+      },
+    },
+    link: new MockLink([
+      {
+        request: { query, variables: () => true },
+        result: ({ id }) => {
+          counts[id] ??= 0;
+
+          return { data: { count: ++counts[id] } };
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+    refetchEventManager,
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      variables: { id: "a" },
+      refetchOn: { test: true },
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  refetchEventManager.emit("test");
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  refetchEventManager.emit("windowFocus", new Event("visibilitychange"));
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test("mutating client.defaultOptions.watchQuery.refetchOn does not affect existing queries", async () => {
   const counts: Record<string, number> = {};
 

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -2700,7 +2700,7 @@ test("warns when refetchOn is provided but refetchEventManager is not configured
 
   expect(console.warn).toHaveBeenCalledTimes(1);
   expect(console.warn).toHaveBeenCalledWith(
-    "`refetchOn` was set on query '%s' but no `RefetchEventManager` is configured on this `ApolloClient` instance. This option has no effect. Pass a `RefetchEventManager` instance to the `refetchEventManager` option on the `ApolloClient` constructor.",
+    "`refetchOn` was set on query '%s' but no `RefetchEventManager` is configured on this `ApolloClient` instance. This option has no effect until a RefetchEventManager is connected to this client. Pass a `RefetchEventManager` instance to the `refetchEventManager` option on the `ApolloClient` constructor.",
     "CountQuery"
   );
 });

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -1383,6 +1383,9 @@ test("per-query refetchOn object only enables specified events when defaultOptio
 });
 
 test("handles defaultOptions refetchOn when manager connects after watchQuery is called", async () => {
+  // Silence the warning about the refetchOn option used while the client is
+  // disconnected.
+  using _ = spyOnConsole("warn");
   const counts: Record<string, number> = {};
 
   const refetchEventManager = new RefetchEventManager({

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -3,6 +3,7 @@ import { gql } from "graphql-tag";
 import type { Observer } from "rxjs";
 import { of } from "rxjs";
 
+import type { RefetchOn } from "@apollo/client";
 import {
   ApolloClient,
   NetworkStatus,
@@ -1377,6 +1378,176 @@ test("per-query refetchOn object only enables specified events when defaultOptio
   });
 
   refetchEventManager.emit("windowFocus", new Event("visibilitychange"));
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("per-query refetchOn object refetches unspecified events when defaultOptions has refetchOn: true", async () => {
+  const counts: Record<string, number> = {};
+
+  const refetchEventManager = new RefetchEventManager({
+    sources: {
+      test: () => of(),
+      windowFocus: () => of(),
+    },
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        refetchOn: true,
+      },
+    },
+    link: new MockLink([
+      {
+        request: { query, variables: () => true },
+        result: ({ id }) => {
+          counts[id] ??= 0;
+
+          return { data: { count: ++counts[id] } };
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+    refetchEventManager,
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      variables: { id: "a" },
+      refetchOn: { test: false },
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  refetchEventManager.emit("test");
+
+  await expect(stream).not.toEmitAnything();
+
+  refetchEventManager.emit("windowFocus", new Event("visibilitychange"));
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("per-query refetchOn object falls back to defaultOptions refetchOn function for unspecified events", async () => {
+  const counts: Record<string, number> = {};
+  const defaultCallback = jest.fn(
+    ({ source }: RefetchOn.Context) => source === "windowFocus"
+  );
+
+  const refetchEventManager = new RefetchEventManager({
+    sources: {
+      test: () => of(),
+      windowFocus: () => of(),
+    },
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        refetchOn: defaultCallback,
+      },
+    },
+    link: new MockLink([
+      {
+        request: { query, variables: () => true },
+        result: ({ id }) => {
+          counts[id] ??= 0;
+
+          return { data: { count: ++counts[id] } };
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+    refetchEventManager,
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      variables: { id: "a" },
+      refetchOn: { test: false },
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  refetchEventManager.emit("test");
+
+  await expect(stream).not.toEmitAnything();
+  expect(defaultCallback).not.toHaveBeenCalled();
+
+  refetchEventManager.emit("windowFocus", new Event("visibilitychange"));
+
+  expect(defaultCallback).toHaveBeenCalledTimes(1);
+  expect(defaultCallback).toHaveBeenCalledWith({
+    source: "windowFocus",
+    payload: new Event("visibilitychange"),
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
 
   await expect(stream).not.toEmitAnything();
 });


### PR DESCRIPTION
Closes #13226 

Fixes an issue where a partial object passed as the `refetchOn` option would mistakenly enable all events if `defaultOptions.watchQuery.refetchOn` was not an object. This also addresses an issue where mutating `defaultOptions` after `watchQuery` was called, or connecting a client after `watchQuery` was called would not evaluate the default refetchOn properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed merging behavior for query refresh options when both default and per-query configurations are specified. Unspecified settings in per-query configurations now properly inherit from default options instead of being fully overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->