### PR TITLE
run `npm stage publish` instead of `npm publish` in changesets

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -8,12 +8,14 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: Ubuntu/Node v20
+    name: Ubuntu/Node v24
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24.x"
       - name: Install dependencies (with cache)
         uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
       - name: Run knip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
           # deliberately not using a cache for action with elevated permissions, see https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
           package-manager-cache: false
 
+      # `npm stage publish` (https://docs.npmjs.com/staged-publishing) requires
+      # npm >= 11.15.0. Node 24.x currently bundles at most 11.13.0, so upgrade.
+      - run: npm install -g npm@11.15.0
+
       - run: npm ci
 
       - name: "[main] Create release PR or publish to npm + GitHub"

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ test-lib
 dist
 npm
 !flow-typed/npm
+!scripts/changesets/wrap-staged/npm
 
 # Unpublished output from @apollo/client build, like bundlesize artifacts
 temp/

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "typedoc": "typedoc src/core/index.ts --json docs/public/docs.json",
     "docmodel": "npm run clean && node config/build.ts --step=prepareDist --step=addExports --step=typescript --step=inlineInheritDoc --step=deprecateInternals && node config/apiExtractor.ts --main-only --generate docModel",
     "changeset-check": "changeset status --verbose --since=origin/main",
-    "changeset-publish": "npm pkg set 'workspaces[0]'=dist && npm run build && changeset publish",
+    "changeset-publish": "npm pkg set 'workspaces[0]'=dist && npm run build && PATH=\"$PWD/scripts/changesets/wrap-staged:$PATH\" changeset publish",
     "changeset-version": "changeset version && npm i",
     "update-size-limits": "size-limit --json | jq '. | map(select(.sizeLimit) | { key: .name, value: .size}) | from_entries' | tee .new-size-limits.json; mv .new-size-limits.json .size-limits.json",
     "knip": "knip --tags=-knipignore",

--- a/scripts/changesets/wrap-staged/npm
+++ b/scripts/changesets/wrap-staged/npm
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Shim that rewrites `npm publish ...` to `npm stage publish ...`
+# (https://docs.npmjs.com/staged-publishing) and forwards every other
+# invocation to the real npm unchanged.
+#
+# Invoked via PATH lookup with its own directory prepended as the first
+# PATH entry, so we pop that entry to find the real npm.
+set -euo pipefail
+
+export PATH="${PATH#*:}"
+
+if [ "${1:-}" = "publish" ]; then
+  shift
+  exec npm stage publish "$@"
+fi
+
+exec npm "$@"


### PR DESCRIPTION
There's no real workflow around changesets and npm staged publishing yet - this is discussed in https://github.com/changesets/changesets/issues/2025.

So far, this will just run `npm stage publish` instead of `npm publish`, but already create tags and everything, before we approve it in the npm CLI or website. If we reject, a version number would be kinda "burned". But it feels like a good start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime from version 20 to version 24 in CI/CD workflows.
  * Upgraded npm to version 11.15.0 in the release pipeline.
  * Enhanced build and release process configurations with updated tooling settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apollographql/apollo-client/pull/13245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->