### PR TITLE
Only run cleanup checks for non-fork PRs

### DIFF
--- a/.github/workflows/cleanup-checks.yml
+++ b/.github/workflows/cleanup-checks.yml
@@ -15,6 +15,7 @@ jobs:
       pull-requests: write
     if: |
       github.repository == 'apollographql/apollo-client' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.review.state == 'APPROVED' &&
       github.event.review.author_association == 'MEMBER' &&
       contains(github.event.pull_request.labels.*.name, 'auto-cleanup') == false
@@ -36,6 +37,7 @@ jobs:
       contents: write
     if: |
       github.repository == 'apollographql/apollo-client' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.labels.*.name, 'auto-cleanup')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Cleanup checks always fail in fork PRs since the GitHub token is read-only. This PR skips the cleanup tasks for fork PRs to avoid unnecessary failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automation workflow safety by restricting cleanup operations to authorized pull requests with additional validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->