### PR TITLE
ci: pin Actions@SHA and disable cache on workflows with elevated OIDC permissions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24.x"
+          # deliberately not using a cache for action with elevated permissions, see https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
           package-manager-cache: false
 
       - run: npm ci

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v1
         id: github-actions-bot-app-token
         with:
           app-id: 819772
@@ -31,7 +31,7 @@ jobs:
       # Check out the repository, using the Github Actions Bot app's token so
       # that we can push later.
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.github-actions-bot-app-token.outputs.token }}
           # Fetch entire git history so  Changesets can generate changelogs
@@ -40,12 +40,12 @@ jobs:
 
       - name: Check for pre.json file existence
         id: check_files
-        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: ".changeset/pre.json"
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24.x"
           # deliberately not using a cache for action with elevated permissions, see https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
@@ -69,7 +69,7 @@ jobs:
         # If .changeset/pre.json exists and we are not currently cutting a
         # release after merging a Version Packages PR
         if: steps.check_files.outputs.files_exists == 'true' && !startsWith(github.event.head_commit.message, 'Version Packages')
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           version: npm run changeset-version
           publish: echo "This step should never publish"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
         id: github-actions-bot-app-token
         with:
           app-id: 819772
@@ -31,7 +31,7 @@ jobs:
       # Check out the repository, using the Github Actions Bot app's token so
       # that we can push later.
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ steps.github-actions-bot-app-token.outputs.token }}
           # Fetch entire git history so  Changesets can generate changelogs
@@ -40,17 +40,17 @@ jobs:
 
       - name: Check for pre.json file existence
         id: check_files
-        uses: andstor/file-existence-action@v3.1.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029
         with:
           files: ".changeset/pre.json"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24.x"
+          package-manager-cache: false
 
-      - name: Install dependencies with cache
-        uses: bahmutov/npm-install@v1
+      - run: npm ci
 
       - name: Enter prerelease mode (alpha by default)
         # If .changeset/pre.json does not exist and we did not recently exit
@@ -68,7 +68,7 @@ jobs:
         # If .changeset/pre.json exists and we are not currently cutting a
         # release after merging a Version Packages PR
         if: steps.check_files.outputs.files_exists == 'true' && !startsWith(github.event.head_commit.message, 'Version Packages')
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
         with:
           version: npm run changeset-version
           publish: echo "This step should never publish"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'apollographql/apollo-client'
     runs-on: ubuntu-latest
     # Permissions necessary for Changesets to push a new branch and open PRs
-    # (for automated Version Packages PRs), and request the JWT for provenance.
+    # (for automated Version Packages PRs), and request an id-token for provenance.
     # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages || steps.changesets-prerelease.outputs.publishedPackages }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           # Fetch entire git history so  Changesets can generate changelogs
           # with the correct commits
@@ -35,23 +35,23 @@ jobs:
 
       - name: Check for pre.json file existence
         id: check_files
-        uses: andstor/file-existence-action@v3.1.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029
         with:
           files: ".changeset/pre.json"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
-      - name: Install dependencies (with cache)
-        uses: bahmutov/npm-install@v1
+      - run: npm ci
 
       - name: "[main] Create release PR or publish to npm + GitHub"
         id: changesets
         if: contains(fromJSON('["main", "version-3.x"]'), github.ref_name) && steps.check_files.outputs.files_exists == 'false'
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
         with:
           version: npm run changeset-version
           publish: npm run changeset-publish
@@ -64,7 +64,7 @@ jobs:
         # Only run publish if we're still in pre mode and the last commit was
         # via an automatically created Version Packages PR
         if: github.ref_name != 'main' && github.ref_name != 'version-3.x' && steps.check_files.outputs.files_exists == 'true' && startsWith(github.event.head_commit.message, 'Version Packages')
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
         with:
           version: echo "This step should never version"
           publish: npm run changeset-publish
@@ -83,7 +83,7 @@ jobs:
     steps:
       - name: Send a Slack notification on publish
         id: slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           # Slack channel id, channel name, or user id to post message
           # See also: https://api.slack.com/methods/chat.postMessage#channels
@@ -138,16 +138,16 @@ jobs:
         package: ${{ fromJSON(needs.release.outputs.publishedPackages) }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
-      - name: Install dependencies with cache
-        uses: bahmutov/npm-install@v1
+      - run: npm ci
 
       - name: Tag release with next on npm
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+          # deliberately not using a cache for action with elevated permissions, see https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
           package-manager-cache: false
 
       - run: npm ci
@@ -145,6 +146,7 @@ jobs:
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+          # deliberately not using a cache for action with elevated permissions, see https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
           package-manager-cache: false
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Send a Slack notification on publish
         id: slack
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v1.27.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
         with:
           # Slack channel id, channel name, or user id to post message
           # See also: https://api.slack.com/methods/chat.postMessage#channels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'apollographql/apollo-client'
     runs-on: ubuntu-latest
     # Permissions necessary for Changesets to push a new branch and open PRs
-    # (for automated Version Packages PRs), and request the JWT for provenance.
+    # (for automated Version Packages PRs), and request an id-token for provenance.
     # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages || steps.changesets-prerelease.outputs.publishedPackages }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Fetch entire git history so  Changesets can generate changelogs
           # with the correct commits
@@ -35,12 +35,12 @@ jobs:
 
       - name: Check for pre.json file existence
         id: check_files
-        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: ".changeset/pre.json"
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
@@ -52,7 +52,7 @@ jobs:
       - name: "[main] Create release PR or publish to npm + GitHub"
         id: changesets
         if: contains(fromJSON('["main", "version-3.x"]'), github.ref_name) && steps.check_files.outputs.files_exists == 'false'
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           version: npm run changeset-version
           publish: npm run changeset-publish
@@ -65,7 +65,7 @@ jobs:
         # Only run publish if we're still in pre mode and the last commit was
         # via an automatically created Version Packages PR
         if: github.ref_name != 'main' && github.ref_name != 'version-3.x' && steps.check_files.outputs.files_exists == 'true' && startsWith(github.event.head_commit.message, 'Version Packages')
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           version: echo "This step should never version"
           publish: npm run changeset-publish
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Send a Slack notification on publish
         id: slack
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v1.27.0
         with:
           # Slack channel id, channel name, or user id to post message
           # See also: https://api.slack.com/methods/chat.postMessage#channels
@@ -139,10 +139,10 @@ jobs:
         package: ${{ fromJSON(needs.release.outputs.publishedPackages) }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["apollo-open-source"],
+  "extends": ["apollo-open-source", "helpers:pinGitHubActionDigests"],
   "ignorePaths": ["**/integration-tests/**"],
   "dependencyDashboard": true,
   "pathRules": [


### PR DESCRIPTION
In the light of https://tanstack.com/blog/npm-supply-chain-compromise-postmortem:

* Pin actions to commits
* Disable cache for CI runs with elevated permissions. Better to wait for a moment longer than have a compromised cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security and reproducibility by pinning GitHub Actions and third-party dependencies to specific commit hashes across all CI/CD workflows
  * Simplified and standardized dependency installation process in build pipelines using direct npm commands
  * Implemented OIDC-based provenance for release artifacts to improve integrity verification
  * Extended configuration presets for automated dependency update management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apollographql/apollo-client/pull/13235)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->