### PR TITLE
Add ability to override the default handler in `RefetchEventManager`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1162,6 +1162,7 @@ export namespace RefetchEventManager {
     export type EventSource<T> = () => Observable<T>;
     // (undocumented)
     export interface Options {
+        defaultHandler?: RefetchEventManager.EventHandler<keyof RefetchEvents>;
         handlers?: {
             [Key in keyof RefetchEvents]?: RefetchEventManager.EventHandler<Key>;
         };
@@ -1188,6 +1189,7 @@ export class RefetchEventManager {
     ] : [payload: RefetchEvents[TSource]]): void;
     hasSource(source: keyof RefetchEvents): boolean;
     removeEventSource(event: keyof RefetchEvents): void;
+    setDefaultEventHandler(handler: RefetchEventManager.EventHandler<keyof RefetchEvents>): void;
     setEventHandler<TSource extends keyof RefetchEvents>(source: TSource, handler: RefetchEventManager.EventHandler<TSource>): void;
     setEventSource<TSource extends keyof RefetchEvents>(name: TSource, source: RefetchEventManager.EventSource<RefetchEvents[TSource]>): void;
 }

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2627,6 +2627,7 @@ export namespace RefetchEventManager {
     export type EventSource<T> = () => Observable<T>;
     // (undocumented)
     export interface Options {
+        defaultHandler?: RefetchEventManager.EventHandler<keyof RefetchEvents>;
         handlers?: {
             [Key in keyof RefetchEvents]?: RefetchEventManager.EventHandler<Key>;
         };
@@ -2653,6 +2654,7 @@ export class RefetchEventManager {
     ] : [payload: RefetchEvents[TSource]]): void;
     hasSource(source: keyof RefetchEvents): boolean;
     removeEventSource(event: keyof RefetchEvents): void;
+    setDefaultEventHandler(handler: RefetchEventManager.EventHandler<keyof RefetchEvents>): void;
     setEventHandler<TSource extends keyof RefetchEvents>(source: TSource, handler: RefetchEventManager.EventHandler<TSource>): void;
     setEventSource<TSource extends keyof RefetchEvents>(name: TSource, source: RefetchEventManager.EventSource<RefetchEvents[TSource]>): void;
 }

--- a/.changeset/tender-dryers-roll.md
+++ b/.changeset/tender-dryers-roll.md
@@ -1,0 +1,16 @@
+---
+"@apollo/client": patch
+---
+
+Add the ability to override the default event handler on `RefetchEventManager`. The default handler runs when no per-source handler is configured for an event. Provide a custom handler via the `defaultHandler` constructor option or the `setDefaultEventHandler` instance method.
+
+```ts
+new RefetchEventManager({
+  defaultHandler: ({ client, matchesRefetchOn }) => {
+    return client.refetchQueries({
+      include: "all",
+      onQueryUpdated: matchesRefetchOn,
+    });
+  },
+});
+```

--- a/src/core/RefetchEventManager.ts
+++ b/src/core/RefetchEventManager.ts
@@ -30,6 +30,12 @@ export declare namespace RefetchEventManager {
     handlers?: {
       [Key in keyof RefetchEvents]?: RefetchEventManager.EventHandler<Key>;
     };
+
+    /**
+     * Override the default handler. Used as a fallback when a refetch
+     * handler is not defined for a specific event.
+     */
+    defaultHandler?: RefetchEventManager.EventHandler<keyof RefetchEvents>;
   }
 
   export type EventSource<T> = () => Observable<T>;
@@ -127,13 +133,12 @@ export class RefetchEventManager {
 
   private client: ApolloClient | undefined;
 
-  private defaultHandler: RefetchEventManager.EventHandler<
-    keyof RefetchEvents
-  > = defaultHandler;
+  private defaultHandler: RefetchEventManager.EventHandler<keyof RefetchEvents>;
 
   constructor(options: RefetchEventManager.Options = {}) {
     this.sources = options.sources ?? {};
     this.handlers = options.handlers ?? {};
+    this.defaultHandler = options.defaultHandler ?? defaultHandler;
   }
 
   /**

--- a/src/core/RefetchEventManager.ts
+++ b/src/core/RefetchEventManager.ts
@@ -127,6 +127,10 @@ export class RefetchEventManager {
 
   private client: ApolloClient | undefined;
 
+  private defaultHandler: RefetchEventManager.EventHandler<
+    keyof RefetchEvents
+  > = defaultHandler;
+
   constructor(options: RefetchEventManager.Options = {}) {
     this.sources = options.sources ?? {};
     this.handlers = options.handlers ?? {};
@@ -213,6 +217,15 @@ export class RefetchEventManager {
   }
 
   /**
+   * Replaces the default event handler with the provided handler.
+   */
+  setDefaultEventHandler(
+    handler: RefetchEventManager.EventHandler<keyof RefetchEvents>
+  ) {
+    this.defaultHandler = handler;
+  }
+
+  /**
    * Manually triggers a refetch for the provided event.
    *
    * @remarks
@@ -251,7 +264,7 @@ export class RefetchEventManager {
     }
 
     const handler: RefetchEventManager.EventHandler<any> =
-      this.handlers[source] ?? defaultHandler;
+      this.handlers[source] ?? this.defaultHandler;
 
     function matchesRefetchOn(oq: ObservableQuery<any>) {
       const ctx: RefetchOn.Context<any> = { source, payload };

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -1025,6 +1025,157 @@ test("can override the default handler when provided via option", async () => {
   await expect(streamB).not.toEmitAnything();
 });
 
+test("per-source handler in handlers option overrides the default handler callback", async () => {
+  const counts: Record<string, number> = {};
+
+  const defaultHandler = jest.fn((({ client, matchesRefetchOn }) => {
+    return client.refetchQueries({
+      include: "active",
+      onQueryUpdated: matchesRefetchOn,
+    });
+  }) satisfies RefetchEventManager.EventHandler);
+
+  const testHandler = jest.fn((({ client }) => {
+    return client.refetchQueries({
+      include: "active",
+      onQueryUpdated: (oq) => oq.variables.id === "a",
+    });
+  }) satisfies RefetchEventManager.EventHandler<"test">);
+
+  const refetchEventManager = new RefetchEventManager({
+    defaultHandler,
+    sources: {
+      test: () => of(),
+      windowFocus: () => of(),
+    },
+    handlers: { test: testHandler },
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query, variables: () => true },
+        result: ({ id }) => {
+          counts[id] ??= 0;
+
+          return { data: { count: ++counts[id] } };
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+    refetchEventManager,
+  });
+
+  const streamA = new ObservableStream(
+    client.watchQuery({ query, variables: { id: "a" } })
+  );
+  const streamB = new ObservableStream(
+    client.watchQuery({ query, variables: { id: "b" } })
+  );
+
+  await expect(streamA).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(streamB).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(streamB).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  refetchEventManager.emit("test");
+
+  expect(testHandler).toHaveBeenCalledTimes(1);
+  expect(testHandler).toHaveBeenCalledWith({
+    client,
+    source: "test",
+    payload: undefined,
+    matchesRefetchOn: expect.any(Function),
+  });
+  expect(defaultHandler).not.toHaveBeenCalled();
+
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(streamA).not.toEmitAnything();
+  await expect(streamB).not.toEmitAnything();
+
+  refetchEventManager.emit("windowFocus", new Event("visibilitychange"));
+
+  expect(defaultHandler).toHaveBeenCalledTimes(1);
+  expect(defaultHandler).toHaveBeenCalledWith({
+    client,
+    source: "windowFocus",
+    payload: new Event("visibilitychange"),
+    matchesRefetchOn: expect.any(Function),
+  });
+  expect(testHandler).toHaveBeenCalledTimes(1);
+
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+  await expect(streamB).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 3 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(streamB).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(streamA).not.toEmitAnything();
+  await expect(streamB).not.toEmitAnything();
+});
+
 test("can override the default handler with `setDefaultEventHandler`", async () => {
   const counts: Record<string, number> = {};
   const defaultHandler = jest.fn((({ client }) => {

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -925,6 +925,106 @@ test("custom handler can conditionally skip refetch", async () => {
   await expect(stream).not.toEmitAnything();
 });
 
+test("can override the default handler when provided via option", async () => {
+  const counts: Record<string, number> = {};
+  const defaultHandler = jest.fn((({ client }) => {
+    return client.refetchQueries({
+      include: "active",
+      onQueryUpdated: (oq) => oq.variables.id === "a",
+    });
+  }) satisfies RefetchEventManager.EventHandler);
+
+  const refetchEventManager = new RefetchEventManager({
+    defaultHandler,
+    sources: {
+      test: () => of(),
+    },
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query, variables: () => true },
+        result: ({ id }) => {
+          counts[id] ??= 0;
+
+          return { data: { count: ++counts[id] } };
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+    refetchEventManager,
+  });
+
+  const streamA = new ObservableStream(
+    client.watchQuery({ query, variables: { id: "a" } })
+  );
+  const streamB = new ObservableStream(
+    client.watchQuery({ query, variables: { id: "b" } })
+  );
+
+  await expect(streamA).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(streamB).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(streamB).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(defaultHandler).not.toHaveBeenCalled();
+
+  refetchEventManager.emit("test");
+
+  expect(defaultHandler).toHaveBeenCalledTimes(1);
+  expect(defaultHandler).toHaveBeenCalledWith({
+    client,
+    source: "test",
+    payload: undefined,
+    matchesRefetchOn: expect.any(Function),
+  });
+
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(streamA).not.toEmitAnything();
+  await expect(streamB).not.toEmitAnything();
+});
+
 test("can override the default handler with `setDefaultEventHandler`", async () => {
   const counts: Record<string, number> = {};
   const defaultHandler = jest.fn((({ client }) => {

--- a/src/core/__tests__/RefetchEventManager/core.test.ts
+++ b/src/core/__tests__/RefetchEventManager/core.test.ts
@@ -925,6 +925,107 @@ test("custom handler can conditionally skip refetch", async () => {
   await expect(stream).not.toEmitAnything();
 });
 
+test("can override the default handler with `setDefaultEventHandler`", async () => {
+  const counts: Record<string, number> = {};
+  const defaultHandler = jest.fn((({ client }) => {
+    return client.refetchQueries({
+      include: "active",
+      onQueryUpdated: (oq) => oq.variables.id === "a",
+    });
+  }) satisfies RefetchEventManager.EventHandler);
+
+  const refetchEventManager = new RefetchEventManager({
+    sources: {
+      test: () => of(),
+    },
+  });
+
+  refetchEventManager.setDefaultEventHandler(defaultHandler);
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query, variables: () => true },
+        result: ({ id }) => {
+          counts[id] ??= 0;
+
+          return { data: { count: ++counts[id] } };
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+    refetchEventManager,
+  });
+
+  const streamA = new ObservableStream(
+    client.watchQuery({ query, variables: { id: "a" } })
+  );
+  const streamB = new ObservableStream(
+    client.watchQuery({ query, variables: { id: "b" } })
+  );
+
+  await expect(streamA).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(streamB).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(streamB).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(defaultHandler).not.toHaveBeenCalled();
+
+  refetchEventManager.emit("test");
+
+  expect(defaultHandler).toHaveBeenCalledTimes(1);
+  expect(defaultHandler).toHaveBeenCalledWith({
+    client,
+    source: "test",
+    payload: undefined,
+    matchesRefetchOn: expect.any(Function),
+  });
+
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 1 },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+  await expect(streamA).toEmitTypedValue({
+    data: { count: 2 },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(streamA).not.toEmitAnything();
+  await expect(streamB).not.toEmitAnything();
+});
+
 test("setEventHandler replaces the handler after construction", async () => {
   const refetchEventManager = new RefetchEventManager({
     sources: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RefetchEventManager now supports a customizable default event handler. Configure it via the `defaultHandler` option when instantiating RefetchEventManager, or update it at runtime using the new `setDefaultEventHandler()` method. This provides flexible fallback behavior for refetch events when source-specific handlers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->