### PR TITLE
Bump testing matrix to use GraphQL 17 rc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ workflows:
               externalPackage:
                 - "graphql@15"
                 - "graphql@16"
-                - "graphql@^17.0.0-alpha"
+                - "graphql@^17.0.0-rc"
                 - "@types/react@17 @types/react-dom@17"
                 - "@types/react@18 @types/react-dom@18"
                 - "@types/react@19 @types/react-dom@19"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,6 @@ workflows:
           matrix:
             parameters:
               externalPackage:
-                - "graphql@15"
                 - "graphql@16"
                 - "graphql@^17.0.0-rc"
                 - "@types/react@17 @types/react-dom@17"


### PR DESCRIPTION
Bumps the testing matrix to use graphql.js v17 rc. A followup PR will bump the peer dependency for it.

This PR also removes testing for graphql 15. We don't support it in package.json   so no need to test for this anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to adjust GraphQL compatibility testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->