### PR TITLE
Ignore formatting in pre.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,4 @@ node_modules/
 .next/
 pnpm-lock.yaml
 scripts/codemods/ac3-to-ac4/src/__testfixtures__
+.changeset/pre.json


### PR DESCRIPTION
We don't write to this file manually but through GitHub workflows. This shouldn't cause a check to fail, so I'm excluding this from prettier formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration to exclude additional files from processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apollographql/apollo-client/pull/13233)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->