### PR TITLE
[Custom scalars] Implement `scalar` option in field policies with cache reads

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -495,6 +495,7 @@ export type FieldPolicy<TExisting = any, TIncoming = TExisting, TReadResult = TI
     keyArgs?: KeySpecifier | KeyArgsFunction | false;
     read?: FieldReadFunction<TExisting, TReadResult, TReadOptions>;
     merge?: FieldMergeFunction<TExisting, TIncoming, TMergeOptions> | boolean;
+    scalar?: ScalarNames;
 };
 
 // @public (undocumented)
@@ -873,6 +874,8 @@ export class Policies {
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
     // (undocumented)
+    maybeCoerceScalarValue(value: StoreValue, options: ReadFieldOptions, context: ReadMergeModifyContext): any;
+    // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)
     readonly rootIdsByTypename: Record<string, string>;
@@ -997,6 +1000,9 @@ export class Scalar<TSerialized, TParsed> {
 }
 
 // @public (undocumented)
+type ScalarNames = keyof KnownScalars | (string extends keyof ApolloCache.Scalars ? string & {} : never);
+
+// @public (undocumented)
 type StorageType = Record<string, any>;
 
 export { StoreObject }
@@ -1078,9 +1084,10 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:136:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:178:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -346,6 +346,14 @@ export { canonicalStringify }
 type CanReadFunction = (value: StoreValue) => boolean;
 
 // @public (undocumented)
+interface CoerceValueOptions {
+    // (undocumented)
+    field: FieldNode;
+    // (undocumented)
+    typename: string;
+}
+
+// @public (undocumented)
 export function createFragmentRegistry(...fragments: DocumentNode[]): FragmentRegistryAPI;
 
 // Warning: (ae-forgotten-export) The symbol "KeyFieldsContext" needs to be exported by the entry point index.d.ts
@@ -873,8 +881,10 @@ export class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
+    // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    maybeCoerceScalarValue(value: StoreValue, options: ReadFieldOptions, context: ReadMergeModifyContext): any;
+    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
     // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1327,6 +1327,7 @@ export type FieldPolicy<TExisting = any, TIncoming = TExisting, TReadResult = TI
     keyArgs?: KeySpecifier | KeyArgsFunction | false;
     read?: FieldReadFunction<TExisting, TReadResult, TReadOptions>;
     merge?: FieldMergeFunction<TExisting, TIncoming, TMergeOptions> | boolean;
+    scalar?: ScalarNames;
 };
 
 // @public (undocumented)
@@ -2374,6 +2375,8 @@ class Policies {
     // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
+    maybeCoerceScalarValue(value: StoreValue, options: ReadFieldOptions, context: ReadMergeModifyContext): any;
+    // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)
     readonly rootIdsByTypename: Record<string, string>;
@@ -2823,6 +2826,9 @@ export class Scalar<TSerialized, TParsed> {
     serialize(value: TParsed): TSerialized;
 }
 
+// @public (undocumented)
+type ScalarNames = keyof KnownScalars | (string extends keyof ApolloCache.Scalars ? string & {} : never);
+
 // Warning: (ae-forgotten-export) The symbol "HttpConfig" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -3139,11 +3145,12 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/core/cache.ts:127:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:101:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:136:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:143:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:103:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:178:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:146:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:201:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:633:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -947,6 +947,14 @@ class ClientAwarenessLink extends ApolloLink {
 }
 
 // @public (undocumented)
+interface CoerceValueOptions {
+    // (undocumented)
+    field: FieldNode;
+    // (undocumented)
+    typename: string;
+}
+
+// @public (undocumented)
 export namespace CombinedGraphQLErrors {
     // (undocumented)
     export namespace DocumentationTypes {
@@ -2372,10 +2380,12 @@ class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
-    // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    maybeCoerceScalarValue(value: StoreValue, options: ReadFieldOptions, context: ReadMergeModifyContext): any;
+    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
+    // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)

--- a/.changeset/strong-shoes-sell.md
+++ b/.changeset/strong-shoes-sell.md
@@ -1,0 +1,28 @@
+---
+"@apollo/client": minor
+---
+
+Adds a `scalar` option to `InMemoryCache` field policies that dictates whether to parse the raw value using the custom scalar definition. Scalar parsing is now performed on cache reads.
+
+```ts
+import { Scalar } from "@apollo/client";
+
+new InMemoryCache({
+  scalars: {
+    DateTime: new Scalar({
+      parse: (dateString) => new Date(dateString),
+      serialize: (date) => date.toISOString(),
+    }),
+  },
+  typePolicies: {
+    Event: {
+      fields: {
+        startTime: {
+          // Parse this field using the DateTime scalar
+          scalar: "DateTime",
+        },
+      },
+    },
+  },
+});
+```

--- a/integration-tests/type-tests/customScalars/all-any/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/differentTypes/index.ts
@@ -209,3 +209,26 @@ test("InMemoryCache.getScalar returns the resolved scalar for a declared scalar"
     Scalar<any, any> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-any/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/empty/index.ts
@@ -152,3 +152,20 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<any, any> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-any/matchingTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/matchingTypes/index.ts
@@ -228,3 +228,23 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<any, any> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+          unknown: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-any/mixed/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/mixed/index.ts
@@ -128,3 +128,29 @@ test("getScalar resolves each scalar according to its declaration", () => {
     Scalar<any, any> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          endDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-structured/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/differentTypes/index.ts
@@ -32,3 +32,27 @@ test("a transforming scalar that conflicts with the index cannot be configured",
     },
   });
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    // @ts-expect-error `DateTime` is not assignable to index signature
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value: Date) => value.toISOString(),
+        parse: (value: string) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-structured/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/empty/index.ts
@@ -150,3 +150,20 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<string, string> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-structured/matchingTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/matchingTypes/index.ts
@@ -113,3 +113,23 @@ test("getScalar resolves each scalar according to its declaration", () => {
     Scalar<string, string> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+          unknown: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-structured/mixed/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/mixed/index.ts
@@ -38,3 +38,34 @@ test("a transforming scalar conflicting with the index blocks configuration", ()
     },
   });
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    // @ts-expect-error `DateTime` is not assignable to index signature
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+      RelativeDate: new Scalar({
+        serialize: (value) => value,
+        parse: (value) => value,
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          endDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-unknown/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/differentTypes/index.ts
@@ -210,3 +210,26 @@ test("InMemoryCache.getScalar returns the resolved scalar for a declared scalar"
     Scalar<unknown, unknown> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-unknown/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/empty/index.ts
@@ -156,3 +156,20 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<unknown, unknown> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-unknown/matchingTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/matchingTypes/index.ts
@@ -230,3 +230,23 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<unknown, unknown> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+          unknown: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-unknown/mixed/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/mixed/index.ts
@@ -129,3 +129,29 @@ test("getScalar resolves each scalar according to its declaration", () => {
     Scalar<unknown, unknown> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          endDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/differentTypes/index.ts
@@ -171,3 +171,27 @@ test("InMemoryCache.getScalar returns the resolved scalar for a declared scalar"
   // @ts-expect-error not a declared scalar
   cache.getScalar("Unknown");
 });
+
+test("allows only defined scalars field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            // @ts-expect-error scalar not registered
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/empty/index.ts
@@ -20,3 +20,18 @@ test("getScalar cannot be called without a declared scalar", () => {
   // @ts-expect-error no scalars are declared
   cache.getScalar("DateTime");
 });
+
+test("does not allow any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            // @ts-expect-error no scalars are declared
+            scalar: "DateTime",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/matchingTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/matchingTypes/index.ts
@@ -182,3 +182,24 @@ test("getScalar returns the resolved scalar or undefined", () => {
   // @ts-expect-error not a declared scalar
   cache.getScalar("Unknown");
 });
+
+test("allows only defined scalars in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+          unknown: {
+            // @ts-expect-error scalar not registered
+            scalar: "DateTime",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/mixed/index.ts
+++ b/integration-tests/type-tests/customScalars/mixed/index.ts
@@ -118,3 +118,30 @@ test("getScalar resolves each scalar according to its declaration", () => {
   // @ts-expect-error not a declared scalar
   cache.getScalar("Unknown");
 });
+
+test("allows only defined scalars in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          endDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            // @ts-expect-error scalar not registered
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -358,3 +358,50 @@ test("parses object-based scalar values (e.g. JSON) when reading from cache", ()
     },
   });
 });
+
+test("parses primitive-to-primitive scalar values when reading from cache", () => {
+  const priceScalar = new Scalar<number, string>({
+    serialize: (dollars) => Math.round(parseFloat(dollars) * 100),
+    parse: (cents) => `${(cents / 100).toFixed(2)}`,
+    is: (value) => typeof value === "string",
+  });
+
+  const cache = new InMemoryCache({
+    scalars: { Price: priceScalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          price: { scalar: "Price" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      product {
+        id
+        price
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      product: {
+        __typename: "Product",
+        id: "1",
+        price: 1099,
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    product: {
+      __typename: "Product",
+      id: "1",
+      price: "10.99",
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -308,3 +308,53 @@ test("returns null as-is when null is stored in a scalar field position", () => 
     },
   });
 });
+
+test("parses object-based scalar values (e.g. JSON) when reading from cache", () => {
+  const scalar = new Scalar<Record<string, unknown>, Map<string, unknown>>({
+    serialize: (value) => Object.fromEntries(value),
+    parse: (value) => new Map(Object.entries(value)),
+    is: (value) => value instanceof Map,
+  });
+
+  const cache = new InMemoryCache({
+    scalars: { JSONObject: scalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      product {
+        id
+        metadata
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      product: {
+        __typename: "Product",
+        id: "1",
+        metadata: { color: "red", size: "large" },
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    product: {
+      __typename: "Product",
+      id: "1",
+      metadata: new Map([
+        ["color", "red"],
+        ["size", "large"],
+      ]),
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -12,6 +12,15 @@ const priceScalar = new Scalar<number, string>({
   is: (value) => typeof value === "string",
 });
 
+const jsonObjectScalar = new Scalar<
+  Record<string, unknown>,
+  Map<string, unknown>
+>({
+  serialize: (value) => Object.fromEntries(value),
+  parse: (value) => new Map(Object.entries(value)),
+  is: (value) => value instanceof Map,
+});
+
 test("getScalar returns a scalar object for a configured scalar", () => {
   const cache = new InMemoryCache({
     scalars: {
@@ -316,14 +325,8 @@ test("returns null as-is when null is stored in a scalar field position", () => 
 });
 
 test("parses object-based scalar values (e.g. JSON) when reading from cache", () => {
-  const scalar = new Scalar<Record<string, unknown>, Map<string, unknown>>({
-    serialize: (value) => Object.fromEntries(value),
-    parse: (value) => new Map(Object.entries(value)),
-    is: (value) => value instanceof Map,
-  });
-
   const cache = new InMemoryCache({
-    scalars: { JSONObject: scalar },
+    scalars: { JSONObject: jsonObjectScalar },
     typePolicies: {
       Product: {
         fields: {
@@ -714,5 +717,238 @@ test("parses scalar values when fields are selected through an interface fragmen
         startTime: new Date("2026-01-02T14:00:00.000Z"),
       },
     ],
+  });
+});
+
+test("parses scalar values across a complex nested query", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+      Price: priceScalar,
+      JSONObject: jsonObjectScalar,
+    },
+    possibleTypes: {
+      Schedulable: ["Session", "Workshop"],
+    },
+    typePolicies: {
+      Conference: {
+        fields: {
+          startDate: { scalar: "DateTime" },
+          endDate: { scalar: "DateTime" },
+          ticketPrice: { scalar: "Price" },
+        },
+      },
+      Schedule: {
+        fields: {
+          timeSlots: { scalar: "DateTime" },
+        },
+      },
+      Speaker: {
+        fields: {
+          availableTimes: { scalar: "DateTime" },
+        },
+      },
+      Session: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+      Workshop: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+      VirtualPresenter: {
+        fields: { nextSession: { scalar: "DateTime" } },
+      },
+      InPersonPresenter: {
+        fields: { arrivalTime: { scalar: "DateTime" } },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      conference {
+        id
+        name
+        startDate
+        endDate
+        ticketPrice
+        schedule {
+          timeSlots
+        }
+        ...SpeakerListFields
+        scheduledItems {
+          __typename
+          ...SchedulableFields
+        }
+        presenters {
+          __typename
+          ... on VirtualPresenter {
+            id
+            name
+            nextSession
+          }
+          ... on InPersonPresenter {
+            id
+            name
+            arrivalTime
+          }
+        }
+      }
+    }
+
+    fragment SpeakerListFields on Conference {
+      speakers {
+        id
+        name
+        availableTimes
+      }
+    }
+
+    fragment SchedulableFields on Schedulable {
+      id
+      startTime
+      metadata
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      conference: {
+        __typename: "Conference",
+        id: "conf-1",
+        name: "GraphQL Summit",
+        startDate: "2026-09-15T09:00:00.000Z",
+        endDate: null,
+        ticketPrice: 19900,
+        schedule: {
+          __typename: "Schedule",
+          timeSlots: [
+            ["2026-09-15T09:00:00.000Z", "2026-09-15T10:00:00.000Z"],
+            ["2026-09-15T14:00:00.000Z", "2026-09-15T15:00:00.000Z"],
+          ],
+        },
+        speakers: [
+          {
+            __typename: "Speaker",
+            id: "speaker-1",
+            name: "Alice",
+            availableTimes: [
+              "2026-09-15T09:00:00.000Z",
+              "2026-09-15T14:00:00.000Z",
+            ],
+          },
+          {
+            __typename: "Speaker",
+            id: "speaker-2",
+            name: "Bob",
+            // null is valid in a scalar array
+            availableTimes: ["2026-09-15T10:00:00.000Z", null],
+          },
+        ],
+        scheduledItems: [
+          {
+            __typename: "Session",
+            id: "session-1",
+            startTime: "2026-09-15T09:00:00.000Z",
+            metadata: { dress: "casual" },
+          },
+          {
+            __typename: "Workshop",
+            id: "workshop-1",
+            startTime: "2026-09-15T14:00:00.000Z",
+            metadata: { venue: "The Workshop Building" },
+          },
+        ],
+        presenters: [
+          {
+            __typename: "VirtualPresenter",
+            id: "vp-1",
+            name: "Charlie",
+            nextSession: "2026-09-15T09:00:00.000Z",
+          },
+          {
+            __typename: "InPersonPresenter",
+            id: "ip-1",
+            name: "Diana",
+            arrivalTime: "2026-09-14T18:00:00.000Z",
+          },
+        ],
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    conference: {
+      __typename: "Conference",
+      id: "conf-1",
+      name: "GraphQL Summit",
+      startDate: new Date("2026-09-15T09:00:00.000Z"),
+      endDate: null,
+      ticketPrice: "199.00",
+      schedule: {
+        __typename: "Schedule",
+        timeSlots: [
+          [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T10:00:00.000Z"),
+          ],
+          [
+            new Date("2026-09-15T14:00:00.000Z"),
+            new Date("2026-09-15T15:00:00.000Z"),
+          ],
+        ],
+      },
+      speakers: [
+        {
+          __typename: "Speaker",
+          id: "speaker-1",
+          name: "Alice",
+          availableTimes: [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T14:00:00.000Z"),
+          ],
+        },
+        {
+          __typename: "Speaker",
+          id: "speaker-2",
+          name: "Bob",
+          availableTimes: [new Date("2026-09-15T10:00:00.000Z"), null],
+        },
+      ],
+      scheduledItems: [
+        {
+          __typename: "Session",
+          id: "session-1",
+          startTime: new Date("2026-09-15T09:00:00.000Z"),
+          metadata: new Map([["dress", "casual"]]),
+        },
+        {
+          __typename: "Workshop",
+          id: "workshop-1",
+          startTime: new Date("2026-09-15T14:00:00.000Z"),
+          metadata: new Map([["venue", "The Workshop Building"]]),
+        },
+      ],
+      presenters: [
+        {
+          __typename: "VirtualPresenter",
+          id: "vp-1",
+          name: "Charlie",
+          nextSession: new Date("2026-09-15T09:00:00.000Z"),
+        },
+        {
+          __typename: "InPersonPresenter",
+          id: "ip-1",
+          name: "Diana",
+          arrivalTime: new Date("2026-09-14T18:00:00.000Z"),
+        },
+      ],
+    },
   });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -267,3 +267,44 @@ test("parses each leaf element when the scalar field contains a 2D array", () =>
     },
   });
 });
+
+test("returns null as-is when null is stored in a scalar field position", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          endTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        endTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        endTime: null,
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      endTime: null,
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1,6 +1,9 @@
 import { gql } from "@apollo/client";
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
-import { spyOnConsole } from "@apollo/client/testing/internal";
+import {
+  ObservableStream,
+  spyOnConsole,
+} from "@apollo/client/testing/internal";
 
 const dateTimeScalar = new Scalar<string, Date>({
   serialize: (value) => value.toISOString(),
@@ -952,6 +955,92 @@ test("parses scalar values across a complex nested query", () => {
       ],
     },
   });
+});
+
+test("parses scalar values on each emit from cache.watchFragment", async () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T09:00:00.000Z",
+    },
+  });
+
+  using stream = new ObservableStream(
+    cache.watchFragment({
+      fragment,
+      from: { __typename: "Event", id: "1" },
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T09:00:00.000Z"),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-06-15T14:30:00.000Z",
+    },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-06-15T14:30:00.000Z"),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-12-31T23:59:59.000Z",
+    },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-12-31T23:59:59.000Z"),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
 });
 
 test("ignores scalar and emits a dev warning when a scalar option is set on a field with a selection set", () => {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -38,8 +38,8 @@ test("serialize uses the configured serialize function", () => {
 
   const scalar = cache.getScalar("DateTime")!;
 
-  expect(scalar.serialize(new Date("2024-01-01T00:00:00.000Z"))).toBe(
-    "2024-01-01T00:00:00.000Z"
+  expect(scalar.serialize(new Date("2026-01-01T00:00:00.000Z"))).toBe(
+    "2026-01-01T00:00:00.000Z"
   );
 });
 
@@ -55,8 +55,8 @@ test("parse uses the configured parse function", () => {
 
   const scalar = cache.getScalar("DateTime")!;
 
-  expect(scalar.parse("2024-01-01T00:00:00.000Z")).toEqual(
-    new Date("2024-01-01T00:00:00.000Z")
+  expect(scalar.parse("2026-01-01T00:00:00.000Z")).toEqual(
+    new Date("2026-01-01T00:00:00.000Z")
   );
 });
 
@@ -72,8 +72,8 @@ test("is defaults to a non-null object check when not configured", () => {
 
   const scalar = cache.getScalar("DateTime")!;
 
-  expect(scalar.is(new Date("2024-01-01T00:00:00.000Z"))).toBe(true);
-  expect(scalar.is("2024-01-01T00:00:00.000Z")).toBe(false);
+  expect(scalar.is(new Date("2026-01-01T00:00:00.000Z"))).toBe(true);
+  expect(scalar.is("2026-01-01T00:00:00.000Z")).toBe(false);
 });
 
 test("is uses the configured type guard when configured", () => {
@@ -89,6 +89,6 @@ test("is uses the configured type guard when configured", () => {
 
   const scalar = cache.getScalar("DateTime")!;
 
-  expect(scalar.is(new Date("2024-01-01T00:00:00.000Z"))).toBe(true);
+  expect(scalar.is(new Date("2026-01-01T00:00:00.000Z"))).toBe(true);
   expect(scalar.is(new Date("invalid"))).toBe(false);
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1139,3 +1139,177 @@ test("ignores scalar and emits a dev warning when a scalar option is set on a fi
     "DateTime"
   );
 });
+
+test("deep merges scalar option with policies.addTypePolices", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+      Price: priceScalar,
+      JSONObject: jsonObjectScalar,
+    },
+    typePolicies: {
+      Conference: {
+        fields: {
+          startDate: { scalar: "DateTime" },
+          endDate: { merge: (_, incoming) => incoming },
+        },
+      },
+      Schedule: {
+        fields: {
+          timeSlots: { scalar: "Price" },
+        },
+      },
+      Speaker: {
+        fields: {
+          availableTimes: { keyArgs: false },
+        },
+      },
+    },
+  });
+
+  cache.policies.addTypePolicies({
+    Conference: {
+      fields: {
+        endDate: { scalar: "DateTime" },
+        ticketPrice: { scalar: "Price" },
+      },
+    },
+    Schedule: {
+      fields: {
+        timeSlots: { scalar: "DateTime" },
+      },
+    },
+    Speaker: {
+      fields: {
+        availableTimes: { scalar: "DateTime" },
+      },
+    },
+    Session: {
+      fields: {
+        startTime: { scalar: "DateTime" },
+        metadata: { scalar: "JSONObject" },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      conference {
+        id
+        name
+        startDate
+        endDate
+        ticketPrice
+        schedule {
+          timeSlots
+        }
+        speakers {
+          id
+          name
+          availableTimes
+        }
+        sessions {
+          __typename
+          id
+          startTime
+          metadata
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      conference: {
+        __typename: "Conference",
+        id: "conf-1",
+        name: "GraphQL Summit",
+        startDate: "2026-09-15T09:00:00.000Z",
+        endDate: "2026-09-15T11:00:00.000Z",
+        ticketPrice: 19900,
+        schedule: {
+          __typename: "Schedule",
+          timeSlots: [
+            ["2026-09-15T09:00:00.000Z", "2026-09-15T10:00:00.000Z"],
+            ["2026-09-15T14:00:00.000Z", "2026-09-15T15:00:00.000Z"],
+          ],
+        },
+        speakers: [
+          {
+            __typename: "Speaker",
+            id: "speaker-1",
+            name: "Alice",
+            availableTimes: [
+              "2026-09-15T09:00:00.000Z",
+              "2026-09-15T14:00:00.000Z",
+            ],
+          },
+          {
+            __typename: "Speaker",
+            id: "speaker-2",
+            name: "Bob",
+            availableTimes: ["2026-09-15T10:00:00.000Z", null],
+          },
+        ],
+        sessions: [
+          {
+            __typename: "Session",
+            id: "session-1",
+            startTime: "2026-09-15T09:00:00.000Z",
+            metadata: { dress: "casual" },
+          },
+        ],
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    conference: {
+      __typename: "Conference",
+      id: "conf-1",
+      name: "GraphQL Summit",
+      startDate: new Date("2026-09-15T09:00:00.000Z"),
+      endDate: new Date("2026-09-15T11:00:00.000Z"),
+      ticketPrice: "199.00",
+      schedule: {
+        __typename: "Schedule",
+        timeSlots: [
+          [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T10:00:00.000Z"),
+          ],
+          [
+            new Date("2026-09-15T14:00:00.000Z"),
+            new Date("2026-09-15T15:00:00.000Z"),
+          ],
+        ],
+      },
+      speakers: [
+        {
+          __typename: "Speaker",
+          id: "speaker-1",
+          name: "Alice",
+          availableTimes: [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T14:00:00.000Z"),
+          ],
+        },
+        {
+          __typename: "Speaker",
+          id: "speaker-2",
+          name: "Bob",
+          availableTimes: [new Date("2026-09-15T10:00:00.000Z"), null],
+        },
+      ],
+      sessions: [
+        {
+          __typename: "Session",
+          id: "session-1",
+          startTime: new Date("2026-09-15T09:00:00.000Z"),
+          metadata: new Map([["dress", "casual"]]),
+        },
+      ],
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -724,6 +724,53 @@ test("parses scalar values when fields are selected through an interface fragmen
   });
 });
 
+test("returns the raw value unchanged when a scalar field policy names an unregistered scalar", () => {
+  using _ = spyOnConsole("warn");
+
+  const cache = new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: {
+            scalar: "Identity",
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        __typename
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
 test("parses scalar values across a complex nested query", () => {
   const cache = new InMemoryCache({
     scalars: {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -6,6 +6,12 @@ const dateTimeScalar = new Scalar<string, Date>({
   parse: (value) => new Date(value),
 });
 
+const priceScalar = new Scalar<number, string>({
+  serialize: (dollars) => Math.round(parseFloat(dollars) * 100),
+  parse: (cents) => `${(cents / 100).toFixed(2)}`,
+  is: (value) => typeof value === "string",
+});
+
 test("getScalar returns a scalar object for a configured scalar", () => {
   const cache = new InMemoryCache({
     scalars: {
@@ -360,12 +366,6 @@ test("parses object-based scalar values (e.g. JSON) when reading from cache", ()
 });
 
 test("parses primitive-to-primitive scalar values when reading from cache", () => {
-  const priceScalar = new Scalar<number, string>({
-    serialize: (dollars) => Math.round(parseFloat(dollars) * 100),
-    parse: (cents) => `${(cents / 100).toFixed(2)}`,
-    is: (value) => typeof value === "string",
-  });
-
   const cache = new InMemoryCache({
     scalars: { Price: priceScalar },
     typePolicies: {
@@ -450,5 +450,54 @@ test("parses scalar fields within each object in an array", () => {
         startTime: new Date("2026-01-02T09:00:00.000Z"),
       },
     ],
+  });
+});
+
+test("parses multiple scalar fields on the same object", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar, Price: priceScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          endTime: { scalar: "DateTime" },
+          ticketPrice: { scalar: "Price" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+        endTime
+        ticketPrice
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T09:00:00.000Z",
+        endTime: "2026-01-01T10:00:00.000Z",
+        ticketPrice: 2099,
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T09:00:00.000Z"),
+      endTime: new Date("2026-01-01T10:00:00.000Z"),
+      ticketPrice: "20.99",
+    },
   });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -199,6 +199,89 @@ test("parses scalar value when reading a field via cache.readFragment", () => {
   });
 });
 
+test("parses scalar value when the field has literal arguments", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime(timezone: "UTC")
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("parses scalar value when the field has arguments with variables", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query ($timezone: String!) {
+      event {
+        id
+        startTime(timezone: $timezone)
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+    variables: { timezone: "UTC" },
+  });
+
+  expect(cache.readQuery({ query, variables: { timezone: "UTC" } })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
 test("parses each element when the scalar field contains an array of values", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -771,6 +771,50 @@ test("returns the raw value unchanged when a scalar field policy names an unregi
   expect(console.warn).not.toHaveBeenCalled();
 });
 
+test("parses scalars for fields with aliases", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        __typename
+        id
+        start: startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        start: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      start: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
 test("parses scalar values across a complex nested query", () => {
   const cache = new InMemoryCache({
     scalars: {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1,4 +1,10 @@
+import { gql } from "@apollo/client";
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
+
+const dateTimeScalar = new Scalar<string, Date>({
+  serialize: (value) => value.toISOString(),
+  parse: (value) => new Date(value),
+});
 
 test("getScalar returns a scalar object for a configured scalar", () => {
   const cache = new InMemoryCache({
@@ -91,4 +97,126 @@ test("is uses the configured type guard when configured", () => {
 
   expect(scalar.is(new Date("2026-01-01T00:00:00.000Z"))).toBe(true);
   expect(scalar.is(new Date("invalid"))).toBe(false);
+});
+
+test("parses scalar value when reading a field via cache.readQuery", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("parses scalar value when reading a field via cache.readFragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(
+    cache.readFragment({
+      id: cache.identify({ __typename: "Event", id: "1" })!,
+      fragment,
+    })
+  ).toEqual({
+    __typename: "Event",
+    id: "1",
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+  });
+});
+
+test("parses each element when the scalar field contains an array of values", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          meetingTimes: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        meetingTimes
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    schedule: {
+      __typename: "Schedule",
+      meetingTimes: [
+        new Date("2026-01-01T09:00:00.000Z"),
+        new Date("2026-01-02T09:00:00.000Z"),
+      ],
+    },
+  });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -589,3 +589,66 @@ test("parses scalar values when the field is selected via an inline fragment", (
     },
   });
 });
+
+test("parses scalar values on the matching member types of a union", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: { startTime: { scalar: "DateTime" } },
+      },
+      Appointment: {
+        fields: { startTime: { scalar: "DateTime" } },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      searchResults {
+        __typename
+        ... on Event {
+          id
+          startTime
+        }
+        ... on Appointment {
+          id
+          startTime
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      searchResults: [
+        {
+          __typename: "Event",
+          id: "1",
+          startTime: "2026-01-01T09:00:00.000Z",
+        },
+        {
+          __typename: "Appointment",
+          id: "2",
+          startTime: "2026-01-02T14:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    searchResults: [
+      {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T09:00:00.000Z"),
+      },
+      {
+        __typename: "Appointment",
+        id: "2",
+        startTime: new Date("2026-01-02T14:00:00.000Z"),
+      },
+    ],
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -652,3 +652,67 @@ test("parses scalar values on the matching member types of a union", () => {
     ],
   });
 });
+
+test("parses scalar values when fields are selected through an interface fragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    possibleTypes: {
+      Schedulable: ["Event", "Appointment"],
+    },
+    typePolicies: {
+      Event: {
+        fields: { startTime: { scalar: "DateTime" } },
+      },
+      Appointment: {
+        fields: { startTime: { scalar: "DateTime" } },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      scheduledItems {
+        __typename
+        ...SchedulableFields
+      }
+    }
+
+    fragment SchedulableFields on Schedulable {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      scheduledItems: [
+        {
+          __typename: "Event",
+          id: "1",
+          startTime: "2026-01-01T09:00:00.000Z",
+        },
+        {
+          __typename: "Appointment",
+          id: "2",
+          startTime: "2026-01-02T14:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    scheduledItems: [
+      {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T09:00:00.000Z"),
+      },
+      {
+        __typename: "Appointment",
+        id: "2",
+        startTime: new Date("2026-01-02T14:00:00.000Z"),
+      },
+    ],
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -501,3 +501,91 @@ test("parses multiple scalar fields on the same object", () => {
     },
   });
 });
+
+test("parses scalar values when the field is selected via a named fragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        ...EventFields
+      }
+    }
+
+    fragment EventFields on Event {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("parses scalar values when the field is selected via an inline fragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        ... @defer {
+          id
+          startTime
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -405,3 +405,50 @@ test("parses primitive-to-primitive scalar values when reading from cache", () =
     },
   });
 });
+
+test("parses scalar fields within each object in an array", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      events {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      events: [
+        { __typename: "Event", id: "1", startTime: "2026-01-01T09:00:00.000Z" },
+        { __typename: "Event", id: "2", startTime: "2026-01-02T09:00:00.000Z" },
+      ],
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    events: [
+      {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T09:00:00.000Z"),
+      },
+      {
+        __typename: "Event",
+        id: "2",
+        startTime: new Date("2026-01-02T09:00:00.000Z"),
+      },
+    ],
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -220,3 +220,50 @@ test("parses each element when the scalar field contains an array of values", ()
     },
   });
 });
+
+test("parses each leaf element when the scalar field contains a 2D array", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          availabilitySlots: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        availabilitySlots
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        availabilitySlots: [
+          ["2026-01-01T09:00:00.000Z", "2026-01-01T10:00:00.000Z"],
+          ["2026-01-02T14:00:00.000Z"],
+        ],
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    schedule: {
+      __typename: "Schedule",
+      availabilitySlots: [
+        [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-01T10:00:00.000Z"),
+        ],
+        [new Date("2026-01-02T14:00:00.000Z")],
+      ],
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
+import { spyOnConsole } from "@apollo/client/testing/internal";
 
 const dateTimeScalar = new Scalar<string, Date>({
   serialize: (value) => value.toISOString(),
@@ -951,4 +952,54 @@ test("parses scalar values across a complex nested query", () => {
       ],
     },
   });
+});
+
+test("ignores scalar and emits a dev warning when a scalar option is set on a field with a selection set", () => {
+  using _ = spyOnConsole("warn");
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Query: {
+        fields: {
+          event: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    "The field policy for '%s' is configured as a '%s' scalar, but the field is not a scalar field because it contains a selection set. The field value remains unchanged.",
+    "Query.event",
+    "DateTime"
+  );
 });

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -22,10 +22,7 @@ import {
   print,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import type {
-  IsLooselyEqual,
-  RemoveIndexSignature,
-} from "@apollo/client/utilities/internal";
+import type { IsLooselyEqual } from "@apollo/client/utilities/internal";
 import { getInMemoryCacheMemoryInternals } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
@@ -39,15 +36,17 @@ import { hasOwn, normalizeConfig } from "./helpers.js";
 import { Policies } from "./policies.js";
 import { forgetCache, makeVar, recallCache } from "./reactiveVars.js";
 import { StoreReader } from "./readFromStore.js";
-import type { InMemoryCacheConfig, NormalizedCacheObject } from "./types.js";
+import type {
+  InMemoryCacheConfig,
+  KnownScalars,
+  NormalizedCacheObject,
+} from "./types.js";
 import { StoreWriter } from "./writeToStore.js";
 
 type BroadcastOptions = Pick<
   Cache.BatchOptions<InMemoryCache>,
   "optimistic" | "onWatchUpdated"
 >;
-
-type KnownScalars = RemoveIndexSignature<ApolloCache.Scalars>;
 
 export declare namespace InMemoryCache {
   export type ScalarsOption = {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -31,6 +31,7 @@ import {
   newInvariantError,
 } from "@apollo/client/utilities/invariant";
 
+import type { ApolloCache } from "../core/cache.js";
 import type {
   CanReadFunction,
   FieldSpecifier,
@@ -173,6 +174,7 @@ export type FieldPolicy<
   keyArgs?: KeySpecifier | KeyArgsFunction | false;
   read?: FieldReadFunction<TExisting, TReadResult, TReadOptions>;
   merge?: FieldMergeFunction<TExisting, TIncoming, TMergeOptions> | boolean;
+  scalar?: keyof ApolloCache.Scalars;
 };
 
 export type StorageType = Record<string, any>;

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -903,19 +903,17 @@ export class Policies {
     // A selection set indicates this is not a scalar field so bail early
     if (options.field && options.field.selectionSet) return value;
 
-    let typename = options.typename;
-    const objectOrReference = options.from;
+    if (options.typename === void 0) {
+      if (!options.from) return value;
 
-    if (!typename && !objectOrReference) return value;
-    if (typename === void 0) {
-      typename = context.store.getFieldValue<string>(
-        objectOrReference,
+      options.typename = context.store.getFieldValue<string>(
+        options.from,
         "__typename"
       );
     }
 
     const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
-    const policy = this.getFieldPolicy(typename, fieldName);
+    const policy = this.getFieldPolicy(options.typename, fieldName);
 
     if (!policy?.scalar) return value;
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -568,7 +568,9 @@ export class Policies {
         if (typeof incoming === "function") {
           existing.read = incoming;
         } else {
-          const { keyArgs, read, merge } = incoming;
+          const { keyArgs, read, merge, scalar } = incoming;
+
+          existing.scalar = scalar;
 
           existing.keyFn =
             // Pass false to disable argument-based differentiation of

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -277,6 +277,11 @@ export interface FieldMergeFunctionOptions<
   existingData: unknown;
 }
 
+interface CoerceValueOptions {
+  typename: string;
+  field: FieldNode;
+}
+
 type MergeObjectsFunction = <T extends StoreObject | Reference>(
   existing: T,
   incoming: T
@@ -895,26 +900,17 @@ export class Policies {
 
   public maybeCoerceScalarValue(
     value: StoreValue,
-    options: ReadFieldOptions,
-    context: ReadMergeModifyContext
+    options: CoerceValueOptions
   ) {
     // null is never coerced
     if (value === null) return value;
 
+    const { field, typename } = options;
+
     // A selection set indicates this is not a scalar field so bail early
-    if (options.field && options.field.selectionSet) return value;
+    if (field && field.selectionSet) return value;
 
-    if (options.typename === void 0) {
-      if (!options.from) return value;
-
-      options.typename = context.store.getFieldValue<string>(
-        options.from,
-        "__typename"
-      );
-    }
-
-    const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
-    const policy = this.getFieldPolicy(options.typename, fieldName);
+    const policy = this.getFieldPolicy(typename, field.name.value);
 
     if (!policy?.scalar) return value;
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -60,6 +60,7 @@ import type {
   MergeInfo,
   NormalizedCache,
   ReadMergeModifyContext,
+  ScalarNames,
 } from "./types.js";
 import type { WriteContext } from "./writeToStore.js";
 
@@ -174,7 +175,7 @@ export type FieldPolicy<
   keyArgs?: KeySpecifier | KeyArgsFunction | false;
   read?: FieldReadFunction<TExisting, TReadResult, TReadOptions>;
   merge?: FieldMergeFunction<TExisting, TIncoming, TMergeOptions> | boolean;
-  scalar?: keyof ApolloCache.Scalars;
+  scalar?: ScalarNames;
 };
 
 export type StorageType = Record<string, any>;

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -898,7 +898,7 @@ export class Policies {
       : fieldName + ":" + storeFieldName;
   }
 
-  public maybeCoerceScalarValue(
+  public maybeCoerceToScalarValue(
     value: StoreValue,
     options: CoerceValueOptions
   ) {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -892,6 +892,34 @@ export class Policies {
       : fieldName + ":" + storeFieldName;
   }
 
+  public maybeCoerceScalarValue(
+    value: StoreValue,
+    options: ReadFieldOptions,
+    context: ReadMergeModifyContext
+  ) {
+    // A selection set indicates this is not a scalar field so bail early
+    if (options.field && options.field.selectionSet) return value;
+
+    let typename = options.typename;
+    const objectOrReference = options.from;
+
+    if (!typename && !objectOrReference) return value;
+    if (typename === void 0) {
+      typename = context.store.getFieldValue<string>(
+        objectOrReference,
+        "__typename"
+      );
+    }
+
+    const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
+    const policy = this.getFieldPolicy(typename, fieldName);
+
+    if (!policy?.scalar) return value;
+
+    const scalar = this.cache.getScalar(policy.scalar);
+    return scalar ? scalar.coerceToParsed(value) : value;
+  }
+
   public readField<V = StoreValue>(
     options: ReadFieldOptions,
     context: ReadMergeModifyContext

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -356,6 +356,7 @@ type InternalFieldPolicy = {
   keyFn?: KeyArgsFunction;
   read?: FieldReadFunction<any>;
   merge?: FieldMergeFunction<any>;
+  scalar?: keyof ApolloCache.Scalars;
 };
 
 export class Policies {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -897,6 +897,9 @@ export class Policies {
     options: ReadFieldOptions,
     context: ReadMergeModifyContext
   ) {
+    // null is never coerced
+    if (value === null) return value;
+
     // A selection set indicates this is not a scalar field so bail early
     if (options.field && options.field.selectionSet) return value;
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -85,6 +85,7 @@ type ExecSubSelectedArrayOptions = {
   array: readonly any[];
   enclosingRef: Reference;
   context: ReadContext;
+  parentObjectOrReference: StoreObject | Reference;
 };
 
 interface StoreReaderConfig {
@@ -357,15 +358,10 @@ export class StoreReader {
                 array: fieldValue,
                 enclosingRef,
                 context,
+                parentObjectOrReference: objectOrReference,
               }),
               resultName
             );
-
-            if (Array.isArray(fieldValue)) {
-              fieldValue = fieldValue.map((item) =>
-                policies.maybeCoerceScalarValue(item, readFieldOptions, context)
-              );
-            }
           }
         } else if (!selection.selectionSet) {
           fieldValue = policies.maybeCoerceScalarValue(
@@ -427,6 +423,7 @@ export class StoreReader {
     array,
     enclosingRef,
     context,
+    parentObjectOrReference,
   }: ExecSubSelectedArrayOptions): ExecResult {
     let missing: MissingTree | undefined;
     let missingMerger = new DeepMerger();
@@ -458,6 +455,7 @@ export class StoreReader {
             array: item,
             enclosingRef,
             context,
+            parentObjectOrReference,
           }),
           i
         );
@@ -480,7 +478,15 @@ export class StoreReader {
         assertSelectionSetForIdValue(context.store, field, item);
       }
 
-      return item;
+      return context.policies.maybeCoerceScalarValue(
+        item,
+        {
+          fieldName: field.name.value,
+          field,
+          from: parentObjectOrReference,
+        },
+        context
+      );
     });
 
     return {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -3,7 +3,11 @@ import { Kind } from "graphql";
 import type { OptimisticWrapperFunction } from "optimism";
 import { wrap } from "optimism";
 
-import type { Reference, StoreObject } from "@apollo/client/utilities";
+import type {
+  Reference,
+  StoreObject,
+  StoreValue,
+} from "@apollo/client/utilities";
 import {
   addTypenameToDocument,
   cacheSizes,
@@ -324,15 +328,14 @@ export class StoreReader {
       if (!shouldInclude(selection, variables)) return;
 
       if (isField(selection)) {
-        let fieldValue = policies.readField(
-          {
-            fieldName: selection.name.value,
-            field: selection,
-            variables: context.variables,
-            from: objectOrReference,
-          },
-          context
-        );
+        const readFieldOptions = {
+          fieldName: selection.name.value,
+          field: selection,
+          variables: context.variables,
+          from: objectOrReference,
+        };
+
+        let fieldValue = policies.readField(readFieldOptions, context);
 
         const resultName = resultKeyNameFromField(selection);
 
@@ -357,8 +360,19 @@ export class StoreReader {
               }),
               resultName
             );
+
+            if (Array.isArray(fieldValue)) {
+              fieldValue = fieldValue.map((item) =>
+                policies.maybeCoerceScalarValue(item, readFieldOptions, context)
+              );
+            }
           }
         } else if (!selection.selectionSet) {
+          fieldValue = policies.maybeCoerceScalarValue(
+            fieldValue,
+            readFieldOptions,
+            context
+          );
           // do nothing
         } else if (fieldValue != null) {
           // In this case, because we know the field has a selection set,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -370,7 +370,6 @@ export class StoreReader {
             readFieldOptions,
             context
           );
-          // do nothing
         } else if (fieldValue != null) {
           if (__DEV__) {
             const typename = context.store.getFieldValue<string>(

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -361,7 +361,7 @@ export class StoreReader {
             );
           }
         } else if (!selection.selectionSet) {
-          fieldValue = policies.maybeCoerceScalarValue(fieldValue, {
+          fieldValue = policies.maybeCoerceToScalarValue(fieldValue, {
             field: selection,
             typename: context.store.getFieldValue<string>(
               objectOrReference,
@@ -495,7 +495,7 @@ export class StoreReader {
         assertSelectionSetForIdValue(context.store, field, item);
       }
 
-      return context.policies.maybeCoerceScalarValue(item, {
+      return context.policies.maybeCoerceToScalarValue(item, {
         field,
         typename: context.store.getFieldValue<string>(
           parentObjectOrReference,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -3,11 +3,7 @@ import { Kind } from "graphql";
 import type { OptimisticWrapperFunction } from "optimism";
 import { wrap } from "optimism";
 
-import type {
-  Reference,
-  StoreObject,
-  StoreValue,
-} from "@apollo/client/utilities";
+import type { Reference, StoreObject } from "@apollo/client/utilities";
 import {
   addTypenameToDocument,
   cacheSizes,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -46,7 +46,6 @@ import {
 } from "./entityStore.js";
 import {
   extractFragmentContext,
-  fieldNameFromStoreName,
   getTypenameFromStoreObject,
 } from "./helpers.js";
 import type { InMemoryCache } from "./inMemoryCache.js";
@@ -326,14 +325,15 @@ export class StoreReader {
       if (!shouldInclude(selection, variables)) return;
 
       if (isField(selection)) {
-        const readFieldOptions = {
-          fieldName: selection.name.value,
-          field: selection,
-          variables: context.variables,
-          from: objectOrReference,
-        };
-
-        let fieldValue = policies.readField(readFieldOptions, context);
+        let fieldValue = policies.readField(
+          {
+            fieldName: selection.name.value,
+            field: selection,
+            variables: context.variables,
+            from: objectOrReference,
+          },
+          context
+        );
 
         const resultName = resultKeyNameFromField(selection);
 
@@ -361,20 +361,20 @@ export class StoreReader {
             );
           }
         } else if (!selection.selectionSet) {
-          fieldValue = policies.maybeCoerceScalarValue(
-            fieldValue,
-            readFieldOptions,
-            context
-          );
+          fieldValue = policies.maybeCoerceScalarValue(fieldValue, {
+            field: selection,
+            typename: context.store.getFieldValue<string>(
+              objectOrReference,
+              "__typename"
+            ),
+          });
         } else if (fieldValue != null) {
           if (__DEV__) {
             const typename = context.store.getFieldValue<string>(
               objectOrReference,
               "__typename"
             );
-            const fieldName = fieldNameFromStoreName(
-              policies.getStoreFieldName(readFieldOptions)
-            );
+            const fieldName = selection.name.value;
 
             if (typename) {
               const policy = policies["getFieldPolicy"](typename, fieldName);
@@ -495,15 +495,13 @@ export class StoreReader {
         assertSelectionSetForIdValue(context.store, field, item);
       }
 
-      return context.policies.maybeCoerceScalarValue(
-        item,
-        {
-          fieldName: field.name.value,
-          field,
-          from: parentObjectOrReference,
-        },
-        context
-      );
+      return context.policies.maybeCoerceScalarValue(item, {
+        field,
+        typename: context.store.getFieldValue<string>(
+          parentObjectOrReference,
+          "__typename"
+        ),
+      });
     });
 
     return {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -50,6 +50,7 @@ import {
 } from "./entityStore.js";
 import {
   extractFragmentContext,
+  fieldNameFromStoreName,
   getTypenameFromStoreObject,
 } from "./helpers.js";
 import type { InMemoryCache } from "./inMemoryCache.js";
@@ -371,6 +372,27 @@ export class StoreReader {
           );
           // do nothing
         } else if (fieldValue != null) {
+          if (__DEV__) {
+            const typename = context.store.getFieldValue<string>(
+              objectOrReference,
+              "__typename"
+            );
+            const fieldName = fieldNameFromStoreName(
+              policies.getStoreFieldName(readFieldOptions)
+            );
+
+            if (typename) {
+              const policy = policies["getFieldPolicy"](typename, fieldName);
+
+              if (policy?.scalar) {
+                invariant.warn(
+                  "The field policy for '%s' is configured as a '%s' scalar, but the field is not a scalar field because it contains a selection set. The field value remains unchanged.",
+                  `${typename}.${fieldName}`,
+                  policy.scalar
+                );
+              }
+            }
+          }
           // In this case, because we know the field has a selection set,
           // it must be trying to query a GraphQLObjectType, which is why
           // fieldValue must be != null.

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -6,9 +6,12 @@ import type {
   StoreObject,
   StoreValue,
 } from "@apollo/client/utilities";
-import type { ExtensionsWithStreamInfo } from "@apollo/client/utilities/internal";
+import type {
+  ExtensionsWithStreamInfo,
+  RemoveIndexSignature,
+} from "@apollo/client/utilities/internal";
 
-import type { Transaction } from "../core/cache.js";
+import type { ApolloCache, Transaction } from "../core/cache.js";
 import type {
   AllFieldsModifier,
   CanReadFunction,
@@ -171,3 +174,5 @@ export interface ReadMergeModifyContext {
   varString?: string;
   extensions?: ExtensionsWithStreamInfo;
 }
+
+export type KnownScalars = RemoveIndexSignature<ApolloCache.Scalars>;

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -176,3 +176,6 @@ export interface ReadMergeModifyContext {
 }
 
 export type KnownScalars = RemoveIndexSignature<ApolloCache.Scalars>;
+export type ScalarNames =
+  | keyof KnownScalars
+  | (string extends keyof ApolloCache.Scalars ? string & {} : never);


### PR DESCRIPTION
_Part of the custom scalars work: https://github.com/apollographql/apollo-client/issues/13227_

Adds the `scalar` option for field policies so that fields can specify which scalar to use. This change also implements scalar parsing for cache reads so that `cache.readQuery`, `cache.readFragment`, and `cache.watchFragment` all return the parsed scalar values for fields that specify a scalar.