### PR TITLE
Add overridable cache type

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -22,7 +22,6 @@ import type { GetDataState } from '@apollo/client';
 import { getInMemoryCacheMemoryInternals } from '@apollo/client/utilities/internal';
 import type { Incremental } from '@apollo/client/incremental';
 import type { InlineFragmentNode } from 'graphql';
-import type { InMemoryCache as InMemoryCache_2 } from '@apollo/client';
 import type { IsAny } from '@apollo/client/utilities/internal';
 import { isReference } from '@apollo/client/utilities';
 import type { NoInfer as NoInfer_2 } from '@apollo/client/utilities/internal';
@@ -210,7 +209,7 @@ namespace Cache_2 {
     // (undocumented)
     type Implementation = TypeOverrides extends {
         cache: infer TCache;
-    } ? TCache extends ApolloCache ? TCache : "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type." : InMemoryCache_2;
+    } ? TCache extends ApolloCache ? TCache : "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type." : ApolloCache;
     // (undocumented)
     interface ModifyOptions<Entity extends Record<string, any> = Record<string, any>> {
         // (undocumented)

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -22,6 +22,7 @@ import type { GetDataState } from '@apollo/client';
 import { getInMemoryCacheMemoryInternals } from '@apollo/client/utilities/internal';
 import type { Incremental } from '@apollo/client/incremental';
 import type { InlineFragmentNode } from 'graphql';
+import type { InMemoryCache as InMemoryCache_2 } from '@apollo/client';
 import type { IsAny } from '@apollo/client/utilities/internal';
 import { isReference } from '@apollo/client/utilities';
 import type { NoInfer as NoInfer_2 } from '@apollo/client/utilities/internal';
@@ -209,7 +210,7 @@ namespace Cache_2 {
     // (undocumented)
     type Implementation = TypeOverrides extends {
         cache: infer TCache;
-    } ? TCache extends ApolloCache ? TCache : ApolloCache : ApolloCache;
+    } ? TCache extends ApolloCache ? TCache : "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type." : InMemoryCache_2;
     // (undocumented)
     interface ModifyOptions<Entity extends Record<string, any> = Record<string, any>> {
         // (undocumented)

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -34,6 +34,7 @@ import type { StoreObject } from '@apollo/client/utilities';
 import type { StoreValue } from '@apollo/client/utilities';
 import { Trie } from '@wry/trie';
 import type { TypedDocumentNode } from '@apollo/client';
+import type { TypeOverrides } from '@apollo/client';
 import type { Unmasked } from '@apollo/client/masking';
 
 // Warning: (ae-forgotten-export) The symbol "StoreObjectValueMaybeReference" needs to be exported by the entry point index.d.ts
@@ -205,6 +206,10 @@ namespace Cache_2 {
         // (undocumented)
         id?: string;
     }
+    // (undocumented)
+    type Implementation = TypeOverrides extends {
+        cache: infer TCache;
+    } ? TCache extends ApolloCache ? TCache : ApolloCache : ApolloCache;
     // (undocumented)
     interface ModifyOptions<Entity extends Record<string, any> = Record<string, any>> {
         // (undocumented)

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -166,7 +166,7 @@ type BroadcastOptions = Pick<Cache_2.BatchOptions<InMemoryCache>, "optimistic" |
 // @public (undocumented)
 namespace Cache_2 {
     // (undocumented)
-    interface BatchOptions<TCache extends ApolloCache, TUpdateResult = void> {
+    interface BatchOptions<TCache extends Cache_2.Implementation, TUpdateResult = void> {
         onWatchUpdated?: (this: TCache, watch: Cache_2.WatchOptions, diff: Cache_2.DiffResult<any>, lastDiff?: Cache_2.DiffResult<any> | undefined) => any;
         optimistic?: string | boolean;
         removeOptimistic?: string;

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -216,7 +216,7 @@ export namespace ApolloClient {
     }
     // (undocumented)
     export namespace DocumentationTypes {
-        export function mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache>(options: ApolloClient.MutateOptions<TData, TVariables, TCache>): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
+        export function mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = Cache_2.Implementation>(options: ApolloClient.MutateOptions<TData, TVariables, TCache>): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
         export function query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables>): Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
     }
     // (undocumented)
@@ -239,11 +239,11 @@ export namespace ApolloClient {
         export namespace Signatures {
             // (undocumented)
             export interface Classic {
-                <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: ApolloClient.MutateOptions<TData, TVariables, ApolloCache> & {
+                <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: ApolloClient.MutateOptions<TData, TVariables, Cache_2.Implementation> & {
                     errorPolicy?: TErrorPolicy;
                 }): Promise<ApolloClient.MutateResult<MaybeMasked<TData>, TErrorPolicy>>;
                 // @deprecated (undocumented)
-                <TData, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: ApolloClient.MutateOptions<TData, TVariables, TCache> & (TErrorPolicy extends undefined ? {} : {
+                <TData, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: ApolloClient.MutateOptions<TData, TVariables, TCache> & (TErrorPolicy extends undefined ? {} : {
                     errorPolicy: TErrorPolicy;
                 })): Promise<ApolloClient.MutateResult<MaybeMasked<TData>, TErrorPolicy>>;
             }
@@ -251,16 +251,16 @@ export namespace ApolloClient {
             export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
             // (undocumented)
             export interface Modern {
-                <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends ApolloClient.MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & VariablesOption<TVariables & {
+                <TData, TVariables extends OperationVariables, TOptions extends ApolloClient.MutateOptions<NoInfer<TData>, NoInfer<TVariables>, Cache_2.Implementation> & VariablesOption<TVariables & {
                     [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
                 }>>(options: TOptions & {
                     mutation: TypedDocumentNode<TData, TVariables>;
-                }): Promise<ApolloClient.mutate.ResultForOptions<TData, TVariables, TCache, TOptions>>;
+                }): Promise<ApolloClient.mutate.ResultForOptions<TData, TVariables, Cache_2.Implementation, TOptions>>;
             }
         }
     }
     // (undocumented)
-    export type MutateOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = {
+    export type MutateOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = Cache_2.Implementation> = {
         optimisticResponse?: Unmasked<NoInfer<TData>> | ((vars: TVariables, { IGNORE }: {
             IGNORE: IgnoreModifier;
         }) => Unmasked<NoInfer<TData>> | IgnoreModifier);
@@ -305,7 +305,7 @@ export namespace ApolloClient {
     // (undocumented)
     export interface Options extends InternalTypes_2.DefaultOptionsParentObject {
         assumeImmutableResults?: boolean;
-        cache: ApolloCache;
+        cache: Cache_2.Implementation;
         // (undocumented)
         clientAwareness?: ClientAwarenessLink.ClientAwarenessOptions;
         dataMasking?: boolean;
@@ -390,7 +390,7 @@ export namespace ApolloClient {
     export type ReadFragmentOptions<TData, TVariables extends OperationVariables> = Base.ReadFragmentOptions<TData, TVariables> & VariablesOption<TVariables> & Cache_2.CacheIdentifierOption<TData>;
     // (undocumented)
     export type ReadQueryOptions<TData, TVariables extends OperationVariables> = Base.ReadQueryOptions<TData, TVariables> & VariablesOption<TVariables>;
-    export interface RefetchQueriesOptions<TCache extends ApolloCache, TResult> {
+    export interface RefetchQueriesOptions<TCache extends Cache_2.Implementation, TResult> {
         include?: RefetchQueriesInclude;
         onQueryUpdated?: OnQueryUpdated<TResult> | null;
         optimistic?: boolean;
@@ -453,7 +453,7 @@ export class ApolloClient {
     // (undocumented)
     __requestRaw(request: ApolloLink.Request): Observable_2<ApolloLink.Result<unknown>>;
     // (undocumented)
-    cache: ApolloCache;
+    cache: Cache_2.Implementation;
     clearStore(): Promise<any[]>;
     // (undocumented)
     get defaultContext(): Partial<DefaultContext>;
@@ -491,7 +491,7 @@ export class ApolloClient {
     // @deprecated
     reFetchObservableQueries: (includeStandby?: boolean) => Promise<ApolloClient.QueryResult<any>[]>;
     refetchObservableQueries(includeStandby?: boolean): Promise<ApolloClient.QueryResult<any>[]>;
-    refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<ApolloClient.QueryResult<any>>>(options: ApolloClient.RefetchQueriesOptions<TCache, TResult>): ApolloClient.RefetchQueriesResult<TResult>;
+    refetchQueries<TCache extends Cache_2.Implementation = Cache_2.Implementation, TResult = Promise<ApolloClient.QueryResult<any>>>(options: ApolloClient.RefetchQueriesOptions<TCache, TResult>): ApolloClient.RefetchQueriesResult<TResult>;
     resetStore(): Promise<ApolloClient.QueryResult<any>[] | null>;
     restore(serializedState: unknown): ApolloCache;
     setLink(newLink: ApolloLink): void;
@@ -1367,7 +1367,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:633:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:635:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -450,11 +450,6 @@ export class ApolloClient {
     // (undocumented)
     __actionHookForDevTools(cb: () => any): void;
     constructor(options: ApolloClient.Options);
-    constructor(options: TypeOverrides extends {
-        cache: any;
-    } ? ApolloClient.Options : {
-        cache: "Using a cache other than `InMemoryCache` requires a cache type declared in TypeOverrides. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.";
-    });
     // (undocumented)
     __requestRaw(request: ApolloLink.Request): Observable_2<ApolloLink.Result<unknown>>;
     // (undocumented)
@@ -1372,7 +1367,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:636:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:635:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -232,7 +232,7 @@ export namespace ApolloClient {
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Mutate.Calculated {
         }
         // (undocumented)
-        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | MutateOptions<any, TVariables, TCache>> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation, TOptions extends Record<string, unknown> | MutateOptions<any, TVariables, TCache>> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
         }
         // (undocumented)
@@ -260,7 +260,7 @@ export namespace ApolloClient {
         }
     }
     // (undocumented)
-    export type MutateOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = Cache_2.Implementation> = {
+    export type MutateOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation> = {
         optimisticResponse?: Unmasked<NoInfer<TData>> | ((vars: TVariables, { IGNORE }: {
             IGNORE: IgnoreModifier;
         }) => Unmasked<NoInfer<TData>> | IgnoreModifier);

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -216,7 +216,7 @@ export namespace ApolloClient {
     }
     // (undocumented)
     export namespace DocumentationTypes {
-        export function mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = Cache_2.Implementation>(options: ApolloClient.MutateOptions<TData, TVariables, TCache>): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
+        export function mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation>(options: ApolloClient.MutateOptions<TData, TVariables, TCache>): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
         export function query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables>): Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
     }
     // (undocumented)
@@ -450,6 +450,11 @@ export class ApolloClient {
     // (undocumented)
     __actionHookForDevTools(cb: () => any): void;
     constructor(options: ApolloClient.Options);
+    constructor(options: TypeOverrides extends {
+        cache: any;
+    } ? ApolloClient.Options : {
+        cache: "Using a cache other than `InMemoryCache` requires a cache type declared in TypeOverrides. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.";
+    });
     // (undocumented)
     __requestRaw(request: ApolloLink.Request): Observable_2<ApolloLink.Result<unknown>>;
     // (undocumented)
@@ -761,7 +766,7 @@ interface MutationStoreValue {
 }
 
 // @public (undocumented)
-export type MutationUpdaterFunction<TData, TVariables extends OperationVariables, TCache extends ApolloCache> = (cache: TCache, result: FormattedExecutionResult<Unmasked<TData>>, options: {
+export type MutationUpdaterFunction<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation> = (cache: TCache, result: FormattedExecutionResult<Unmasked<TData>>, options: {
     context?: DefaultContext;
     variables?: TVariables;
 }) => void;
@@ -1059,7 +1064,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: ApolloClient.MutateOptions<TData, TVariables, TCache> & {
+    mutate<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: ApolloClient.MutateOptions<TData, TVariables, TCache> & {
         errorPolicy: ErrorPolicy;
         fetchPolicy: MutationFetchPolicy;
     }): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
@@ -1074,7 +1079,7 @@ class QueryManager {
     // (undocumented)
     refetchObservableQueries(includeStandby?: boolean): Promise<ApolloClient.QueryResult<any>[]>;
     // (undocumented)
-    refetchQueries<TResult>({ updateCache, include, optimistic, removeOptimistic, onQueryUpdated, }: InternalRefetchQueriesOptions<ApolloCache, TResult>): InternalRefetchQueriesMap<TResult>;
+    refetchQueries<TResult>({ updateCache, include, optimistic, removeOptimistic, onQueryUpdated, }: InternalRefetchQueriesOptions<Cache_2.Implementation, TResult>): InternalRefetchQueriesMap<TResult>;
     // (undocumented)
     readonly ssrMode: boolean;
     // (undocumented)
@@ -1367,7 +1372,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:635:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:636:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -732,7 +732,7 @@ export type MutateResult<TData = unknown> = ApolloClient.MutateResult<TData>;
 export type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cache">;
 
 // @public @deprecated (undocumented)
-export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = ApolloClient.MutateOptions<TData, TVariables, TCache>;
+export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation> = ApolloClient.MutateOptions<TData, TVariables, TCache>;
 
 // @public (undocumented)
 export type MutationQueryReducer<T> = (previousResult: Record<string, any>, options: {
@@ -1224,7 +1224,7 @@ export type RefetchQueriesInclude = RefetchQueryDescriptor[] | RefetchQueriesInc
 type RefetchQueriesIncludeShorthand = "all" | "active";
 
 // @public @deprecated (undocumented)
-export type RefetchQueriesOptions<TCache extends ApolloCache, TResult> = ApolloClient.RefetchQueriesOptions<TCache, TResult>;
+export type RefetchQueriesOptions<TCache extends Cache_2.Implementation, TResult> = ApolloClient.RefetchQueriesOptions<TCache, TResult>;
 
 // @public (undocumented)
 export type RefetchQueriesPromiseResults<TResult> = IsAny<TResult> extends true ? any[] : TResult extends boolean ? ApolloClient.QueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -4,9 +4,10 @@
 
 ```ts
 
-import type { ApolloCache } from '@apollo/client';
-import type { ApolloCache as ApolloCache_2 } from '@apollo/client/cache';
+import type { ApolloCache } from '@apollo/client/cache';
+import type { ApolloCache as ApolloCache_2 } from '@apollo/client';
 import type { ApolloClient } from '@apollo/client';
+import type { Cache as Cache_2 } from '@apollo/client/cache';
 import type { DataState } from '@apollo/client';
 import type { DataValue } from '@apollo/client';
 import type { DefaultContext } from '@apollo/client';
@@ -130,16 +131,16 @@ type MakeRequiredVariablesOptional<TVariables extends OperationVariables, TConfi
 } & Omit<TVariables, keyof TConfiguredVariables>>;
 
 // @public @deprecated (undocumented)
-export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
+export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
-export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.Options<TData, TVariables, TCache>;
+export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.Options<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
 export type MutationResult<TData = unknown> = useMutation.Result<TData>;
 
 // @public @deprecated (undocumented)
-export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.ResultTuple<TData, TVariables, TCache>;
+export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.ResultTuple<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
 export type OnDataOptions<TData = unknown> = useSubscription.OnDataOptions<TData>;
@@ -607,7 +608,7 @@ export namespace useFragment {
     export namespace DocumentationTypes {
         export function useFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ fragment, from, fragmentName, variables, optimistic, client, }: useFragment.Options<TData, TVariables>): useFragment.Result<TData>;
     }
-    export type FromOptionValue<TData> = ApolloCache_2.FromOptionValue<TData>;
+    export type FromOptionValue<TData> = ApolloCache.FromOptionValue<TData>;
     // (undocumented)
     export interface Options<TData, TVariables extends OperationVariables> {
         client?: ApolloClient;
@@ -913,7 +914,7 @@ export namespace useMutation {
         }
     }
     // (undocumented)
-    export type MutationFunction<TData, TVariables extends OperationVariables, TCache extends ApolloCache = ApolloCache, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...[options]: {} extends TVariables ? [
+    export type MutationFunction<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...[options]: {} extends TVariables ? [
     options?: MutationFunctionOptions<TData, TVariables, TCache> & {
         variables?: TVariables;
     }
@@ -923,11 +924,11 @@ export namespace useMutation {
     }
     ]) => Promise<ApolloClient.MutateResult<MaybeMasked<TData>, TErrorPolicy>>;
     // (undocumented)
-    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = Options<TData, TVariables, TCache> & {
+    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation> = Options<TData, TVariables, TCache> & {
         context?: DefaultContext | ((hookContext: DefaultContext | undefined) => DefaultContext);
     };
     // (undocumented)
-    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
+    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
         awaitRefetchQueries?: boolean;
         client?: ApolloClient;
         context?: DefaultContext;
@@ -952,7 +953,7 @@ export namespace useMutation {
     // Warning: (ae-forgotten-export) The symbol "ExtractConfiguredVariables" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, never> | Options<TData, TVariables, TCache>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, ExtractConfiguredVariables<TOptions, TVariables>>, TCache, [
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation, TOptions extends Record<string, never> | Options<TData, TVariables, TCache>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, ExtractConfiguredVariables<TOptions, TVariables>>, TCache, [
     TErrorPolicy
     ] extends [undefined] ? DefaultOptions extends {
         errorPolicy: infer D;
@@ -976,7 +977,7 @@ export namespace useMutation {
         };
     };
     // (undocumented)
-    export type ResultTuple<TData, TVariables extends OperationVariables, TCache extends ApolloCache = ApolloCache, TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
+    export type ResultTuple<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
     mutate: MutationFunction<TData, TVariables, TCache, TErrorPolicy>,
     result: Result<TData, TErrorPolicy>
     ];
@@ -988,13 +989,13 @@ export namespace useMutation {
         // (undocumented)
         export interface Classic {
             // (undocumented)
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, ApolloCache, {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, Cache_2.Implementation, {
                 [K in keyof TConfiguredVariables]: K extends keyof TVariables ? TConfiguredVariables[K] : never;
             }> & {
                 errorPolicy?: TErrorPolicy;
-            }): useMutation.ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>, ApolloCache, TErrorPolicy>;
+            }): useMutation.ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>, Cache_2.Implementation, TErrorPolicy>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TCache, {
+            <TData, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TCache, {
                 [K in keyof TConfiguredVariables]: K extends keyof TVariables ? TConfiguredVariables[K] : never;
             }> & (TErrorPolicy extends undefined ? {} : {
                 errorPolicy: TErrorPolicy;
@@ -1005,15 +1006,15 @@ export namespace useMutation {
         // (undocumented)
         export interface Modern {
             // (undocumented)
-            <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends never>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>): useMutation.ResultForOptions<TData, TVariables, TCache, Record<string, never>>;
+            <TData, TVariables extends OperationVariables, TOptions extends never>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>): useMutation.ResultForOptions<TData, TVariables, Cache_2.Implementation, Record<string, never>>;
             // (undocumented)
-            <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TCache> & {
+            <TData, TVariables extends OperationVariables, TOptions extends useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, Cache_2.Implementation> & {
                 variables?: {
                     [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
                 };
             }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: TOptions & {
                 errorPolicy?: TErrorPolicy;
-            }): useMutation.ResultForOptions<TData, TVariables, TCache, TOptions, TErrorPolicy>;
+            }): useMutation.ResultForOptions<TData, TVariables, Cache_2.Implementation, TOptions, TErrorPolicy>;
         }
     }
 }
@@ -1384,7 +1385,7 @@ export namespace useSuspenseFragment {
     export namespace DocumentationTypes {
         export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: useSuspenseFragment.Options<TData, TVariables>): useSuspenseFragment.Result<TData>;
     }
-    export type FromOptionValue<TData> = ApolloCache_2.FromOptionValue<TData>;
+    export type FromOptionValue<TData> = ApolloCache.FromOptionValue<TData>;
     // (undocumented)
     export type Options<TData, TVariables extends OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<NoInfer_2<TVariables>>;
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -257,7 +257,7 @@ export namespace ApolloClient {
     }
     // (undocumented)
     export namespace DocumentationTypes {
-        export function mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache>(options: ApolloClient.MutateOptions<TData, TVariables, TCache>): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
+        export function mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = Cache_2.Implementation>(options: ApolloClient.MutateOptions<TData, TVariables, TCache>): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
         export function query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables>): Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
     }
     // (undocumented)
@@ -283,11 +283,11 @@ export namespace ApolloClient {
         export namespace Signatures {
             // (undocumented)
             export interface Classic {
-                <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: ApolloClient.MutateOptions<TData, TVariables, ApolloCache> & {
+                <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: ApolloClient.MutateOptions<TData, TVariables, Cache_2.Implementation> & {
                     errorPolicy?: TErrorPolicy;
                 }): Promise<ApolloClient.MutateResult<MaybeMasked<TData>, TErrorPolicy>>;
                 // @deprecated (undocumented)
-                <TData, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: ApolloClient.MutateOptions<TData, TVariables, TCache> & (TErrorPolicy extends undefined ? {} : {
+                <TData, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: ApolloClient.MutateOptions<TData, TVariables, TCache> & (TErrorPolicy extends undefined ? {} : {
                     errorPolicy: TErrorPolicy;
                 })): Promise<ApolloClient.MutateResult<MaybeMasked<TData>, TErrorPolicy>>;
             }
@@ -297,18 +297,18 @@ export namespace ApolloClient {
             export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
             // (undocumented)
             export interface Modern {
-                <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends ApolloClient.MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & VariablesOption<TVariables & {
+                <TData, TVariables extends OperationVariables, TOptions extends ApolloClient.MutateOptions<NoInfer<TData>, NoInfer<TVariables>, Cache_2.Implementation> & VariablesOption<TVariables & {
                     [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
                 }>>(options: TOptions & {
                     mutation: TypedDocumentNode<TData, TVariables>;
-                }): Promise<ApolloClient.mutate.ResultForOptions<TData, TVariables, TCache, TOptions>>;
+                }): Promise<ApolloClient.mutate.ResultForOptions<TData, TVariables, Cache_2.Implementation, TOptions>>;
             }
         }
     }
     // Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    export type MutateOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = {
+    export type MutateOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = Cache_2.Implementation> = {
         optimisticResponse?: Unmasked<NoInfer<TData>> | ((vars: TVariables, { IGNORE }: {
             IGNORE: IgnoreModifier;
         }) => Unmasked<NoInfer<TData>> | IgnoreModifier);
@@ -355,7 +355,7 @@ export namespace ApolloClient {
     // (undocumented)
     export interface Options extends InternalTypes.DefaultOptionsParentObject {
         assumeImmutableResults?: boolean;
-        cache: ApolloCache;
+        cache: Cache_2.Implementation;
         // Warning: (ae-forgotten-export) The symbol "ClientAwarenessLink" needs to be exported by the entry point index.d.ts
         //
         // (undocumented)
@@ -445,7 +445,7 @@ export namespace ApolloClient {
     export type ReadFragmentOptions<TData, TVariables extends OperationVariables> = Base.ReadFragmentOptions<TData, TVariables> & VariablesOption<TVariables> & Cache_2.CacheIdentifierOption<TData>;
     // (undocumented)
     export type ReadQueryOptions<TData, TVariables extends OperationVariables> = Base.ReadQueryOptions<TData, TVariables> & VariablesOption<TVariables>;
-    export interface RefetchQueriesOptions<TCache extends ApolloCache, TResult> {
+    export interface RefetchQueriesOptions<TCache extends Cache_2.Implementation, TResult> {
         include?: RefetchQueriesInclude;
         onQueryUpdated?: OnQueryUpdated<TResult> | null;
         optimistic?: boolean;
@@ -508,7 +508,7 @@ export class ApolloClient {
     // (undocumented)
     __requestRaw(request: ApolloLink.Request): Observable<ApolloLink.Result<unknown>>;
     // (undocumented)
-    cache: ApolloCache;
+    cache: Cache_2.Implementation;
     clearStore(): Promise<any[]>;
     // (undocumented)
     get defaultContext(): Partial<DefaultContext>;
@@ -547,7 +547,7 @@ export class ApolloClient {
     // @deprecated
     reFetchObservableQueries: (includeStandby?: boolean) => Promise<ApolloClient.QueryResult<any>[]>;
     refetchObservableQueries(includeStandby?: boolean): Promise<ApolloClient.QueryResult<any>[]>;
-    refetchQueries<TCache extends ApolloCache = ApolloCache, TResult = Promise<ApolloClient.QueryResult<any>>>(options: ApolloClient.RefetchQueriesOptions<TCache, TResult>): ApolloClient.RefetchQueriesResult<TResult>;
+    refetchQueries<TCache extends Cache_2.Implementation = Cache_2.Implementation, TResult = Promise<ApolloClient.QueryResult<any>>>(options: ApolloClient.RefetchQueriesOptions<TCache, TResult>): ApolloClient.RefetchQueriesResult<TResult>;
     resetStore(): Promise<ApolloClient.QueryResult<any>[] | null>;
     restore(serializedState: unknown): ApolloCache;
     setLink(newLink: ApolloLink): void;
@@ -786,6 +786,10 @@ namespace Cache_2 {
         // (undocumented)
         id?: string;
     }
+    // (undocumented)
+    type Implementation = TypeOverrides extends {
+        cache: infer TCache;
+    } ? TCache extends ApolloCache ? TCache : ApolloCache : ApolloCache;
     // (undocumented)
     interface ModifyOptions<Entity extends Record<string, any> = Record<string, any>> {
         // (undocumented)
@@ -3070,7 +3074,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:201:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:633:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:635:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -746,7 +746,7 @@ export const build: "source" | "esm" | "cjs";
 // @public (undocumented)
 namespace Cache_2 {
     // (undocumented)
-    interface BatchOptions<TCache extends ApolloCache, TUpdateResult = void> {
+    interface BatchOptions<TCache extends Cache_2.Implementation, TUpdateResult = void> {
         onWatchUpdated?: (this: TCache, watch: Cache_2.WatchOptions, diff: Cache_2.DiffResult<any>, lastDiff?: Cache_2.DiffResult<any> | undefined) => any;
         optimistic?: string | boolean;
         removeOptimistic?: string;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -257,7 +257,7 @@ export namespace ApolloClient {
     }
     // (undocumented)
     export namespace DocumentationTypes {
-        export function mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = Cache_2.Implementation>(options: ApolloClient.MutateOptions<TData, TVariables, TCache>): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
+        export function mutate<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation>(options: ApolloClient.MutateOptions<TData, TVariables, TCache>): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
         export function query<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloClient.QueryOptions<TData, TVariables>): Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
     }
     // (undocumented)
@@ -505,6 +505,11 @@ export class ApolloClient {
     // (undocumented)
     __actionHookForDevTools(cb: () => any): void;
     constructor(options: ApolloClient.Options);
+    constructor(options: TypeOverrides extends {
+        cache: any;
+    } ? ApolloClient.Options : {
+        cache: "Using a cache other than `InMemoryCache` requires a cache type declared in TypeOverrides. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.";
+    });
     // (undocumented)
     __requestRaw(request: ApolloLink.Request): Observable<ApolloLink.Result<unknown>>;
     // (undocumented)
@@ -789,7 +794,7 @@ namespace Cache_2 {
     // (undocumented)
     type Implementation = TypeOverrides extends {
         cache: infer TCache;
-    } ? TCache extends ApolloCache ? TCache : ApolloCache : ApolloCache;
+    } ? TCache extends ApolloCache ? TCache : "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type." : InMemoryCache;
     // (undocumented)
     interface ModifyOptions<Entity extends Record<string, any> = Record<string, any>> {
         // (undocumented)
@@ -1995,7 +2000,7 @@ interface MutationStoreValue {
 }
 
 // @public (undocumented)
-export type MutationUpdaterFunction<TData, TVariables extends OperationVariables, TCache extends ApolloCache> = (cache: TCache, result: FormattedExecutionResult<Unmasked<TData>>, options: {
+export type MutationUpdaterFunction<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation> = (cache: TCache, result: FormattedExecutionResult<Unmasked<TData>>, options: {
     context?: DefaultContext;
     variables?: TVariables;
 }) => void;
@@ -2477,7 +2482,7 @@ class QueryManager {
     // (undocumented)
     maskOperation<TData = unknown>(options: MaskOperationOptions<TData>): MaybeMasked<TData>;
     // (undocumented)
-    mutate<TData, TVariables extends OperationVariables, TCache extends ApolloCache>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: ApolloClient.MutateOptions<TData, TVariables, TCache> & {
+    mutate<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation>({ mutation, variables, optimisticResponse, updateQueries, refetchQueries, awaitRefetchQueries, update: updateWithProxyFn, onQueryUpdated, fetchPolicy, errorPolicy, keepRootFields, context, }: ApolloClient.MutateOptions<TData, TVariables, TCache> & {
         errorPolicy: ErrorPolicy;
         fetchPolicy: MutationFetchPolicy;
     }): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
@@ -2492,7 +2497,7 @@ class QueryManager {
     // (undocumented)
     refetchObservableQueries(includeStandby?: boolean): Promise<ApolloClient.QueryResult<any>[]>;
     // (undocumented)
-    refetchQueries<TResult>({ updateCache, include, optimistic, removeOptimistic, onQueryUpdated, }: InternalRefetchQueriesOptions<ApolloCache, TResult>): InternalRefetchQueriesMap<TResult>;
+    refetchQueries<TResult>({ updateCache, include, optimistic, removeOptimistic, onQueryUpdated, }: InternalRefetchQueriesOptions<Cache_2.Implementation, TResult>): InternalRefetchQueriesMap<TResult>;
     // (undocumented)
     readonly ssrMode: boolean;
     // (undocumented)
@@ -3073,8 +3078,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:201:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:635:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:636:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -276,7 +276,7 @@ export namespace ApolloClient {
         // Warning: (ae-forgotten-export) The symbol "OptionWithFallback" needs to be exported by the entry point index.d.ts
         //
         // (undocumented)
-        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | MutateOptions<any, TVariables, TCache>> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation, TOptions extends Record<string, unknown> | MutateOptions<any, TVariables, TCache>> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
         }
         // (undocumented)
@@ -308,7 +308,7 @@ export namespace ApolloClient {
     // Warning: (ae-forgotten-export) The symbol "VariablesOption" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    export type MutateOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = Cache_2.Implementation> = {
+    export type MutateOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation> = {
         optimisticResponse?: Unmasked<NoInfer<TData>> | ((vars: TVariables, { IGNORE }: {
             IGNORE: IgnoreModifier;
         }) => Unmasked<NoInfer<TData>> | IgnoreModifier);

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1966,7 +1966,7 @@ export type MutateResult<TData = unknown> = ApolloClient.MutateResult<TData>;
 export type MutationFetchPolicy = Extract<FetchPolicy, "network-only" | "no-cache">;
 
 // @public @deprecated (undocumented)
-export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = ApolloClient.MutateOptions<TData, TVariables, TCache>;
+export type MutationOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation> = ApolloClient.MutateOptions<TData, TVariables, TCache>;
 
 // @public (undocumented)
 export type MutationQueryReducer<T> = (previousResult: Record<string, any>, options: {
@@ -2693,7 +2693,7 @@ export type RefetchQueriesInclude = RefetchQueryDescriptor[] | RefetchQueriesInc
 type RefetchQueriesIncludeShorthand = "all" | "active";
 
 // @public @deprecated (undocumented)
-export type RefetchQueriesOptions<TCache extends ApolloCache, TResult> = ApolloClient.RefetchQueriesOptions<TCache, TResult>;
+export type RefetchQueriesOptions<TCache extends Cache_2.Implementation, TResult> = ApolloClient.RefetchQueriesOptions<TCache, TResult>;
 
 // @public (undocumented)
 export type RefetchQueriesPromiseResults<TResult> = IsAny<TResult> extends true ? any[] : TResult extends boolean ? ApolloClient.QueryResult<any>[] : TResult extends PromiseLike<infer U> ? U[] : TResult[];

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -505,11 +505,6 @@ export class ApolloClient {
     // (undocumented)
     __actionHookForDevTools(cb: () => any): void;
     constructor(options: ApolloClient.Options);
-    constructor(options: TypeOverrides extends {
-        cache: any;
-    } ? ApolloClient.Options : {
-        cache: "Using a cache other than `InMemoryCache` requires a cache type declared in TypeOverrides. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.";
-    });
     // (undocumented)
     __requestRaw(request: ApolloLink.Request): Observable<ApolloLink.Result<unknown>>;
     // (undocumented)
@@ -794,7 +789,7 @@ namespace Cache_2 {
     // (undocumented)
     type Implementation = TypeOverrides extends {
         cache: infer TCache;
-    } ? TCache extends ApolloCache ? TCache : "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type." : InMemoryCache;
+    } ? TCache extends ApolloCache ? TCache : "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type." : ApolloCache;
     // (undocumented)
     interface ModifyOptions<Entity extends Record<string, any> = Record<string, any>> {
         // (undocumented)
@@ -3078,8 +3073,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:636:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:201:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:635:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/fuzzy-hairs-tie.md
+++ b/.changeset/fuzzy-hairs-tie.md
@@ -1,0 +1,35 @@
+---
+"@apollo/client": minor
+---
+
+Add the ability to define the cache type for the client. `client.cache` currently returns `ApolloCache` as the cache type regardless of what cache you've provided to `ApolloClient`.
+
+Declare the cache type using the `cache` property in the `TypeOverrides` interface to set the cache implementation used for the client.
+
+```ts
+// apollo.d.ts
+import type { InMemoryCache } from "@apollo/client";
+
+declare module "@apollo/client" {
+  export interface TypeOverrides {
+    cache: InMemoryCache;
+  }
+}
+```
+
+Now anywhere `cache` is accessible, the type is the declared cache type:
+
+```ts
+client.cache;
+//     ^?InMemoryCache
+
+client.mutate({
+  update: (cache) => {
+    //     ^?InMemoryCache
+  },
+});
+```
+
+> [!NOTE]
+> Setting a cache type enforces that cache type in the `cache` option for
+> the `ApolloClient` constructor.

--- a/.changeset/fuzzy-hairs-tie.md
+++ b/.changeset/fuzzy-hairs-tie.md
@@ -21,15 +21,14 @@ Now anywhere `cache` is accessible, the type is the declared cache type:
 
 ```ts
 client.cache;
-//     ^?InMemoryCache
+//     ^? InMemoryCache
 
 client.mutate({
   update: (cache) => {
-    //     ^?InMemoryCache
+    //     ^? InMemoryCache
   },
 });
 ```
 
 > [!NOTE]
-> Setting a cache type enforces that cache type in the `cache` option for
-> the `ApolloClient` constructor.
+> Setting a cache type enforces that cache type in the `cache` option for the `ApolloClient` constructor.

--- a/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
@@ -1,0 +1,261 @@
+import {
+  ApolloClient,
+  ApolloLink,
+  Cache,
+  TypedDocumentNode,
+  MutationUpdaterFunction,
+  ApolloCache,
+} from "@apollo/client";
+import { useMutation } from "@apollo/client/react";
+import { expectTypeOf } from "expect-type";
+import { test, TestCache } from "../shared/index.js";
+
+declare module "@apollo/client" {
+  export interface TypeOverrides {
+    cache: TestCache;
+    signatureStyle: "classic";
+  }
+}
+
+type Data = { foo: string };
+type Variables = { bar?: string };
+
+declare const mutation: TypedDocumentNode<Data, Variables>;
+
+test("ApolloClient constructor", () => {
+  {
+    const client = new ApolloClient({
+      // @ts-expect-error cache isn't TestCache
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+  }
+});
+
+test("client.mutate", () => {
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
+
+  client.mutate({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+
+  client.mutate<Data, Variables>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+
+  client.mutate<Data, Variables, ApolloCache>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
+
+  client.mutate<Data, Variables, Cache.Implementation>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+
+  client.mutate<Data, Variables, ApolloCache, "all">({
+    errorPolicy: "all",
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
+
+  client.mutate<Data, Variables, Cache.Implementation, "all">({
+    errorPolicy: "all",
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+});
+
+test("client.refetchQueries", () => {
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
+
+  client.refetchQueries({
+    updateCache: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+
+  client.refetchQueries<ApolloCache>({
+    updateCache: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
+
+  client.refetchQueries<Cache.Implementation>({
+    updateCache: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+});
+
+test("useMutation", () => {
+  {
+    const [mutate] = useMutation(mutation, {
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+  }
+
+  {
+    const [mutate] = useMutation<Data, Variables>(mutation, {
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+  }
+
+  {
+    const [mutate] = useMutation<Data, Variables, ApolloCache>(mutation, {
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
+  }
+
+  {
+    const [mutate] = useMutation<Data, Variables, Cache.Implementation>(
+      mutation,
+      {
+        update: (cache) => {
+          expectTypeOf(cache).toEqualTypeOf<TestCache>();
+        },
+        onCompleted: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, TestCache>
+          >;
+        },
+        onError: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, TestCache>
+          >;
+        },
+      }
+    );
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+  }
+});

--- a/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
@@ -70,30 +70,22 @@ test("client.mutate", () => {
     },
   });
 
+  // @ts-expect-error wrong TCache subtype
   client.mutate<Data, Variables, ApolloCache>({
-    mutation,
-    update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-    },
-  });
-
-  client.mutate<Data, Variables, Cache.Implementation>({
     mutation,
     update: (cache) => {
       expectTypeOf(cache).toEqualTypeOf<TestCache>();
     },
   });
 
-  client.mutate<Data, Variables, ApolloCache, "all">({
-    errorPolicy: "all",
+  client.mutate<Data, Variables, TestCache>({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
     },
   });
 
-  client.mutate<Data, Variables, Cache.Implementation, "all">({
-    errorPolicy: "all",
+  client.mutate<Data, Variables, Cache.Implementation>({
     mutation,
     update: (cache) => {
       expectTypeOf(cache).toEqualTypeOf<TestCache>();

--- a/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
@@ -105,9 +105,16 @@ test("client.refetchQueries", () => {
     },
   });
 
+  // @ts-expect-error wrong TCache subtype
   client.refetchQueries<ApolloCache>({
     updateCache: (cache) => {
       expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
+
+  client.refetchQueries<TestCache>({
+    updateCache: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
     },
   });
 

--- a/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
@@ -6,7 +6,13 @@ import {
   MutationUpdaterFunction,
   ApolloCache,
 } from "@apollo/client";
-import { useMutation } from "@apollo/client/react";
+import {
+  useApolloClient,
+  useLazyQuery,
+  useMutation,
+  useQuery,
+  useSuspenseQuery,
+} from "@apollo/client/react";
 import { expectTypeOf } from "expect-type";
 import { test, TestCache } from "../shared/index.js";
 
@@ -21,6 +27,7 @@ type Data = { foo: string };
 type Variables = { bar?: string };
 
 declare const mutation: TypedDocumentNode<Data, Variables>;
+declare const query: TypedDocumentNode<Data, Variables>;
 
 test("ApolloClient constructor", () => {
   {
@@ -117,6 +124,18 @@ test("client.refetchQueries", () => {
       expectTypeOf(cache).toEqualTypeOf<TestCache>();
     },
   });
+});
+
+test("useApolloClient", () => {
+  const client = useApolloClient();
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+});
+
+test("useLazyQuery", () => {
+  const [, { client }] = useLazyQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
 });
 
 test("useMutation", () => {
@@ -270,4 +289,16 @@ test("useMutation", () => {
 
     expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
   }
+});
+
+test("useQuery", () => {
+  const { client } = useQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+});
+
+test("useSuspenseQuery", () => {
+  const { client } = useSuspenseQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
 });

--- a/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
@@ -121,7 +121,7 @@ test("client.refetchQueries", () => {
 
 test("useMutation", () => {
   {
-    const [mutate] = useMutation(mutation, {
+    const [mutate, { client }] = useMutation(mutation, {
       update: (cache) => {
         expectTypeOf(cache).toEqualTypeOf<TestCache>();
       },
@@ -152,10 +152,12 @@ test("useMutation", () => {
         >;
       },
     });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
   }
 
   {
-    const [mutate] = useMutation<Data, Variables>(mutation, {
+    const [mutate, { client }] = useMutation<Data, Variables>(mutation, {
       update: (cache) => {
         expectTypeOf(cache).toEqualTypeOf<TestCache>();
       },
@@ -186,57 +188,25 @@ test("useMutation", () => {
         >;
       },
     });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
   }
 
   {
-    const [mutate] = useMutation<Data, Variables, ApolloCache>(mutation, {
-      update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-      },
-      onCompleted: (_, options) => {
-        expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
-        >;
-      },
-      onError: (_, options) => {
-        expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
-        >;
-      },
-    });
-
-    mutate({
-      update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-      },
-      onCompleted: (_, options) => {
-        expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
-        >;
-      },
-      onError: (_, options) => {
-        expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
-        >;
-      },
-    });
-  }
-
-  {
-    const [mutate] = useMutation<Data, Variables, Cache.Implementation>(
+    const [mutate, { client }] = useMutation<Data, Variables, ApolloCache>(
       mutation,
       {
         update: (cache) => {
-          expectTypeOf(cache).toEqualTypeOf<TestCache>();
+          expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
         },
         onCompleted: (_, options) => {
           expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, TestCache>
+            MutationUpdaterFunction<Data, Variables, ApolloCache>
           >;
         },
         onError: (_, options) => {
           expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, TestCache>
+            MutationUpdaterFunction<Data, Variables, ApolloCache>
           >;
         },
       }
@@ -244,6 +214,30 @@ test("useMutation", () => {
 
     mutate({
       update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+  }
+
+  {
+    const [mutate, { client }] = useMutation<
+      Data,
+      Variables,
+      Cache.Implementation
+    >(mutation, {
+      update: (cache) => {
         expectTypeOf(cache).toEqualTypeOf<TestCache>();
       },
       onCompleted: (_, options) => {
@@ -257,5 +251,23 @@ test("useMutation", () => {
         >;
       },
     });
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
   }
 });

--- a/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
@@ -5,6 +5,7 @@ import {
   TypedDocumentNode,
   MutationUpdaterFunction,
   ApolloCache,
+  InMemoryCache,
 } from "@apollo/client";
 import {
   useApolloClient,

--- a/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
@@ -211,20 +211,21 @@ test("useMutation", () => {
   }
 
   {
+    // @ts-expect-error wrong TCache subtype
     const [mutate, { client }] = useMutation<Data, Variables, ApolloCache>(
       mutation,
       {
         update: (cache) => {
-          expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+          expectTypeOf(cache).toEqualTypeOf<TestCache>();
         },
         onCompleted: (_, options) => {
           expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, ApolloCache>
+            MutationUpdaterFunction<Data, Variables, TestCache>
           >;
         },
         onError: (_, options) => {
           expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, ApolloCache>
+            MutationUpdaterFunction<Data, Variables, TestCache>
           >;
         },
       }
@@ -232,16 +233,55 @@ test("useMutation", () => {
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, TestCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+  }
+
+  {
+    const [mutate, { client }] = useMutation<Data, Variables, TestCache>(
+      mutation,
+      {
+        update: (cache) => {
+          expectTypeOf(cache).toEqualTypeOf<TestCache>();
+        },
+        onCompleted: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, TestCache>
+          >;
+        },
+        onError: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, TestCache>
+          >;
+        },
+      }
+    );
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
         >;
       },
     });

--- a/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/index.ts
@@ -126,6 +126,22 @@ test("client.refetchQueries", () => {
   });
 });
 
+test("cache.batch", () => {
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
+
+  client.cache.batch({
+    update(cache) {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+    onWatchUpdated() {
+      expectTypeOf(this).toEqualTypeOf<TestCache>();
+    },
+  });
+});
+
 test("useApolloClient", () => {
   const client = useApolloClient();
 

--- a/integration-tests/type-tests/cacheOverride/classicSignature/tsconfig.json
+++ b/integration-tests/type-tests/cacheOverride/classicSignature/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../../tsconfig.src.json"
+    },
+    {
+      "path": "../shared/tsconfig.json"
+    }
+  ]
+}

--- a/integration-tests/type-tests/cacheOverride/defaults/index.ts
+++ b/integration-tests/type-tests/cacheOverride/defaults/index.ts
@@ -2,10 +2,9 @@ import {
   ApolloCache,
   ApolloClient,
   ApolloLink,
-  DocumentNode,
   InMemoryCache,
   MutationUpdaterFunction,
-  OperationVariables,
+  TypedDocumentNode,
 } from "@apollo/client";
 import {
   useApolloClient,
@@ -17,8 +16,11 @@ import {
 import { expectTypeOf } from "expect-type";
 import { test, TestCache } from "../shared/index.js";
 
-declare const mutation: DocumentNode;
-declare const query: DocumentNode;
+type Data = { foo: string };
+type Variables = { bar?: string };
+
+declare const mutation: TypedDocumentNode<Data, Variables>;
+declare const query: TypedDocumentNode<Data, Variables>;
 
 test("ApolloClient constructor", () => {
   {
@@ -41,33 +43,38 @@ test("ApolloClient constructor", () => {
 });
 
 test("client.mutate", () => {
-  {
-    const client = new ApolloClient({
-      cache: new InMemoryCache(),
-      link: ApolloLink.empty(),
-    });
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
 
-    client.mutate({
-      mutation,
-      update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-      },
-    });
-  }
+  client.mutate({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
 
-  {
-    const client = new ApolloClient({
-      cache: new TestCache(),
-      link: ApolloLink.empty(),
-    });
+  client.mutate<Data, Variables>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
 
-    client.mutate({
-      mutation,
-      update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-      },
-    });
-  }
+  client.mutate<Data, Variables, TestCache>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+
+  client.mutate<Data, Variables, InMemoryCache>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+    },
+  });
 });
 
 test("client.refetchQueries", () => {
@@ -111,39 +118,157 @@ test("useLazyQuery", () => {
 });
 
 test("useMutation", () => {
-  const [mutate, { client }] = useMutation(mutation, {
-    update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-    },
-    onCompleted: (_, options) => {
-      expectTypeOf(options!.update!).toEqualTypeOf<
-        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
-      >;
-    },
-    onError: (_, options) => {
-      expectTypeOf(options!.update!).toEqualTypeOf<
-        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
-      >;
-    },
-  });
+  {
+    const [mutate, { client }] = useMutation(mutation, {
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
 
-  mutate({
-    update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-    },
-    onCompleted: (_, options) => {
-      expectTypeOf(options!.update!).toEqualTypeOf<
-        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
-      >;
-    },
-    onError: (_, options) => {
-      expectTypeOf(options!.update!).toEqualTypeOf<
-        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
-      >;
-    },
-  });
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+
+  {
+    const [mutate, { client }] = useMutation<Data, Variables>(mutation, {
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+
+  // Ensure TCache can override any subtype of ApolloCache
+  {
+    const [mutate, { client }] = useMutation<Data, Variables, TestCache>(
+      mutation,
+      {
+        update: (cache) => {
+          expectTypeOf(cache).toEqualTypeOf<TestCache>();
+        },
+        onCompleted: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, TestCache>
+          >;
+        },
+        onError: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, TestCache>
+          >;
+        },
+      }
+    );
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+
+  // Ensure TCache can override any subtype of ApolloCache
+  {
+    const [mutate, { client }] = useMutation<Data, Variables, InMemoryCache>(
+      mutation,
+      {
+        update: (cache) => {
+          expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        },
+        onCompleted: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          >;
+        },
+        onError: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          >;
+        },
+      }
+    );
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
 });
 
 test("useQuery", () => {

--- a/integration-tests/type-tests/cacheOverride/defaults/index.ts
+++ b/integration-tests/type-tests/cacheOverride/defaults/index.ts
@@ -105,6 +105,22 @@ test("client.refetchQueries", () => {
   }
 });
 
+test("cache.batch", () => {
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
+
+  client.cache.batch({
+    update(cache) {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+    onWatchUpdated() {
+      expectTypeOf(this).toEqualTypeOf<ApolloCache>();
+    },
+  });
+});
+
 test("useApolloClient", () => {
   const client = useApolloClient();
 

--- a/integration-tests/type-tests/cacheOverride/defaults/index.ts
+++ b/integration-tests/type-tests/cacheOverride/defaults/index.ts
@@ -92,7 +92,7 @@ test("client.refetchQueries", () => {
 });
 
 test("useMutation", () => {
-  const [mutate] = useMutation(mutation, {
+  const [mutate, { client }] = useMutation(mutation, {
     update: (cache) => {
       expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
     },
@@ -123,4 +123,6 @@ test("useMutation", () => {
       >;
     },
   });
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
 });

--- a/integration-tests/type-tests/cacheOverride/defaults/index.ts
+++ b/integration-tests/type-tests/cacheOverride/defaults/index.ts
@@ -7,11 +7,18 @@ import {
   MutationUpdaterFunction,
   OperationVariables,
 } from "@apollo/client";
-import { useMutation } from "@apollo/client/react";
+import {
+  useApolloClient,
+  useLazyQuery,
+  useMutation,
+  useQuery,
+  useSuspenseQuery,
+} from "@apollo/client/react";
 import { expectTypeOf } from "expect-type";
 import { test, TestCache } from "../shared/index.js";
 
 declare const mutation: DocumentNode;
+declare const query: DocumentNode;
 
 test("ApolloClient constructor", () => {
   {
@@ -91,6 +98,18 @@ test("client.refetchQueries", () => {
   }
 });
 
+test("useApolloClient", () => {
+  const client = useApolloClient();
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});
+
+test("useLazyQuery", () => {
+  const [, { client }] = useLazyQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});
+
 test("useMutation", () => {
   const [mutate, { client }] = useMutation(mutation, {
     update: (cache) => {
@@ -123,6 +142,18 @@ test("useMutation", () => {
       >;
     },
   });
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});
+
+test("useQuery", () => {
+  const { client } = useQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});
+
+test("useSuspenseQuery", () => {
+  const { client } = useSuspenseQuery(query);
 
   expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
 });

--- a/integration-tests/type-tests/cacheOverride/defaults/index.ts
+++ b/integration-tests/type-tests/cacheOverride/defaults/index.ts
@@ -1,5 +1,4 @@
 import {
-  ApolloCache,
   ApolloClient,
   ApolloLink,
   InMemoryCache,
@@ -29,43 +28,45 @@ test("ApolloClient constructor", () => {
       link: ApolloLink.empty(),
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
   }
 
   {
     const client = new ApolloClient({
+      // @ts-expect-error Using a cache other than `InMemoryCache` requires a cache type declared in TypeOverrides. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.      cache: new TestCache(),
       cache: new TestCache(),
       link: ApolloLink.empty(),
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
   }
 });
 
 test("client.mutate", () => {
   const client = new ApolloClient({
-    cache: new TestCache(),
+    cache: new InMemoryCache(),
     link: ApolloLink.empty(),
   });
 
   client.mutate({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
     },
   });
 
   client.mutate<Data, Variables>({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
     },
   });
 
+  // @ts-expect-error TestCache doesn't extend InMemoryCache (the default)
   client.mutate<Data, Variables, TestCache>({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
     },
   });
 
@@ -86,20 +87,7 @@ test("client.refetchQueries", () => {
 
     client.refetchQueries({
       updateCache: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-      },
-    });
-  }
-
-  {
-    const client = new ApolloClient({
-      cache: new TestCache(),
-      link: ApolloLink.empty(),
-    });
-
-    client.refetchQueries({
-      updateCache: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
       },
     });
   }
@@ -107,16 +95,16 @@ test("client.refetchQueries", () => {
 
 test("cache.batch", () => {
   const client = new ApolloClient({
-    cache: new TestCache(),
+    cache: new InMemoryCache(),
     link: ApolloLink.empty(),
   });
 
   client.cache.batch({
     update(cache) {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
     },
     onWatchUpdated() {
-      expectTypeOf(this).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(this).toEqualTypeOf<InMemoryCache>();
     },
   });
 });
@@ -124,104 +112,105 @@ test("cache.batch", () => {
 test("useApolloClient", () => {
   const client = useApolloClient();
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
 });
 
 test("useLazyQuery", () => {
   const [, { client }] = useLazyQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
 });
 
 test("useMutation", () => {
   {
     const [mutate, { client }] = useMutation(mutation, {
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
     });
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
   }
 
   {
     const [mutate, { client }] = useMutation<Data, Variables>(mutation, {
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
     });
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
   }
 
-  // Ensure TCache can override any subtype of ApolloCache
+  // TestCache doesn't extend InMemoryCache, so it cannot be used as TCache without TypeOverrides
   {
+    // @ts-expect-error TestCache doesn't extend InMemoryCache (the default)
     const [mutate, { client }] = useMutation<Data, Variables, TestCache>(
       mutation,
       {
         update: (cache) => {
-          expectTypeOf(cache).toEqualTypeOf<TestCache>();
+          expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
         },
         onCompleted: (_, options) => {
           expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, TestCache>
+            MutationUpdaterFunction<Data, Variables, InMemoryCache>
           >;
         },
         onError: (_, options) => {
           expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, TestCache>
+            MutationUpdaterFunction<Data, Variables, InMemoryCache>
           >;
         },
       }
@@ -229,24 +218,24 @@ test("useMutation", () => {
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, TestCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, TestCache>
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
   }
 
-  // Ensure TCache can override any subtype of ApolloCache
+  // Ensure TCache can be explicitly set to InMemoryCache
   {
     const [mutate, { client }] = useMutation<Data, Variables, InMemoryCache>(
       mutation,
@@ -283,18 +272,18 @@ test("useMutation", () => {
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
   }
 });
 
 test("useQuery", () => {
   const { client } = useQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
 });
 
 test("useSuspenseQuery", () => {
   const { client } = useSuspenseQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
 });

--- a/integration-tests/type-tests/cacheOverride/defaults/index.ts
+++ b/integration-tests/type-tests/cacheOverride/defaults/index.ts
@@ -1,0 +1,126 @@
+import {
+  ApolloCache,
+  ApolloClient,
+  ApolloLink,
+  DocumentNode,
+  InMemoryCache,
+  MutationUpdaterFunction,
+  OperationVariables,
+} from "@apollo/client";
+import { useMutation } from "@apollo/client/react";
+import { expectTypeOf } from "expect-type";
+import { test, TestCache } from "../shared/index.js";
+
+declare const mutation: DocumentNode;
+
+test("ApolloClient constructor", () => {
+  {
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+});
+
+test("client.mutate", () => {
+  {
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.mutate({
+      mutation,
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.mutate({
+      mutation,
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+});
+
+test("client.refetchQueries", () => {
+  {
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.refetchQueries({
+      updateCache: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.refetchQueries({
+      updateCache: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+});
+
+test("useMutation", () => {
+  const [mutate] = useMutation(mutation, {
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+    onCompleted: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
+      >;
+    },
+    onError: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
+      >;
+    },
+  });
+
+  mutate({
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+    onCompleted: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
+      >;
+    },
+    onError: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
+      >;
+    },
+  });
+});

--- a/integration-tests/type-tests/cacheOverride/defaults/index.ts
+++ b/integration-tests/type-tests/cacheOverride/defaults/index.ts
@@ -1,4 +1,5 @@
 import {
+  ApolloCache,
   ApolloClient,
   ApolloLink,
   InMemoryCache,
@@ -28,45 +29,43 @@ test("ApolloClient constructor", () => {
       link: ApolloLink.empty(),
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
   }
 
   {
     const client = new ApolloClient({
-      // @ts-expect-error Using a cache other than `InMemoryCache` requires a cache type declared in TypeOverrides. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.      cache: new TestCache(),
       cache: new TestCache(),
       link: ApolloLink.empty(),
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
   }
 });
 
 test("client.mutate", () => {
   const client = new ApolloClient({
-    cache: new InMemoryCache(),
+    cache: new TestCache(),
     link: ApolloLink.empty(),
   });
 
   client.mutate({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
     },
   });
 
   client.mutate<Data, Variables>({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
     },
   });
 
-  // @ts-expect-error TestCache doesn't extend InMemoryCache (the default)
   client.mutate<Data, Variables, TestCache>({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
     },
   });
 
@@ -87,7 +86,20 @@ test("client.refetchQueries", () => {
 
     client.refetchQueries({
       updateCache: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.refetchQueries({
+      updateCache: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
       },
     });
   }
@@ -95,16 +107,16 @@ test("client.refetchQueries", () => {
 
 test("cache.batch", () => {
   const client = new ApolloClient({
-    cache: new InMemoryCache(),
+    cache: new TestCache(),
     link: ApolloLink.empty(),
   });
 
   client.cache.batch({
     update(cache) {
-      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
     },
     onWatchUpdated() {
-      expectTypeOf(this).toEqualTypeOf<InMemoryCache>();
+      expectTypeOf(this).toEqualTypeOf<ApolloCache>();
     },
   });
 });
@@ -112,105 +124,104 @@ test("cache.batch", () => {
 test("useApolloClient", () => {
   const client = useApolloClient();
 
-  expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
 });
 
 test("useLazyQuery", () => {
   const [, { client }] = useLazyQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
 });
 
 test("useMutation", () => {
   {
     const [mutate, { client }] = useMutation(mutation, {
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
         >;
       },
     });
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
   }
 
   {
     const [mutate, { client }] = useMutation<Data, Variables>(mutation, {
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
         >;
       },
     });
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
   }
 
-  // TestCache doesn't extend InMemoryCache, so it cannot be used as TCache without TypeOverrides
+  // Ensure TCache can override any subtype of ApolloCache
   {
-    // @ts-expect-error TestCache doesn't extend InMemoryCache (the default)
     const [mutate, { client }] = useMutation<Data, Variables, TestCache>(
       mutation,
       {
         update: (cache) => {
-          expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+          expectTypeOf(cache).toEqualTypeOf<TestCache>();
         },
         onCompleted: (_, options) => {
           expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, InMemoryCache>
+            MutationUpdaterFunction<Data, Variables, TestCache>
           >;
         },
         onError: (_, options) => {
           expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, InMemoryCache>
+            MutationUpdaterFunction<Data, Variables, TestCache>
           >;
         },
       }
@@ -218,24 +229,24 @@ test("useMutation", () => {
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, TestCache>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, TestCache>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
   }
 
-  // Ensure TCache can be explicitly set to InMemoryCache
+  // Ensure TCache can override any subtype of ApolloCache
   {
     const [mutate, { client }] = useMutation<Data, Variables, InMemoryCache>(
       mutation,
@@ -272,18 +283,18 @@ test("useMutation", () => {
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
   }
 });
 
 test("useQuery", () => {
   const { client } = useQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
 });
 
 test("useSuspenseQuery", () => {
   const { client } = useSuspenseQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<InMemoryCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
 });

--- a/integration-tests/type-tests/cacheOverride/defaults/tsconfig.json
+++ b/integration-tests/type-tests/cacheOverride/defaults/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../../tsconfig.src.json"
+    },
+    {
+      "path": "../shared/tsconfig.json"
+    }
+  ]
+}

--- a/integration-tests/type-tests/cacheOverride/invalid/index.ts
+++ b/integration-tests/type-tests/cacheOverride/invalid/index.ts
@@ -7,7 +7,13 @@ import {
   MutationUpdaterFunction,
   OperationVariables,
 } from "@apollo/client";
-import { useMutation } from "@apollo/client/react";
+import {
+  useApolloClient,
+  useLazyQuery,
+  useMutation,
+  useQuery,
+  useSuspenseQuery,
+} from "@apollo/client/react";
 import { expectTypeOf } from "expect-type";
 import { test, TestCache } from "../shared/index.js";
 
@@ -19,6 +25,7 @@ declare module "@apollo/client" {
 }
 
 declare const mutation: DocumentNode;
+declare const query: DocumentNode;
 
 test("ApolloClient constructor", () => {
   {
@@ -98,6 +105,18 @@ test("client.refetchQueries", () => {
   }
 });
 
+test("useApolloClient", () => {
+  const client = useApolloClient();
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});
+
+test("useLazyQuery", () => {
+  const [, { client }] = useLazyQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});
+
 test("useMutation", () => {
   const [mutate, { client }] = useMutation(mutation, {
     update: (cache) => {
@@ -130,6 +149,18 @@ test("useMutation", () => {
       >;
     },
   });
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});
+
+test("useQuery", () => {
+  const { client } = useQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});
+
+test("useSuspenseQuery", () => {
+  const { client } = useSuspenseQuery(query);
 
   expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
 });

--- a/integration-tests/type-tests/cacheOverride/invalid/index.ts
+++ b/integration-tests/type-tests/cacheOverride/invalid/index.ts
@@ -121,6 +121,22 @@ test("client.refetchQueries", () => {
   }
 });
 
+test("cache.batch", () => {
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
+
+  client.cache.batch({
+    update(cache) {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+    onWatchUpdated() {
+      expectTypeOf(this).toEqualTypeOf<ApolloCache>();
+    },
+  });
+});
+
 test("useApolloClient", () => {
   const client = useApolloClient();
 

--- a/integration-tests/type-tests/cacheOverride/invalid/index.ts
+++ b/integration-tests/type-tests/cacheOverride/invalid/index.ts
@@ -46,6 +46,16 @@ test("ApolloClient constructor", () => {
 
     expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
   }
+
+  {
+    const client = new ApolloClient({
+      // @ts-expect-error not an ApolloCache subtype despite the type override
+      cache: 123,
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
 });
 
 test("client.mutate", () => {

--- a/integration-tests/type-tests/cacheOverride/invalid/index.ts
+++ b/integration-tests/type-tests/cacheOverride/invalid/index.ts
@@ -16,7 +16,6 @@ import {
 import { expectTypeOf } from "expect-type";
 import { test, TestCache } from "../shared/index.js";
 
-// A cache type that doesn't extend ApolloCache should behave like ApolloCache
 declare module "@apollo/client" {
   export interface TypeOverrides {
     cache: number;
@@ -28,38 +27,44 @@ type Variables = { bar?: string };
 declare const mutation: TypedDocumentNode<Data, Variables>;
 declare const query: TypedDocumentNode<Data, Variables>;
 
+type WrongCacheMessage =
+  "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.";
+
 test("ApolloClient constructor", () => {
   {
     const client = new ApolloClient({
+      // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
       cache: new InMemoryCache(),
       link: ApolloLink.empty(),
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
   }
 
   {
     const client = new ApolloClient({
+      // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
       cache: new TestCache(),
       link: ApolloLink.empty(),
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
   }
 
   {
     const client = new ApolloClient({
-      // @ts-expect-error not an ApolloCache subtype despite the type override
+      // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
       cache: 123,
       link: ApolloLink.empty(),
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
   }
 });
 
 test("client.mutate", () => {
   const client = new ApolloClient({
+    // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
     cache: new TestCache(),
     link: ApolloLink.empty(),
   });
@@ -67,28 +72,30 @@ test("client.mutate", () => {
   client.mutate({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
     },
   });
 
   client.mutate<Data, Variables>({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
     },
   });
 
+  // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
   client.mutate<Data, Variables, TestCache>({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
     },
   });
 
+  // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
   client.mutate<Data, Variables, InMemoryCache>({
     mutation,
     update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+      expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
     },
   });
 });
@@ -96,26 +103,28 @@ test("client.mutate", () => {
 test("client.refetchQueries", () => {
   {
     const client = new ApolloClient({
+      // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
       cache: new InMemoryCache(),
       link: ApolloLink.empty(),
     });
 
     client.refetchQueries({
       updateCache: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
       },
     });
   }
 
   {
     const client = new ApolloClient({
+      // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
       cache: new TestCache(),
       link: ApolloLink.empty(),
     });
 
     client.refetchQueries({
       updateCache: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
       },
     });
   }
@@ -123,16 +132,19 @@ test("client.refetchQueries", () => {
 
 test("cache.batch", () => {
   const client = new ApolloClient({
+    // @ts-expect-error The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.
     cache: new TestCache(),
     link: ApolloLink.empty(),
   });
 
+  // @ts-expect-error property 'batch' doesn't exist in 'The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.'
   client.cache.batch({
+    // @ts-expect-error inferred any
     update(cache) {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(cache).toEqualTypeOf<any>();
     },
     onWatchUpdated() {
-      expectTypeOf(this).toEqualTypeOf<ApolloCache>();
+      expectTypeOf(this).toEqualTypeOf<any>();
     },
   });
 });
@@ -140,177 +152,137 @@ test("cache.batch", () => {
 test("useApolloClient", () => {
   const client = useApolloClient();
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
 });
 
 test("useLazyQuery", () => {
   const [, { client }] = useLazyQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
 });
 
 test("useMutation", () => {
   {
     const [mutate, { client }] = useMutation(mutation, {
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
     });
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
   }
 
   {
     const [mutate, { client }] = useMutation<Data, Variables>(mutation, {
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
     });
 
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+        expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, ApolloCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
   }
 
-  // Ensure TCache can override any subtype of ApolloCache
   {
-    const [mutate, { client }] = useMutation<Data, Variables, TestCache>(
-      mutation,
-      {
-        update: (cache) => {
-          expectTypeOf(cache).toEqualTypeOf<TestCache>();
-        },
-        onCompleted: (_, options) => {
-          expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, TestCache>
-          >;
-        },
-        onError: (_, options) => {
-          expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, TestCache>
-          >;
-        },
-      }
-    );
-
-    mutate({
+    const [mutate, { client }] = useMutation<
+      Data,
+      Variables,
+      WrongCacheMessage
+    >(mutation, {
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+        expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, TestCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, TestCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
-  }
-
-  // Ensure TCache can override any subtype of ApolloCache
-  {
-    const [mutate, { client }] = useMutation<Data, Variables, InMemoryCache>(
-      mutation,
-      {
-        update: (cache) => {
-          expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
-        },
-        onCompleted: (_, options) => {
-          expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, InMemoryCache>
-          >;
-        },
-        onError: (_, options) => {
-          expectTypeOf(options!.update!).toEqualTypeOf<
-            MutationUpdaterFunction<Data, Variables, InMemoryCache>
-          >;
-        },
-      }
-    );
-
     mutate({
       update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        expectTypeOf(cache).toEqualTypeOf<WrongCacheMessage>();
       },
       onCompleted: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
       onError: (_, options) => {
         expectTypeOf(options!.update!).toEqualTypeOf<
-          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          MutationUpdaterFunction<Data, Variables, WrongCacheMessage>
         >;
       },
     });
 
-    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
   }
 });
 
 test("useQuery", () => {
   const { client } = useQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
 });
 
 test("useSuspenseQuery", () => {
   const { client } = useSuspenseQuery(query);
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  expectTypeOf(client.cache).toEqualTypeOf<WrongCacheMessage>();
 });

--- a/integration-tests/type-tests/cacheOverride/invalid/index.ts
+++ b/integration-tests/type-tests/cacheOverride/invalid/index.ts
@@ -1,0 +1,135 @@
+import {
+  ApolloCache,
+  ApolloClient,
+  ApolloLink,
+  DocumentNode,
+  InMemoryCache,
+  MutationUpdaterFunction,
+  OperationVariables,
+} from "@apollo/client";
+import { useMutation } from "@apollo/client/react";
+import { expectTypeOf } from "expect-type";
+import { test, TestCache } from "../shared/index.js";
+
+// A cache type that doesn't extend ApolloCache should behave like ApolloCache
+declare module "@apollo/client" {
+  export interface TypeOverrides {
+    cache: number;
+  }
+}
+
+declare const mutation: DocumentNode;
+
+test("ApolloClient constructor", () => {
+  {
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+});
+
+test("client.mutate", () => {
+  {
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.mutate({
+      mutation,
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.mutate({
+      mutation,
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+});
+
+test("client.refetchQueries", () => {
+  {
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.refetchQueries({
+      updateCache: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.refetchQueries({
+      updateCache: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+    });
+  }
+});
+
+test("useMutation", () => {
+  const [mutate, { client }] = useMutation(mutation, {
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+    onCompleted: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
+      >;
+    },
+    onError: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
+      >;
+    },
+  });
+
+  mutate({
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+    onCompleted: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
+      >;
+    },
+    onError: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
+      >;
+    },
+  });
+
+  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+});

--- a/integration-tests/type-tests/cacheOverride/invalid/index.ts
+++ b/integration-tests/type-tests/cacheOverride/invalid/index.ts
@@ -2,10 +2,9 @@ import {
   ApolloCache,
   ApolloClient,
   ApolloLink,
-  DocumentNode,
   InMemoryCache,
   MutationUpdaterFunction,
-  OperationVariables,
+  TypedDocumentNode,
 } from "@apollo/client";
 import {
   useApolloClient,
@@ -23,9 +22,11 @@ declare module "@apollo/client" {
     cache: number;
   }
 }
+type Data = { foo: string };
+type Variables = { bar?: string };
 
-declare const mutation: DocumentNode;
-declare const query: DocumentNode;
+declare const mutation: TypedDocumentNode<Data, Variables>;
+declare const query: TypedDocumentNode<Data, Variables>;
 
 test("ApolloClient constructor", () => {
   {
@@ -48,33 +49,38 @@ test("ApolloClient constructor", () => {
 });
 
 test("client.mutate", () => {
-  {
-    const client = new ApolloClient({
-      cache: new InMemoryCache(),
-      link: ApolloLink.empty(),
-    });
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
 
-    client.mutate({
-      mutation,
-      update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-      },
-    });
-  }
+  client.mutate({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
 
-  {
-    const client = new ApolloClient({
-      cache: new TestCache(),
-      link: ApolloLink.empty(),
-    });
+  client.mutate<Data, Variables>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
 
-    client.mutate({
-      mutation,
-      update: (cache) => {
-        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-      },
-    });
-  }
+  client.mutate<Data, Variables, TestCache>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+
+  client.mutate<Data, Variables, InMemoryCache>({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+    },
+  });
 });
 
 test("client.refetchQueries", () => {
@@ -118,39 +124,157 @@ test("useLazyQuery", () => {
 });
 
 test("useMutation", () => {
-  const [mutate, { client }] = useMutation(mutation, {
-    update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-    },
-    onCompleted: (_, options) => {
-      expectTypeOf(options!.update!).toEqualTypeOf<
-        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
-      >;
-    },
-    onError: (_, options) => {
-      expectTypeOf(options!.update!).toEqualTypeOf<
-        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
-      >;
-    },
-  });
+  {
+    const [mutate, { client }] = useMutation(mutation, {
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
 
-  mutate({
-    update: (cache) => {
-      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
-    },
-    onCompleted: (_, options) => {
-      expectTypeOf(options!.update!).toEqualTypeOf<
-        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
-      >;
-    },
-    onError: (_, options) => {
-      expectTypeOf(options!.update!).toEqualTypeOf<
-        MutationUpdaterFunction<unknown, OperationVariables, ApolloCache>
-      >;
-    },
-  });
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
 
-  expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+
+  {
+    const [mutate, { client }] = useMutation<Data, Variables>(mutation, {
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, ApolloCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+
+  // Ensure TCache can override any subtype of ApolloCache
+  {
+    const [mutate, { client }] = useMutation<Data, Variables, TestCache>(
+      mutation,
+      {
+        update: (cache) => {
+          expectTypeOf(cache).toEqualTypeOf<TestCache>();
+        },
+        onCompleted: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, TestCache>
+          >;
+        },
+        onError: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, TestCache>
+          >;
+        },
+      }
+    );
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<TestCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, TestCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
+
+  // Ensure TCache can override any subtype of ApolloCache
+  {
+    const [mutate, { client }] = useMutation<Data, Variables, InMemoryCache>(
+      mutation,
+      {
+        update: (cache) => {
+          expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+        },
+        onCompleted: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          >;
+        },
+        onError: (_, options) => {
+          expectTypeOf(options!.update!).toEqualTypeOf<
+            MutationUpdaterFunction<Data, Variables, InMemoryCache>
+          >;
+        },
+      }
+    );
+
+    mutate({
+      update: (cache) => {
+        expectTypeOf(cache).toEqualTypeOf<InMemoryCache>();
+      },
+      onCompleted: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+        >;
+      },
+      onError: (_, options) => {
+        expectTypeOf(options!.update!).toEqualTypeOf<
+          MutationUpdaterFunction<Data, Variables, InMemoryCache>
+        >;
+      },
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<ApolloCache>();
+  }
 });
 
 test("useQuery", () => {

--- a/integration-tests/type-tests/cacheOverride/invalid/tsconfig.json
+++ b/integration-tests/type-tests/cacheOverride/invalid/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../../tsconfig.src.json"
+    },
+    {
+      "path": "../shared/tsconfig.json"
+    }
+  ]
+}

--- a/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
@@ -97,6 +97,22 @@ test("client.refetchQueries", () => {
   });
 });
 
+test("cache.batch", () => {
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
+
+  client.cache.batch({
+    update(cache) {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+    onWatchUpdated() {
+      expectTypeOf(this).toEqualTypeOf<TestCache>();
+    },
+  });
+});
+
 test("useApolloClient", () => {
   const client = useApolloClient();
 

--- a/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
@@ -5,6 +5,7 @@ import {
   TypedDocumentNode,
   MutationUpdaterFunction,
   ApolloCache,
+  InMemoryCache,
 } from "@apollo/client";
 import {
   useApolloClient,

--- a/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
@@ -83,7 +83,7 @@ test("client.refetchQueries", () => {
 });
 
 test("useMutation", () => {
-  const [mutate] = useMutation(mutation, {
+  const [mutate, { client }] = useMutation(mutation, {
     update: (cache) => {
       expectTypeOf(cache).toEqualTypeOf<TestCache>();
     },
@@ -114,4 +114,6 @@ test("useMutation", () => {
       >;
     },
   });
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
 });

--- a/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
@@ -1,0 +1,117 @@
+import {
+  ApolloClient,
+  ApolloLink,
+  Cache,
+  TypedDocumentNode,
+  MutationUpdaterFunction,
+  ApolloCache,
+} from "@apollo/client";
+import { useMutation } from "@apollo/client/react";
+import { expectTypeOf } from "expect-type";
+import { test, TestCache } from "../shared/index.js";
+
+declare module "@apollo/client" {
+  export interface TypeOverrides {
+    cache: TestCache;
+    signatureStyle: "modern";
+  }
+}
+
+type Data = { foo: string };
+type Variables = { bar?: string };
+
+declare const mutation: TypedDocumentNode<Data, Variables>;
+
+test("ApolloClient constructor", () => {
+  {
+    const client = new ApolloClient({
+      // @ts-expect-error cache isn't TestCache
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+  }
+
+  {
+    const client = new ApolloClient({
+      cache: new TestCache(),
+      link: ApolloLink.empty(),
+    });
+
+    expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+  }
+});
+
+test("client.mutate", () => {
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
+
+  client.mutate({
+    mutation,
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+});
+
+test("client.refetchQueries", () => {
+  const client = new ApolloClient({
+    cache: new TestCache(),
+    link: ApolloLink.empty(),
+  });
+
+  client.refetchQueries({
+    updateCache: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+
+  client.refetchQueries<ApolloCache>({
+    updateCache: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
+
+  client.refetchQueries<Cache.Implementation>({
+    updateCache: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+  });
+});
+
+test("useMutation", () => {
+  const [mutate] = useMutation(mutation, {
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+    onCompleted: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<Data, Variables, TestCache>
+      >;
+    },
+    onError: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<Data, Variables, TestCache>
+      >;
+    },
+  });
+
+  mutate({
+    update: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
+    },
+    onCompleted: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<Data, Variables, TestCache>
+      >;
+    },
+    onError: (_, options) => {
+      expectTypeOf(options!.update!).toEqualTypeOf<
+        MutationUpdaterFunction<Data, Variables, TestCache>
+      >;
+    },
+  });
+});

--- a/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
@@ -6,7 +6,13 @@ import {
   MutationUpdaterFunction,
   ApolloCache,
 } from "@apollo/client";
-import { useMutation } from "@apollo/client/react";
+import {
+  useApolloClient,
+  useLazyQuery,
+  useMutation,
+  useQuery,
+  useSuspenseQuery,
+} from "@apollo/client/react";
 import { expectTypeOf } from "expect-type";
 import { test, TestCache } from "../shared/index.js";
 
@@ -21,6 +27,7 @@ type Data = { foo: string };
 type Variables = { bar?: string };
 
 declare const mutation: TypedDocumentNode<Data, Variables>;
+declare const query: TypedDocumentNode<Data, Variables>;
 
 test("ApolloClient constructor", () => {
   {
@@ -82,6 +89,18 @@ test("client.refetchQueries", () => {
   });
 });
 
+test("useApolloClient", () => {
+  const client = useApolloClient();
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+});
+
+test("useLazyQuery", () => {
+  const [, { client }] = useLazyQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+});
+
 test("useMutation", () => {
   const [mutate, { client }] = useMutation(mutation, {
     update: (cache) => {
@@ -114,6 +133,18 @@ test("useMutation", () => {
       >;
     },
   });
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+});
+
+test("useQuery", () => {
+  const { client } = useQuery(query);
+
+  expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
+});
+
+test("useSuspenseQuery", () => {
+  const { client } = useSuspenseQuery(query);
 
   expectTypeOf(client.cache).toEqualTypeOf<TestCache>();
 });

--- a/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
+++ b/integration-tests/type-tests/cacheOverride/modernSignature/index.ts
@@ -77,9 +77,16 @@ test("client.refetchQueries", () => {
     },
   });
 
+  // @ts-expect-error wrong TCache subtype
   client.refetchQueries<ApolloCache>({
     updateCache: (cache) => {
       expectTypeOf(cache).toEqualTypeOf<ApolloCache>();
+    },
+  });
+
+  client.refetchQueries<TestCache>({
+    updateCache: (cache) => {
+      expectTypeOf(cache).toEqualTypeOf<TestCache>();
     },
   });
 

--- a/integration-tests/type-tests/cacheOverride/modernSignature/tsconfig.json
+++ b/integration-tests/type-tests/cacheOverride/modernSignature/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../../tsconfig.src.json"
+    },
+    {
+      "path": "../shared/tsconfig.json"
+    }
+  ]
+}

--- a/integration-tests/type-tests/cacheOverride/shared/index.ts
+++ b/integration-tests/type-tests/cacheOverride/shared/index.ts
@@ -1,0 +1,46 @@
+import {
+  ApolloCache,
+  Cache,
+  OperationVariables,
+  Reference,
+  Transaction,
+} from "@apollo/client";
+import { FragmentDefinitionNode, InlineFragmentNode } from "graphql";
+
+export declare function test(description: string, fn: () => void): void;
+
+export declare class TestCache extends ApolloCache {
+  public read<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(query: Cache.ReadOptions<TData, TVariables>): TData | null;
+  public write<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(write: Cache.WriteOptions<TData, TVariables>): Reference | undefined;
+  public diff<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(query: Cache.DiffOptions<TData, TVariables>): Cache.DiffResult<TData>;
+  public watch<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(watch: Cache.WatchOptions<TData, TVariables>): () => void;
+  public reset(options?: Cache.ResetOptions): Promise<void>;
+  public evict(options: Cache.EvictOptions): boolean;
+  public restore(serializedState: unknown): this;
+  public extract(optimistic?: boolean): unknown;
+  public removeOptimistic(id: string): void;
+  public fragmentMatches(
+    fragment: InlineFragmentNode | FragmentDefinitionNode,
+    typename: string
+  ): boolean;
+  public performTransaction(
+    transaction: Transaction,
+    optimisticId?: string | null
+  ): void;
+
+  // a custom method to structurally distinguish this cache
+  // impl from base cache or InMemoryCache
+  public testCacheOnly(): boolean;
+}

--- a/integration-tests/type-tests/cacheOverride/shared/tsconfig.json
+++ b/integration-tests/type-tests/cacheOverride/shared/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../../tsconfig.src.json"
+    }
+  ]
+}

--- a/integration-tests/type-tests/tsconfig.json
+++ b/integration-tests/type-tests/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "./cacheOverride/defaults/tsconfig.json"
     },
     {
+      "path": "./cacheOverride/modernSignature/tsconfig.json"
+    },
+    {
       "path": "./cacheOverride/shared/tsconfig.json"
     },
     {

--- a/integration-tests/type-tests/tsconfig.json
+++ b/integration-tests/type-tests/tsconfig.json
@@ -4,6 +4,12 @@
       "path": "./tsconfig.src.json"
     },
     {
+      "path": "./cacheOverride/defaults/tsconfig.json"
+    },
+    {
+      "path": "./cacheOverride/shared/tsconfig.json"
+    },
+    {
       "path": "./defaultOptions/shared/tsconfig.json"
     },
     {

--- a/integration-tests/type-tests/tsconfig.json
+++ b/integration-tests/type-tests/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "./cacheOverride/defaults/tsconfig.json"
     },
     {
+      "path": "./cacheOverride/invalid/tsconfig.json"
+    },
+    {
       "path": "./cacheOverride/modernSignature/tsconfig.json"
     },
     {

--- a/integration-tests/type-tests/tsconfig.json
+++ b/integration-tests/type-tests/tsconfig.json
@@ -4,6 +4,9 @@
       "path": "./tsconfig.src.json"
     },
     {
+      "path": "./cacheOverride/classicSignature/tsconfig.json"
+    },
+    {
       "path": "./cacheOverride/defaults/tsconfig.json"
     },
     {

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -3,6 +3,7 @@ import type {
   DocumentNode,
   OperationVariables,
   TypedDocumentNode,
+  TypeOverrides,
 } from "@apollo/client";
 import type { Unmasked } from "@apollo/client/masking";
 import type { ExtensionsWithStreamInfo } from "@apollo/client/utilities/internal";
@@ -19,6 +20,9 @@ export declare namespace Cache {
     diff: Cache.DiffResult<TData>,
     lastDiff?: Cache.DiffResult<TData>
   ) => void;
+
+  export type Implementation =
+    TypeOverrides extends { cache: infer TCache } ? TCache : ApolloCache;
 
   export interface ReadOptions<
     TData = unknown,

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,6 +1,7 @@
 import type {
   DataValue,
   DocumentNode,
+  InMemoryCache,
   OperationVariables,
   TypedDocumentNode,
   TypeOverrides,
@@ -26,7 +27,7 @@ export declare namespace Cache {
       TCache extends ApolloCache ?
         TCache
       : ApolloCache
-    : ApolloCache;
+    : InMemoryCache;
 
   export interface ReadOptions<
     TData = unknown,

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -136,7 +136,7 @@ export declare namespace Cache {
   }
 
   export interface BatchOptions<
-    TCache extends ApolloCache,
+    TCache extends Cache.Implementation,
     TUpdateResult = void,
   > {
     /**

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -1,7 +1,6 @@
 import type {
   DataValue,
   DocumentNode,
-  InMemoryCache,
   OperationVariables,
   TypedDocumentNode,
   TypeOverrides,
@@ -27,7 +26,7 @@ export declare namespace Cache {
       TCache extends ApolloCache ?
         TCache
       : "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type."
-    : InMemoryCache;
+    : ApolloCache;
 
   export interface ReadOptions<
     TData = unknown,

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -22,7 +22,11 @@ export declare namespace Cache {
   ) => void;
 
   export type Implementation =
-    TypeOverrides extends { cache: infer TCache } ? TCache : ApolloCache;
+    TypeOverrides extends { cache: infer TCache } ?
+      TCache extends ApolloCache ?
+        TCache
+      : ApolloCache
+    : ApolloCache;
 
   export interface ReadOptions<
     TData = unknown,

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -26,7 +26,7 @@ export declare namespace Cache {
     TypeOverrides extends { cache: infer TCache } ?
       TCache extends ApolloCache ?
         TCache
-      : ApolloCache
+      : "The cache type declared in TypeOverrides does not extend `ApolloCache` and cannot be used with Apollo Client. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type."
     : InMemoryCache;
 
   export interface ReadOptions<

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -283,7 +283,7 @@ export declare namespace ApolloClient {
         <
           TData,
           TVariables extends OperationVariables = OperationVariables,
-          TCache extends ApolloCache = Cache.Implementation,
+          TCache extends Cache.Implementation = Cache.Implementation,
           TErrorPolicy extends ErrorPolicy | undefined = undefined,
         >(
           options: ApolloClient.MutateOptions<TData, TVariables, TCache> &
@@ -1398,7 +1398,7 @@ export class ApolloClient {
   public mutate: ApolloClient.mutate.Signature = <
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TCache extends ApolloCache = Cache.Implementation,
+    TCache extends Cache.Implementation = Cache.Implementation,
   >(
     options: ApolloClient.MutateOptions<TData, TVariables, TCache>
   ): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>> => {

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -511,7 +511,10 @@ export declare namespace ApolloClient {
   /**
    * Options object for the `client.refetchQueries` method.
    */
-  export interface RefetchQueriesOptions<TCache extends ApolloCache, TResult> {
+  export interface RefetchQueriesOptions<
+    TCache extends Cache.Implementation,
+    TResult,
+  > {
     /**
      * Optional function that updates cached fields to trigger refetches of queries that include those fields.
      */
@@ -1847,7 +1850,7 @@ export class ApolloClient {
    * active queries.
    */
   public refetchQueries<
-    TCache extends ApolloCache = Cache.Implementation,
+    TCache extends Cache.Implementation = Cache.Implementation,
     TResult = Promise<ApolloClient.QueryResult<any>>,
   >(
     options: ApolloClient.RefetchQueriesOptions<TCache, TResult>

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -195,7 +195,7 @@ export declare namespace ApolloClient {
   export type MutateOptions<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TCache extends ApolloCache = Cache.Implementation,
+    TCache extends Cache.Implementation = Cache.Implementation,
   > = {
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#optimisticResponse:member} */
     optimisticResponse?:
@@ -247,7 +247,7 @@ export declare namespace ApolloClient {
     export type ResultForOptions<
       TData,
       TVariables extends OperationVariables,
-      TCache extends ApolloCache,
+      TCache extends Cache.Implementation,
       TOptions extends
         | Record<string, unknown>
         | MutateOptions<any, TVariables, TCache>,

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -994,7 +994,7 @@ export declare namespace ApolloClient {
  */
 export class ApolloClient {
   public link: ApolloLink;
-  public cache: ApolloCache;
+  public cache: Cache.Implementation;
   /**
    * @deprecated `disableNetworkFetches` has been renamed to `prioritizeCacheValues`.
    */

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -106,7 +106,7 @@ export declare namespace ApolloClient {
      *
      * For more information, see [Configuring the cache](https://www.apollographql.com/docs/react/caching/cache-configuration/).
      */
-    cache: ApolloCache;
+    cache: Cache.Implementation;
     /**
      * The time interval (in milliseconds) before Apollo Client force-fetches queries after a server-side render.
      *
@@ -195,7 +195,7 @@ export declare namespace ApolloClient {
   export type MutateOptions<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TCache extends ApolloCache = ApolloCache,
+    TCache extends ApolloCache = Cache.Implementation,
   > = {
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#optimisticResponse:member} */
     optimisticResponse?:
@@ -270,7 +270,7 @@ export declare namespace ApolloClient {
           options: ApolloClient.MutateOptions<
             TData,
             TVariables,
-            ApolloCache
+            Cache.Implementation
           > & { errorPolicy?: TErrorPolicy }
         ): Promise<ApolloClient.MutateResult<MaybeMasked<TData>, TErrorPolicy>>;
 
@@ -283,7 +283,7 @@ export declare namespace ApolloClient {
         <
           TData,
           TVariables extends OperationVariables = OperationVariables,
-          TCache extends ApolloCache = ApolloCache,
+          TCache extends ApolloCache = Cache.Implementation,
           TErrorPolicy extends ErrorPolicy | undefined = undefined,
         >(
           options: ApolloClient.MutateOptions<TData, TVariables, TCache> &
@@ -296,12 +296,11 @@ export declare namespace ApolloClient {
         <
           TData,
           TVariables extends OperationVariables,
-          TCache extends ApolloCache,
           // this overload should never be manually defined, it should always be inferred
           TOptions extends ApolloClient.MutateOptions<
             NoInfer<TData>,
             NoInfer<TVariables>,
-            TCache
+            Cache.Implementation
           > &
             VariablesOption<
               TVariables & {
@@ -319,7 +318,7 @@ export declare namespace ApolloClient {
           ApolloClient.mutate.ResultForOptions<
             TData,
             TVariables,
-            TCache,
+            Cache.Implementation,
             TOptions
           >
         >;
@@ -979,7 +978,7 @@ export declare namespace ApolloClient {
     function mutate<
       TData = unknown,
       TVariables extends OperationVariables = OperationVariables,
-      TCache extends ApolloCache = ApolloCache,
+      TCache extends ApolloCache = Cache.Implementation,
     >(
       options: ApolloClient.MutateOptions<TData, TVariables, TCache>
     ): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
@@ -1399,7 +1398,7 @@ export class ApolloClient {
   public mutate: ApolloClient.mutate.Signature = <
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TCache extends ApolloCache = ApolloCache,
+    TCache extends ApolloCache = Cache.Implementation,
   >(
     options: ApolloClient.MutateOptions<TData, TVariables, TCache>
   ): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>> => {
@@ -1848,7 +1847,7 @@ export class ApolloClient {
    * active queries.
    */
   public refetchQueries<
-    TCache extends ApolloCache = ApolloCache,
+    TCache extends ApolloCache = Cache.Implementation,
     TResult = Promise<ApolloClient.QueryResult<any>>,
   >(
     options: ApolloClient.RefetchQueriesOptions<TCache, TResult>

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -982,7 +982,7 @@ export declare namespace ApolloClient {
     function mutate<
       TData = unknown,
       TVariables extends OperationVariables = OperationVariables,
-      TCache extends ApolloCache = Cache.Implementation,
+      TCache extends Cache.Implementation = Cache.Implementation,
     >(
       options: ApolloClient.MutateOptions<TData, TVariables, TCache>
     ): Promise<ApolloClient.MutateResult<MaybeMasked<TData>>>;
@@ -1864,7 +1864,10 @@ export class ApolloClient {
     options: ApolloClient.RefetchQueriesOptions<TCache, TResult>
   ): ApolloClient.RefetchQueriesResult<TResult> {
     const map = this.queryManager.refetchQueries(
-      options as ApolloClient.RefetchQueriesOptions<ApolloCache, TResult>
+      options as ApolloClient.RefetchQueriesOptions<
+        Cache.Implementation,
+        TResult
+      >
     );
     const queries: ObservableQuery<any>[] = [];
     const results: InternalRefetchQueriesResult<TResult>[] = [];

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -62,7 +62,6 @@ import type {
   RefetchQueriesPromiseResults,
   SubscriptionObservable,
   TypedDocumentNode,
-  TypeOverrides,
 } from "./types.js";
 import type {
   ErrorPolicy,
@@ -1053,14 +1052,7 @@ export class ApolloClient {
    * });
    * ```
    */
-  constructor(options: ApolloClient.Options);
-  constructor(
-    options: TypeOverrides extends { cache: any } ? ApolloClient.Options
-    : {
-        cache: "Using a cache other than `InMemoryCache` requires a cache type declared in TypeOverrides. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.";
-      }
-  );
-  constructor(options: any) {
+  constructor(options: ApolloClient.Options) {
     if (__DEV__) {
       invariant(
         options.cache,
@@ -1093,7 +1085,7 @@ export class ApolloClient {
       incrementalHandler = new NotImplementedHandler(),
       experiments = [],
       refetchEventManager,
-    } = options as ApolloClient.Options;
+    } = options;
 
     this.link = link;
     this.cache = cache;

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -62,6 +62,7 @@ import type {
   RefetchQueriesPromiseResults,
   SubscriptionObservable,
   TypedDocumentNode,
+  TypeOverrides,
 } from "./types.js";
 import type {
   ErrorPolicy,
@@ -1052,7 +1053,14 @@ export class ApolloClient {
    * });
    * ```
    */
-  constructor(options: ApolloClient.Options) {
+  constructor(options: ApolloClient.Options);
+  constructor(
+    options: TypeOverrides extends { cache: any } ? ApolloClient.Options
+    : {
+        cache: "Using a cache other than `InMemoryCache` requires a cache type declared in TypeOverrides. See https://www.apollographql.com/docs/react/data/typescript#declaring-the-cache-type.";
+      }
+  );
+  constructor(options: any) {
     if (__DEV__) {
       invariant(
         options.cache,
@@ -1085,7 +1093,7 @@ export class ApolloClient {
       incrementalHandler = new NotImplementedHandler(),
       experiments = [],
       refetchEventManager,
-    } = options;
+    } = options as ApolloClient.Options;
 
     this.link = link;
     this.cache = cache;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -24,7 +24,7 @@ import {
   tap,
 } from "rxjs";
 
-import type { ApolloCache, Cache } from "@apollo/client/cache";
+import type { Cache } from "@apollo/client/cache";
 import { canonicalStringify } from "@apollo/client/cache";
 import {
   CombinedGraphQLErrors,
@@ -268,7 +268,7 @@ export class QueryManager {
   public async mutate<
     TData,
     TVariables extends OperationVariables,
-    TCache extends ApolloCache,
+    TCache extends Cache.Implementation,
   >({
     mutation,
     variables,
@@ -1329,7 +1329,7 @@ export class QueryManager {
     removeOptimistic = optimistic ? makeUniqueId("refetchQueries") : void 0,
     onQueryUpdated,
   }: InternalRefetchQueriesOptions<
-    ApolloCache,
+    Cache.Implementation,
     TResult
   >): InternalRefetchQueriesMap<TResult> {
     const includedQueriesByOq = new Map<

--- a/src/core/deprecated.ts
+++ b/src/core/deprecated.ts
@@ -1,4 +1,4 @@
-import type { ApolloCache } from "@apollo/client/cache";
+import type { Cache } from "@apollo/client/cache";
 
 import type { ApolloClient } from "./ApolloClient.js";
 import type { ObservableQuery } from "./ObservableQuery.js";
@@ -23,7 +23,7 @@ export type DevtoolsOptions = ApolloClient.DevtoolsOptions;
 export type MutationOptions<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
-  TCache extends ApolloCache = ApolloCache,
+  TCache extends Cache.Implementation = Cache.Implementation,
 > = ApolloClient.MutateOptions<TData, TVariables, TCache>;
 
 /** @deprecated Use `ApolloClient.MutateResult` instead */
@@ -38,7 +38,7 @@ export type QueryOptions<
 
 /** @deprecated Use `ApolloClient.RefetchQueriesOptions` instead */
 export type RefetchQueriesOptions<
-  TCache extends ApolloCache,
+  TCache extends Cache.Implementation,
   TResult,
 > = ApolloClient.RefetchQueriesOptions<TCache, TResult>;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -361,7 +361,7 @@ export type MutationQueryReducersMap<T = { [key: string]: any }> = {
 export type MutationUpdaterFunction<
   TData,
   TVariables extends OperationVariables,
-  TCache extends ApolloCache,
+  TCache extends Cache.Implementation,
 > = (
   cache: TCache,
   result: FormattedExecutionResult<Unmasked<TData>>,

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,4 +1,4 @@
-import type { InternalTypes } from "@apollo/client";
+import type { ApolloCache, InternalTypes } from "@apollo/client";
 
 declare module "@apollo/client" {
   // in our own codebase, we have to account for all possible `defaultOptions`s
@@ -8,5 +8,9 @@ declare module "@apollo/client" {
       interface Query {}
       interface Mutate {}
     }
+  }
+
+  export interface TypeOverrides {
+    cache: ApolloCache;
   }
 }

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -19,7 +19,7 @@ import type {
   OperationVariables,
   Unmasked,
 } from "@apollo/client";
-import type { IgnoreModifier } from "@apollo/client/cache";
+import type { Cache, IgnoreModifier } from "@apollo/client/cache";
 import type {
   LazyType,
   NoInfer,
@@ -66,7 +66,7 @@ export declare namespace useMutation {
   export interface Options<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TCache extends ApolloCache = ApolloCache,
+    TCache extends ApolloCache = Cache.Implementation,
     TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>,
   > {
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#optimisticResponse:member} */
@@ -207,7 +207,7 @@ export declare namespace useMutation {
   export type ResultTuple<
     TData,
     TVariables extends OperationVariables,
-    TCache extends ApolloCache = ApolloCache,
+    TCache extends ApolloCache = Cache.Implementation,
     TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = [
     mutate: MutationFunction<TData, TVariables, TCache, TErrorPolicy>,
@@ -217,7 +217,7 @@ export declare namespace useMutation {
   export type MutationFunction<
     TData,
     TVariables extends OperationVariables,
-    TCache extends ApolloCache = ApolloCache,
+    TCache extends ApolloCache = Cache.Implementation,
     TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = (
     ...[options]: {} extends TVariables ?
@@ -238,7 +238,7 @@ export declare namespace useMutation {
   export type MutationFunctionOptions<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TCache extends ApolloCache = ApolloCache,
+    TCache extends ApolloCache = Cache.Implementation,
   > = Options<TData, TVariables, TCache> & {
     /**
      * {@inheritDoc @apollo/client!MutationOptionsDocumentation#context:member}
@@ -357,7 +357,7 @@ export declare namespace useMutation {
         options?: useMutation.Options<
           NoInfer<TData>,
           NoInfer<TVariables>,
-          ApolloCache,
+          Cache.Implementation,
           {
             [K in keyof TConfiguredVariables]: K extends keyof TVariables ?
               TConfiguredVariables[K]
@@ -370,7 +370,7 @@ export declare namespace useMutation {
       ): useMutation.ResultTuple<
         TData,
         MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>,
-        ApolloCache,
+        Cache.Implementation,
         TErrorPolicy
       >;
 
@@ -383,7 +383,7 @@ export declare namespace useMutation {
       <
         TData,
         TVariables extends OperationVariables = OperationVariables,
-        TCache extends ApolloCache = ApolloCache,
+        TCache extends ApolloCache = Cache.Implementation,
         TConfiguredVariables extends Partial<TVariables> = {},
         TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
@@ -417,7 +417,6 @@ export declare namespace useMutation {
       <
         TData,
         TVariables extends OperationVariables,
-        TCache extends ApolloCache,
         // this overload should never be manually defined, it should always be inferred
         TOptions extends never,
       >(
@@ -425,7 +424,7 @@ export declare namespace useMutation {
       ): useMutation.ResultForOptions<
         TData,
         TVariables,
-        TCache,
+        Cache.Implementation,
         Record<string, never>
       >;
 
@@ -433,12 +432,11 @@ export declare namespace useMutation {
       <
         TData,
         TVariables extends OperationVariables,
-        TCache extends ApolloCache,
         // this overload should never be manually defined, it should always be inferred
         TOptions extends useMutation.Options<
           NoInfer<TData>,
           NoInfer<TVariables>,
-          TCache
+          Cache.Implementation
         > & {
           variables?: {
             [K in Exclude<
@@ -457,7 +455,7 @@ export declare namespace useMutation {
       ): useMutation.ResultForOptions<
         TData,
         TVariables,
-        TCache,
+        Cache.Implementation,
         TOptions,
         TErrorPolicy
       >;
@@ -474,7 +472,7 @@ export declare namespace useMutation {
 export const useMutation: useMutation.Signature = function useMutation<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
-  TCache extends ApolloCache = ApolloCache,
+  TCache extends ApolloCache = Cache.Implementation,
   TConfiguredVariables extends Partial<TVariables> = {},
 >(
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -3,7 +3,6 @@ import { equal } from "@wry/equality";
 import * as React from "react";
 
 import type {
-  ApolloCache,
   ApolloClient,
   DefaultContext,
   DocumentNode,
@@ -66,7 +65,7 @@ export declare namespace useMutation {
   export interface Options<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TCache extends ApolloCache = Cache.Implementation,
+    TCache extends Cache.Implementation = Cache.Implementation,
     TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>,
   > {
     /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#optimisticResponse:member} */
@@ -207,7 +206,7 @@ export declare namespace useMutation {
   export type ResultTuple<
     TData,
     TVariables extends OperationVariables,
-    TCache extends ApolloCache = Cache.Implementation,
+    TCache extends Cache.Implementation = Cache.Implementation,
     TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = [
     mutate: MutationFunction<TData, TVariables, TCache, TErrorPolicy>,
@@ -217,7 +216,7 @@ export declare namespace useMutation {
   export type MutationFunction<
     TData,
     TVariables extends OperationVariables,
-    TCache extends ApolloCache = Cache.Implementation,
+    TCache extends Cache.Implementation = Cache.Implementation,
     TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = (
     ...[options]: {} extends TVariables ?
@@ -238,7 +237,7 @@ export declare namespace useMutation {
   export type MutationFunctionOptions<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-    TCache extends ApolloCache = Cache.Implementation,
+    TCache extends Cache.Implementation = Cache.Implementation,
   > = Options<TData, TVariables, TCache> & {
     /**
      * {@inheritDoc @apollo/client!MutationOptionsDocumentation#context:member}
@@ -258,7 +257,7 @@ export declare namespace useMutation {
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
-    TCache extends ApolloCache,
+    TCache extends Cache.Implementation,
     TOptions extends Record<string, never> | Options<TData, TVariables, TCache>,
     TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = LazyType<
@@ -383,7 +382,7 @@ export declare namespace useMutation {
       <
         TData,
         TVariables extends OperationVariables = OperationVariables,
-        TCache extends ApolloCache = Cache.Implementation,
+        TCache extends Cache.Implementation = Cache.Implementation,
         TConfiguredVariables extends Partial<TVariables> = {},
         TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
@@ -472,7 +471,7 @@ export declare namespace useMutation {
 export const useMutation: useMutation.Signature = function useMutation<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
-  TCache extends ApolloCache = Cache.Implementation,
+  TCache extends Cache.Implementation = Cache.Implementation,
   TConfiguredVariables extends Partial<TVariables> = {},
 >(
   mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,


### PR DESCRIPTION
Currently `client.cache` always return an `ApolloCache` type, regardless of the actual `cache` instance you provide to `ApolloClient`. This can be slightly annoying in cases where you might want to access `cache` through `client.cache` and work directly with e.g. `InMemoryCache` specific APIs. Currently this requires a type override, or access to the original `cache` instance from elsewhere in your app.

This PR adds the ability to specify the cache implementation in the `TypeOverrides` interface using the `cache` property. Anywhere `cache` is accessible, its type will be the override type (e.g. `client.cache // => InMemoryCache`). To ensure the runtime value matches the declared type, `ApolloClient.Options` has been updated to enforce the implemented type.

```ts
// apollo.d.ts
import type { InMemoryCache } from "@apollo/client";

declare module "@apollo/client" {
  export interface TypeOverrides {
    cache: InMemoryCache;
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client cache typing can be customized via TypeScript augmentation and now propagates to client.cache, mutation/refetch callbacks, and React hooks for stronger, consistent type safety.

* **Tests**
  * Added comprehensive type tests covering classic/modern signatures and hook scenarios to validate cache-override behavior.

* **Documentation**
  * Added guidance and examples showing how to declare a custom cache type and how it affects client APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->