### PR TITLE
Replace npm-install action with npm ci

### DIFF
--- a/.github/workflows/api-extractor.yml
+++ b/.github/workflows/api-extractor.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           node-version: ">=23.6.0"
 
-      - name: Install dependencies (with cache)
-        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+      - run: npm ci
 
         # Builds the library and runs the api extractor
       - name: Run Api-Extractor

--- a/.github/workflows/arethetypeswrong.yml
+++ b/.github/workflows/arethetypeswrong.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ">=23.6.0"
-      - name: Install dependencies (with cache)
-        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+
+      - run: npm ci
 
       - name: Run build
         run: npm run build

--- a/.github/workflows/cleanup-checks.yml
+++ b/.github/workflows/cleanup-checks.yml
@@ -49,8 +49,7 @@ jobs:
         with:
           node-version: ">=23.6.0"
 
-      - name: Install dependencies (with cache)
-        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+      - run: npm ci
 
       - name: Run Api-Extractor
         run: npm run extract-api

--- a/.github/workflows/compare-build-output.yml
+++ b/.github/workflows/compare-build-output.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ">=23.6.0"
-      - name: Install dependencies (with cache)
-        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+
+      - run: npm ci
 
       - name: Run comparison script
         id: attw

--- a/.github/workflows/docmodel.yml
+++ b/.github/workflows/docmodel.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           node-version: ">=23.6.0"
 
-      - name: Install dependencies (with cache)
-        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+      - run: npm ci
 
       - name: Generate documentation model
         run: npm run docmodel

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24.x"
-      - name: Install dependencies (with cache)
-        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+      - run: npm ci
       - name: Run knip
         run: npm run knip

--- a/.github/workflows/publish-pr-releases.yml
+++ b/.github/workflows/publish-pr-releases.yml
@@ -42,8 +42,7 @@ jobs:
         with:
           file-filter: "scripts/codemods/ac3-to-ac4/**"
 
-      - name: Install dependencies with cache
-        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+      - run: npm ci
 
       - name: Build AC
         run: npm run build

--- a/.github/workflows/scheduled-test-canary.yml
+++ b/.github/workflows/scheduled-test-canary.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ">=23.6.0"
-      - uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+      - run: npm ci
       - run: |
           npm install react@${MATRIX_TAG} react-dom@${MATRIX_TAG}
         env:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -20,8 +20,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ">=23.6.0"
-      - name: Install dependencies (with cache)
-        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
+      - run: npm ci
       - name: Run size-limit
         uses: andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1 # v1
         with:


### PR DESCRIPTION
This PR switches away from the `bahmutov/npm-install` action to plain `npm ci`. If we want to use a cache, `actions/setup-node` includes it and we'd rather leverage that instead. This should reduce one more potential attack vector in case this action caches differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to streamline dependency installation across all build pipelines for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apollographql/apollo-client/pull/13247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->