### PR TITLE
Temporarily disable slack notifications for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,59 +80,59 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ""
 
-  slack-notification:
-    name: Postrelease Slack Notification
-    runs-on: ubuntu-latest
-    needs: release
-    if: needs.release.result == 'success' && needs.release.outputs.published == 'true'
-    strategy:
-      matrix:
-        package: ${{ fromJSON(needs.release.outputs.publishedPackages) }}
-    steps:
-      - name: Send a Slack notification on publish
-        id: slack
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
-        with:
-          # Slack channel id, channel name, or user id to post message
-          # See also: https://api.slack.com/methods/chat.postMessage#channels
-          # You can pass in multiple channels to post to by providing
-          # a comma-delimited list of channel IDs
-          channel-id: "C01PS0CB41G"
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "A new version of `{{ matrix.package.name }}` was released :rocket:"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Version:*\n`${{ matrix.package.version }}`"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Tag:*\n`${{ github.ref_name == 'main' && 'latest' || 'next' }}`"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*GitHub release:*\n<https://github.com/apollographql/apollo-client/releases/tag/${{ matrix.package.name }}@${{ matrix.package.version }}|link>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*npm releases:*\n<https://www.npmjs.com/package/@apollo/client?activeTab=versions|link>"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  # slack-notification:
+  #   name: Postrelease Slack Notification
+  #   runs-on: ubuntu-latest
+  #   needs: release
+  #   if: needs.release.result == 'success' && needs.release.outputs.published == 'true'
+  #   strategy:
+  #     matrix:
+  #       package: ${{ fromJSON(needs.release.outputs.publishedPackages) }}
+  #   steps:
+  #     - name: Send a Slack notification on publish
+  #       id: slack
+  #       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
+  #       with:
+  #         # Slack channel id, channel name, or user id to post message
+  #         # See also: https://api.slack.com/methods/chat.postMessage#channels
+  #         # You can pass in multiple channels to post to by providing
+  #         # a comma-delimited list of channel IDs
+  #         channel-id: "C01PS0CB41G"
+  #         payload: |
+  #           {
+  #             "blocks": [
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": "A new version of `{{ matrix.package.name }}` was released :rocket:"
+  #                 }
+  #               },
+  #               {
+  #                 "type": "section",
+  #                 "fields": [
+  #                   {
+  #                     "type": "mrkdwn",
+  #                     "text": "*Version:*\n`${{ matrix.package.version }}`"
+  #                   },
+  #                   {
+  #                     "type": "mrkdwn",
+  #                     "text": "*Tag:*\n`${{ github.ref_name == 'main' && 'latest' || 'next' }}`"
+  #                   },
+  #                   {
+  #                     "type": "mrkdwn",
+  #                     "text": "*GitHub release:*\n<https://github.com/apollographql/apollo-client/releases/tag/${{ matrix.package.name }}@${{ matrix.package.version }}|link>"
+  #                   },
+  #                   {
+  #                     "type": "mrkdwn",
+  #                     "text": "*npm releases:*\n<https://www.npmjs.com/package/@apollo/client?activeTab=versions|link>"
+  #                   }
+  #                 ]
+  #               }
+  #             ]
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   tag-next:
     name: Postrelease Tag Next Release


### PR DESCRIPTION
This task currently fails on every release so I'm disabling it until we dig into this more. We may not want it anymore anyways now that we are using staged publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->