### PR TITLE
[Custom scalars] Handle scalar parsing during cache reads and writes

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -346,12 +346,15 @@ export { canonicalStringify }
 type CanReadFunction = (value: StoreValue) => boolean;
 
 // @public (undocumented)
-interface CoerceValueOptions {
-    // (undocumented)
-    field: FieldNode;
-    // (undocumented)
+type CoerceValueOptions = {
     typename: string;
-}
+} & ({
+    field: FieldNode;
+    fieldName?: never;
+} | {
+    field?: never;
+    fieldName: string;
+});
 
 // @public (undocumented)
 export function createFragmentRegistry(...fragments: DocumentNode[]): FragmentRegistryAPI;
@@ -873,6 +876,8 @@ export class Policies {
     getMergeFunction(parentTypename: string | undefined, fieldName: string, childTypename: string | undefined): FieldMergeFunction | undefined;
     // (undocumented)
     getReadFunction(typename: string | undefined, fieldName: string): FieldReadFunction | undefined;
+    // (undocumented)
+    getScalarForField(typename: string, fieldName: string): Scalar<any, any> | undefined;
     // Warning: (ae-forgotten-export) The symbol "FieldSpecifier" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -881,14 +886,12 @@ export class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
-    // (undocumented)
-    maybeCoerceSerializedValue(value: StoreValue, options: CoerceValueOptions & {
-        scalar?: Scalar<any, any>;
-    }): StoreValue;
     // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
+    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): StoreValue;
+    // (undocumented)
+    maybeCoerceToSerializedValue(value: StoreValue, options: CoerceValueOptions): StoreValue;
     // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -886,6 +886,10 @@ export class Policies {
     // (undocumented)
     maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
     // (undocumented)
+    maybeCoerceSerializedValue(value: StoreValue, options: FieldSpecifier & {
+        scalar?: Scalar<any, any>;
+    }): StoreValue;
+    // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)
     readonly rootIdsByTypename: Record<string, string>;
@@ -1094,9 +1098,9 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:178:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:179:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -346,17 +346,6 @@ export { canonicalStringify }
 type CanReadFunction = (value: StoreValue) => boolean;
 
 // @public (undocumented)
-type CoerceValueOptions = {
-    typename: string;
-} & ({
-    field: FieldNode;
-    fieldName?: never;
-} | {
-    field?: never;
-    fieldName: string;
-});
-
-// @public (undocumented)
 export function createFragmentRegistry(...fragments: DocumentNode[]): FragmentRegistryAPI;
 
 // Warning: (ae-forgotten-export) The symbol "KeyFieldsContext" needs to be exported by the entry point index.d.ts
@@ -886,12 +875,6 @@ export class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
-    // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): StoreValue;
-    // (undocumented)
-    maybeCoerceToSerializedValue(value: StoreValue, options: CoerceValueOptions): StoreValue;
     // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -495,6 +495,7 @@ export type FieldPolicy<TExisting = any, TIncoming = TExisting, TReadResult = TI
     keyArgs?: KeySpecifier | KeyArgsFunction | false;
     read?: FieldReadFunction<TExisting, TReadResult, TReadOptions>;
     merge?: FieldMergeFunction<TExisting, TIncoming, TMergeOptions> | boolean;
+    scalar?: ScalarNames;
 };
 
 // @public (undocumented)
@@ -873,6 +874,8 @@ export class Policies {
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
     // (undocumented)
+    maybeCoerceScalarValue(value: StoreValue, options: ReadFieldOptions, context: ReadMergeModifyContext): any;
+    // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)
     readonly rootIdsByTypename: Record<string, string>;
@@ -997,6 +1000,9 @@ export class Scalar<TSerialized, TParsed> {
 }
 
 // @public (undocumented)
+type ScalarNames = keyof KnownScalars | (string extends keyof ApolloCache.Scalars ? string & {} : never);
+
+// @public (undocumented)
 type StorageType = Record<string, any>;
 
 export { StoreObject }
@@ -1078,9 +1084,10 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:136:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:178:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -346,6 +346,14 @@ export { canonicalStringify }
 type CanReadFunction = (value: StoreValue) => boolean;
 
 // @public (undocumented)
+interface CoerceValueOptions {
+    // (undocumented)
+    field: FieldNode;
+    // (undocumented)
+    typename: string;
+}
+
+// @public (undocumented)
 export function createFragmentRegistry(...fragments: DocumentNode[]): FragmentRegistryAPI;
 
 // Warning: (ae-forgotten-export) The symbol "KeyFieldsContext" needs to be exported by the entry point index.d.ts
@@ -873,8 +881,10 @@ export class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
+    // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    maybeCoerceScalarValue(value: StoreValue, options: ReadFieldOptions, context: ReadMergeModifyContext): any;
+    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
     // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -881,14 +881,14 @@ export class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
+    // (undocumented)
+    maybeCoerceSerializedValue(value: StoreValue, options: CoerceValueOptions & {
+        scalar?: Scalar<any, any>;
+    }): StoreValue;
     // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
-    // (undocumented)
-    maybeCoerceSerializedValue(value: StoreValue, options: FieldSpecifier & {
-        scalar?: Scalar<any, any>;
-    }): StoreValue;
     // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1327,6 +1327,7 @@ export type FieldPolicy<TExisting = any, TIncoming = TExisting, TReadResult = TI
     keyArgs?: KeySpecifier | KeyArgsFunction | false;
     read?: FieldReadFunction<TExisting, TReadResult, TReadOptions>;
     merge?: FieldMergeFunction<TExisting, TIncoming, TMergeOptions> | boolean;
+    scalar?: ScalarNames;
 };
 
 // @public (undocumented)
@@ -2374,6 +2375,8 @@ class Policies {
     // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
+    maybeCoerceScalarValue(value: StoreValue, options: ReadFieldOptions, context: ReadMergeModifyContext): any;
+    // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)
     readonly rootIdsByTypename: Record<string, string>;
@@ -2823,6 +2826,9 @@ export class Scalar<TSerialized, TParsed> {
     serialize(value: TParsed): TSerialized;
 }
 
+// @public (undocumented)
+type ScalarNames = keyof KnownScalars | (string extends keyof ApolloCache.Scalars ? string & {} : never);
+
 // Warning: (ae-forgotten-export) The symbol "HttpConfig" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -3139,11 +3145,12 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/core/cache.ts:127:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:101:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:136:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:143:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:103:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:178:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:146:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:201:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:633:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -947,12 +947,15 @@ class ClientAwarenessLink extends ApolloLink {
 }
 
 // @public (undocumented)
-interface CoerceValueOptions {
-    // (undocumented)
-    field: FieldNode;
-    // (undocumented)
+type CoerceValueOptions = {
     typename: string;
-}
+} & ({
+    field: FieldNode;
+    fieldName?: never;
+} | {
+    field?: never;
+    fieldName: string;
+});
 
 // @public (undocumented)
 export namespace CombinedGraphQLErrors {
@@ -2372,6 +2375,8 @@ class Policies {
     getMergeFunction(parentTypename: string | undefined, fieldName: string, childTypename: string | undefined): FieldMergeFunction | undefined;
     // (undocumented)
     getReadFunction(typename: string | undefined, fieldName: string): FieldReadFunction | undefined;
+    // (undocumented)
+    getScalarForField(typename: string, fieldName: string): Scalar<any, any> | undefined;
     // Warning: (ae-forgotten-export) The symbol "FieldSpecifier" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -2380,14 +2385,12 @@ class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
-    // (undocumented)
-    maybeCoerceSerializedValue(value: StoreValue, options: CoerceValueOptions & {
-        scalar?: Scalar<any, any>;
-    }): StoreValue;
     // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
+    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): StoreValue;
+    // (undocumented)
+    maybeCoerceToSerializedValue(value: StoreValue, options: CoerceValueOptions): StoreValue;
     // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2380,16 +2380,16 @@ class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
+    // (undocumented)
+    maybeCoerceSerializedValue(value: StoreValue, options: CoerceValueOptions & {
+        scalar?: Scalar<any, any>;
+    }): StoreValue;
     // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
     // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
     //
-    // (undocumented)
-    maybeCoerceSerializedValue(value: StoreValue, options: FieldSpecifier & {
-        scalar?: Scalar<any, any>;
-    }): StoreValue;
     // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -947,17 +947,6 @@ class ClientAwarenessLink extends ApolloLink {
 }
 
 // @public (undocumented)
-type CoerceValueOptions = {
-    typename: string;
-} & ({
-    field: FieldNode;
-    fieldName?: never;
-} | {
-    field?: never;
-    fieldName: string;
-});
-
-// @public (undocumented)
 export namespace CombinedGraphQLErrors {
     // (undocumented)
     export namespace DocumentationTypes {
@@ -2385,12 +2374,6 @@ class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
-    // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): StoreValue;
-    // (undocumented)
-    maybeCoerceToSerializedValue(value: StoreValue, options: CoerceValueOptions): StoreValue;
     // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -947,6 +947,14 @@ class ClientAwarenessLink extends ApolloLink {
 }
 
 // @public (undocumented)
+interface CoerceValueOptions {
+    // (undocumented)
+    field: FieldNode;
+    // (undocumented)
+    typename: string;
+}
+
+// @public (undocumented)
 export namespace CombinedGraphQLErrors {
     // (undocumented)
     export namespace DocumentationTypes {
@@ -2372,10 +2380,12 @@ class Policies {
     hasKeyArgs(typename: string | undefined, fieldName: string): boolean;
     // (undocumented)
     identify(object: StoreObject, partialContext?: Partial<KeyFieldsContext>): [string?, StoreObject?];
-    // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "CoerceValueOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    maybeCoerceScalarValue(value: StoreValue, options: ReadFieldOptions, context: ReadMergeModifyContext): any;
+    maybeCoerceToScalarValue(value: StoreValue, options: CoerceValueOptions): any;
+    // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2387,6 +2387,10 @@ class Policies {
     // Warning: (ae-forgotten-export) The symbol "ReadFieldOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
+    maybeCoerceSerializedValue(value: StoreValue, options: FieldSpecifier & {
+        scalar?: Scalar<any, any>;
+    }): StoreValue;
+    // (undocumented)
     readField<V = StoreValue>(options: ReadFieldOptions, context: ReadMergeModifyContext): SafeReadonly<V> | undefined;
     // (undocumented)
     readonly rootIdsByTypename: Record<string, string>;
@@ -3155,10 +3159,10 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/core/cache.ts:127:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:103:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:178:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:104:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/policies.ts:179:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:139:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:146:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:201:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts

--- a/.changeset/sour-poets-leave.md
+++ b/.changeset/sour-poets-leave.md
@@ -1,5 +1,0 @@
----
-"@apollo/client": minor
----
-
-Add support for serializing scalar values when writing data to the cache. Fields that define scalars can pass the serialized or parsed value of a scalar and it will automatically be serialized for you.

--- a/.changeset/sour-poets-leave.md
+++ b/.changeset/sour-poets-leave.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add support for serializing scalar values when writing data to the cache. Fields that define scalars can pass the serialized or parsed value of a scalar and it will automatically be serialized for you.

--- a/.changeset/strong-shoes-sell.md
+++ b/.changeset/strong-shoes-sell.md
@@ -1,0 +1,28 @@
+---
+"@apollo/client": minor
+---
+
+Adds a `scalar` option to `InMemoryCache` field policies that dictates whether to parse the raw value using the custom scalar definition. Scalar parsing is now performed on cache reads.
+
+```ts
+import { Scalar } from "@apollo/client";
+
+new InMemoryCache({
+  scalars: {
+    DateTime: new Scalar({
+      parse: (dateString) => new Date(dateString),
+      serialize: (date) => date.toISOString(),
+    }),
+  },
+  typePolicies: {
+    Event: {
+      fields: {
+        startTime: {
+          // Parse this field using the DateTime scalar
+          scalar: "DateTime",
+        },
+      },
+    },
+  },
+});
+```

--- a/.changeset/strong-shoes-sell.md
+++ b/.changeset/strong-shoes-sell.md
@@ -2,7 +2,7 @@
 "@apollo/client": minor
 ---
 
-Adds a `scalar` option to `InMemoryCache` field policies that dictates whether to parse the raw value using the custom scalar definition. Scalar parsing is now performed on cache reads.
+Adds a `scalar` option to `InMemoryCache` field policies that tells the cache which scalar to use when parsing or serializing the field value.
 
 ```ts
 import { Scalar } from "@apollo/client";
@@ -26,3 +26,5 @@ new InMemoryCache({
   },
 });
 ```
+
+This scalar definition is now used to properly parse or serialize the field value for cache reads and writes as well as `cache.extract()` and `cache.restore()`.

--- a/integration-tests/type-tests/customScalars/all-any/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/differentTypes/index.ts
@@ -227,6 +227,9 @@ test("allows any scalar name in field policies", () => {
           metadata: {
             scalar: "JSONObject",
           },
+          unknown: {
+            scalar: "Unknown",
+          },
         },
       },
     },

--- a/integration-tests/type-tests/customScalars/all-any/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/differentTypes/index.ts
@@ -209,3 +209,26 @@ test("InMemoryCache.getScalar returns the resolved scalar for a declared scalar"
     Scalar<any, any> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-any/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/empty/index.ts
@@ -152,3 +152,20 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<any, any> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-any/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/empty/index.ts
@@ -1,4 +1,4 @@
-import { ApolloCache, InMemoryCache, Scalar } from "@apollo/client/cache";
+import { InMemoryCache, Scalar } from "@apollo/client/cache";
 import { expectTypeOf } from "expect-type";
 
 declare function test(name: string, fn: () => void): void;
@@ -163,6 +163,9 @@ test("allows any scalar name in field policies", () => {
           },
           metadata: {
             scalar: "JSONObject",
+          },
+          unknown: {
+            scalar: "Unknown",
           },
         },
       },

--- a/integration-tests/type-tests/customScalars/all-any/matchingTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/matchingTypes/index.ts
@@ -228,3 +228,23 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<any, any> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+          unknown: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-any/mixed/index.ts
+++ b/integration-tests/type-tests/customScalars/all-any/mixed/index.ts
@@ -128,3 +128,29 @@ test("getScalar resolves each scalar according to its declaration", () => {
     Scalar<any, any> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          endDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-structured/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/differentTypes/index.ts
@@ -32,3 +32,27 @@ test("a transforming scalar that conflicts with the index cannot be configured",
     },
   });
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    // @ts-expect-error `DateTime` is not assignable to index signature
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value: Date) => value.toISOString(),
+        parse: (value: string) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-structured/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/differentTypes/index.ts
@@ -51,6 +51,9 @@ test("allows any scalar name in field policies", () => {
           metadata: {
             scalar: "JSONObject",
           },
+          unknown: {
+            scalar: "Unknown",
+          },
         },
       },
     },

--- a/integration-tests/type-tests/customScalars/all-structured/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/empty/index.ts
@@ -150,3 +150,20 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<string, string> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-structured/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/empty/index.ts
@@ -162,6 +162,9 @@ test("allows any scalar name in field policies", () => {
           metadata: {
             scalar: "JSONObject",
           },
+          unknown: {
+            scalar: "Unknown",
+          },
         },
       },
     },

--- a/integration-tests/type-tests/customScalars/all-structured/matchingTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/matchingTypes/index.ts
@@ -113,3 +113,23 @@ test("getScalar resolves each scalar according to its declaration", () => {
     Scalar<string, string> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+          unknown: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-structured/mixed/index.ts
+++ b/integration-tests/type-tests/customScalars/all-structured/mixed/index.ts
@@ -38,3 +38,34 @@ test("a transforming scalar conflicting with the index blocks configuration", ()
     },
   });
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    // @ts-expect-error `DateTime` is not assignable to index signature
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+      RelativeDate: new Scalar({
+        serialize: (value) => value,
+        parse: (value) => value,
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          endDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-unknown/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/differentTypes/index.ts
@@ -228,6 +228,9 @@ test("allows any scalar name in field policies", () => {
           metadata: {
             scalar: "JSONObject",
           },
+          unknown: {
+            scalar: "Unknown",
+          },
         },
       },
     },

--- a/integration-tests/type-tests/customScalars/all-unknown/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/differentTypes/index.ts
@@ -210,3 +210,26 @@ test("InMemoryCache.getScalar returns the resolved scalar for a declared scalar"
     Scalar<unknown, unknown> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-unknown/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/empty/index.ts
@@ -156,3 +156,20 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<unknown, unknown> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-unknown/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/empty/index.ts
@@ -168,6 +168,9 @@ test("allows any scalar name in field policies", () => {
           metadata: {
             scalar: "JSONObject",
           },
+          unknown: {
+            scalar: "Unknown",
+          },
         },
       },
     },

--- a/integration-tests/type-tests/customScalars/all-unknown/matchingTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/matchingTypes/index.ts
@@ -230,3 +230,23 @@ test("getScalar returns the resolved scalar or undefined", () => {
     Scalar<unknown, unknown> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+          unknown: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/all-unknown/mixed/index.ts
+++ b/integration-tests/type-tests/customScalars/all-unknown/mixed/index.ts
@@ -129,3 +129,29 @@ test("getScalar resolves each scalar according to its declaration", () => {
     Scalar<unknown, unknown> | undefined
   >();
 });
+
+test("allows any scalar name in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          endDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "Unknown",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/differentTypes/index.ts
@@ -171,3 +171,27 @@ test("InMemoryCache.getScalar returns the resolved scalar for a declared scalar"
   // @ts-expect-error not a declared scalar
   cache.getScalar("Unknown");
 });
+
+test("allows only defined scalars field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          metadata: {
+            // @ts-expect-error scalar not registered
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/empty/index.ts
+++ b/integration-tests/type-tests/customScalars/empty/index.ts
@@ -20,3 +20,18 @@ test("getScalar cannot be called without a declared scalar", () => {
   // @ts-expect-error no scalars are declared
   cache.getScalar("DateTime");
 });
+
+test("does not allow any scalar name in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            // @ts-expect-error no scalars are declared
+            scalar: "DateTime",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/matchingTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/matchingTypes/index.ts
@@ -182,3 +182,24 @@ test("getScalar returns the resolved scalar or undefined", () => {
   // @ts-expect-error not a declared scalar
   cache.getScalar("Unknown");
 });
+
+test("allows only defined scalars in field policies", () => {
+  new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            scalar: "JSONObject",
+          },
+          unknown: {
+            // @ts-expect-error scalar not registered
+            scalar: "DateTime",
+          },
+        },
+      },
+    },
+  });
+});

--- a/integration-tests/type-tests/customScalars/mixed/index.ts
+++ b/integration-tests/type-tests/customScalars/mixed/index.ts
@@ -118,3 +118,30 @@ test("getScalar resolves each scalar according to its declaration", () => {
   // @ts-expect-error not a declared scalar
   cache.getScalar("Unknown");
 });
+
+test("allows only defined scalars in field policies", () => {
+  new InMemoryCache({
+    scalars: {
+      DateTime: new Scalar({
+        serialize: (value) => value.toISOString(),
+        parse: (value) => new Date(value),
+      }),
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "DateTime",
+          },
+          endDate: {
+            scalar: "RelativeDate",
+          },
+          metadata: {
+            // @ts-expect-error scalar not registered
+            scalar: "JSONObject",
+          },
+        },
+      },
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -358,3 +358,50 @@ test("parses object-based scalar values (e.g. JSON) when reading from cache", ()
     },
   });
 });
+
+test("parses primitive-to-primitive scalar values when reading from cache", () => {
+  const priceScalar = new Scalar<number, string>({
+    serialize: (dollars) => Math.round(parseFloat(dollars) * 100),
+    parse: (cents) => `${(cents / 100).toFixed(2)}`,
+    is: (value) => typeof value === "string",
+  });
+
+  const cache = new InMemoryCache({
+    scalars: { Price: priceScalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          price: { scalar: "Price" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      product {
+        id
+        price
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      product: {
+        __typename: "Product",
+        id: "1",
+        price: 1099,
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    product: {
+      __typename: "Product",
+      id: "1",
+      price: "10.99",
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -308,3 +308,53 @@ test("returns null as-is when null is stored in a scalar field position", () => 
     },
   });
 });
+
+test("parses object-based scalar values (e.g. JSON) when reading from cache", () => {
+  const scalar = new Scalar<Record<string, unknown>, Map<string, unknown>>({
+    serialize: (value) => Object.fromEntries(value),
+    parse: (value) => new Map(Object.entries(value)),
+    is: (value) => value instanceof Map,
+  });
+
+  const cache = new InMemoryCache({
+    scalars: { JSONObject: scalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      product {
+        id
+        metadata
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      product: {
+        __typename: "Product",
+        id: "1",
+        metadata: { color: "red", size: "large" },
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    product: {
+      __typename: "Product",
+      id: "1",
+      metadata: new Map([
+        ["color", "red"],
+        ["size", "large"],
+      ]),
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -511,6 +511,54 @@ test("serializes parsed scalar value when overwriting an existing field", () => 
   });
 });
 
+test("serializes parsed scalar value when a merge function is also configured on the field", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: {
+            scalar: "DateTime",
+            merge: (_, incoming) => incoming,
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      event: { __ref: "Event:1" },
+    },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
 test("serializes parsed scalar values across a complex nested write", () => {
   const cache = new InMemoryCache({
     scalars: {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -12,6 +12,15 @@ const priceScalar = new Scalar<number, string>({
   is: (value) => typeof value === "string",
 });
 
+const jsonObjectScalar = new Scalar<
+  Record<string, unknown>,
+  Map<string, unknown>
+>({
+  serialize: (value) => Object.fromEntries(value),
+  parse: (value) => new Map(Object.entries(value)),
+  is: (value) => value instanceof Map,
+});
+
 test("getScalar returns a scalar object for a configured scalar", () => {
   const cache = new InMemoryCache({
     scalars: {
@@ -316,14 +325,8 @@ test("returns null as-is when null is stored in a scalar field position", () => 
 });
 
 test("parses object-based scalar values (e.g. JSON) when reading from cache", () => {
-  const scalar = new Scalar<Record<string, unknown>, Map<string, unknown>>({
-    serialize: (value) => Object.fromEntries(value),
-    parse: (value) => new Map(Object.entries(value)),
-    is: (value) => value instanceof Map,
-  });
-
   const cache = new InMemoryCache({
-    scalars: { JSONObject: scalar },
+    scalars: { JSONObject: jsonObjectScalar },
     typePolicies: {
       Product: {
         fields: {
@@ -714,5 +717,238 @@ test("parses scalar values when fields are selected through an interface fragmen
         startTime: new Date("2026-01-02T14:00:00.000Z"),
       },
     ],
+  });
+});
+
+test("parses scalar values across a complex nested query", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+      Price: priceScalar,
+      JSONObject: jsonObjectScalar,
+    },
+    possibleTypes: {
+      Schedulable: ["Session", "Workshop"],
+    },
+    typePolicies: {
+      Conference: {
+        fields: {
+          startDate: { scalar: "DateTime" },
+          endDate: { scalar: "DateTime" },
+          ticketPrice: { scalar: "Price" },
+        },
+      },
+      Schedule: {
+        fields: {
+          timeSlots: { scalar: "DateTime" },
+        },
+      },
+      Speaker: {
+        fields: {
+          availableTimes: { scalar: "DateTime" },
+        },
+      },
+      Session: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+      Workshop: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+      VirtualPresenter: {
+        fields: { nextSession: { scalar: "DateTime" } },
+      },
+      InPersonPresenter: {
+        fields: { arrivalTime: { scalar: "DateTime" } },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      conference {
+        id
+        name
+        startDate
+        endDate
+        ticketPrice
+        schedule {
+          timeSlots
+        }
+        ...SpeakerListFields
+        scheduledItems {
+          __typename
+          ...SchedulableFields
+        }
+        presenters {
+          __typename
+          ... on VirtualPresenter {
+            id
+            name
+            nextSession
+          }
+          ... on InPersonPresenter {
+            id
+            name
+            arrivalTime
+          }
+        }
+      }
+    }
+
+    fragment SpeakerListFields on Conference {
+      speakers {
+        id
+        name
+        availableTimes
+      }
+    }
+
+    fragment SchedulableFields on Schedulable {
+      id
+      startTime
+      metadata
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      conference: {
+        __typename: "Conference",
+        id: "conf-1",
+        name: "GraphQL Summit",
+        startDate: "2026-09-15T09:00:00.000Z",
+        endDate: null,
+        ticketPrice: 19900,
+        schedule: {
+          __typename: "Schedule",
+          timeSlots: [
+            ["2026-09-15T09:00:00.000Z", "2026-09-15T10:00:00.000Z"],
+            ["2026-09-15T14:00:00.000Z", "2026-09-15T15:00:00.000Z"],
+          ],
+        },
+        speakers: [
+          {
+            __typename: "Speaker",
+            id: "speaker-1",
+            name: "Alice",
+            availableTimes: [
+              "2026-09-15T09:00:00.000Z",
+              "2026-09-15T14:00:00.000Z",
+            ],
+          },
+          {
+            __typename: "Speaker",
+            id: "speaker-2",
+            name: "Bob",
+            // null is valid in a scalar array
+            availableTimes: ["2026-09-15T10:00:00.000Z", null],
+          },
+        ],
+        scheduledItems: [
+          {
+            __typename: "Session",
+            id: "session-1",
+            startTime: "2026-09-15T09:00:00.000Z",
+            metadata: { dress: "casual" },
+          },
+          {
+            __typename: "Workshop",
+            id: "workshop-1",
+            startTime: "2026-09-15T14:00:00.000Z",
+            metadata: { venue: "The Workshop Building" },
+          },
+        ],
+        presenters: [
+          {
+            __typename: "VirtualPresenter",
+            id: "vp-1",
+            name: "Charlie",
+            nextSession: "2026-09-15T09:00:00.000Z",
+          },
+          {
+            __typename: "InPersonPresenter",
+            id: "ip-1",
+            name: "Diana",
+            arrivalTime: "2026-09-14T18:00:00.000Z",
+          },
+        ],
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    conference: {
+      __typename: "Conference",
+      id: "conf-1",
+      name: "GraphQL Summit",
+      startDate: new Date("2026-09-15T09:00:00.000Z"),
+      endDate: null,
+      ticketPrice: "199.00",
+      schedule: {
+        __typename: "Schedule",
+        timeSlots: [
+          [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T10:00:00.000Z"),
+          ],
+          [
+            new Date("2026-09-15T14:00:00.000Z"),
+            new Date("2026-09-15T15:00:00.000Z"),
+          ],
+        ],
+      },
+      speakers: [
+        {
+          __typename: "Speaker",
+          id: "speaker-1",
+          name: "Alice",
+          availableTimes: [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T14:00:00.000Z"),
+          ],
+        },
+        {
+          __typename: "Speaker",
+          id: "speaker-2",
+          name: "Bob",
+          availableTimes: [new Date("2026-09-15T10:00:00.000Z"), null],
+        },
+      ],
+      scheduledItems: [
+        {
+          __typename: "Session",
+          id: "session-1",
+          startTime: new Date("2026-09-15T09:00:00.000Z"),
+          metadata: new Map([["dress", "casual"]]),
+        },
+        {
+          __typename: "Workshop",
+          id: "workshop-1",
+          startTime: new Date("2026-09-15T14:00:00.000Z"),
+          metadata: new Map([["venue", "The Workshop Building"]]),
+        },
+      ],
+      presenters: [
+        {
+          __typename: "VirtualPresenter",
+          id: "vp-1",
+          name: "Charlie",
+          nextSession: new Date("2026-09-15T09:00:00.000Z"),
+        },
+        {
+          __typename: "InPersonPresenter",
+          id: "ip-1",
+          name: "Diana",
+          arrivalTime: new Date("2026-09-14T18:00:00.000Z"),
+        },
+      ],
+    },
   });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -267,3 +267,44 @@ test("parses each leaf element when the scalar field contains a 2D array", () =>
     },
   });
 });
+
+test("returns null as-is when null is stored in a scalar field position", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          endTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        endTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        endTime: null,
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      endTime: null,
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1,6 +1,9 @@
 import { gql } from "@apollo/client";
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
-import { spyOnConsole } from "@apollo/client/testing/internal";
+import {
+  ObservableStream,
+  spyOnConsole,
+} from "@apollo/client/testing/internal";
 
 const dateTimeScalar = new Scalar<string, Date>({
   serialize: (value) => value.toISOString(),
@@ -952,6 +955,92 @@ test("parses scalar values across a complex nested query", () => {
       ],
     },
   });
+});
+
+test("parses scalar values on each emit from cache.watchFragment", async () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T09:00:00.000Z",
+    },
+  });
+
+  using stream = new ObservableStream(
+    cache.watchFragment({
+      fragment,
+      from: { __typename: "Event", id: "1" },
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T09:00:00.000Z"),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-06-15T14:30:00.000Z",
+    },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-06-15T14:30:00.000Z"),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-12-31T23:59:59.000Z",
+    },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-12-31T23:59:59.000Z"),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
 });
 
 test("ignores scalar and emits a dev warning when a scalar option is set on a field with a selection set", () => {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1250,6 +1250,38 @@ test("leaves parsed value unchanged when modifying via cache.modify with no scal
   });
 });
 
+test("parses a scalar field on an implicit root type when modifying via cache.modify", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Query: {
+        fields: {
+          now: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  cache.restore({
+    ROOT_QUERY: {
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  cache.modify({
+    id: "ROOT_QUERY",
+    fields: {
+      now: () => "2026-06-15T14:30:00.000Z",
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: {
+      now: new Date("2026-06-15T14:30:00.000Z"),
+    },
+  });
+});
+
 test("stores each element as a parsed value when modifying an array of scalar values via cache.modify", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1,3 +1,4 @@
+import type { TypedDocumentNode } from "@apollo/client";
 import { gql } from "@apollo/client";
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
 import {
@@ -3464,6 +3465,72 @@ test("preserves an existing scalar option when policies.addTypePolicies updates 
       startTime: new Date("2026-01-01T00:00:00.000Z"),
     },
   });
+});
+
+test("maintains referential equality with multiple cache reads", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: {
+            scalar: "DateTime",
+          },
+        },
+      },
+    },
+  });
+
+  const query: TypedDocumentNode<{
+    event: { __typename: "Event"; id: string; startTime: Date };
+  }> = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  const fragment: TypedDocumentNode<{
+    __typename: "Event";
+    id: string;
+    startTime: Date;
+  }> = gql`
+    fragment EventFragment on Event {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        // @ts-expect-error TODO: Need to figure out types
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  const initialValue = cache.readQuery({ query });
+
+  {
+    const result = cache.readQuery({ query });
+
+    expect(result!.event.startTime).toBe(initialValue!.event.startTime);
+  }
+
+  {
+    const result = cache.readFragment({
+      fragment,
+      from: { __typename: "Event", id: "1" },
+    });
+
+    expect(result!.startTime).toBe(initialValue!.event.startTime);
+  }
 });
 
 // This helper function extracts the raw stored value for tests to actually

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -38,8 +38,8 @@ test("serialize uses the configured serialize function", () => {
 
   const scalar = cache.getScalar("DateTime")!;
 
-  expect(scalar.serialize(new Date("2024-01-01T00:00:00.000Z"))).toBe(
-    "2024-01-01T00:00:00.000Z"
+  expect(scalar.serialize(new Date("2026-01-01T00:00:00.000Z"))).toBe(
+    "2026-01-01T00:00:00.000Z"
   );
 });
 
@@ -55,8 +55,8 @@ test("parse uses the configured parse function", () => {
 
   const scalar = cache.getScalar("DateTime")!;
 
-  expect(scalar.parse("2024-01-01T00:00:00.000Z")).toEqual(
-    new Date("2024-01-01T00:00:00.000Z")
+  expect(scalar.parse("2026-01-01T00:00:00.000Z")).toEqual(
+    new Date("2026-01-01T00:00:00.000Z")
   );
 });
 
@@ -72,8 +72,8 @@ test("is defaults to a non-null object check when not configured", () => {
 
   const scalar = cache.getScalar("DateTime")!;
 
-  expect(scalar.is(new Date("2024-01-01T00:00:00.000Z"))).toBe(true);
-  expect(scalar.is("2024-01-01T00:00:00.000Z")).toBe(false);
+  expect(scalar.is(new Date("2026-01-01T00:00:00.000Z"))).toBe(true);
+  expect(scalar.is("2026-01-01T00:00:00.000Z")).toBe(false);
 });
 
 test("is uses the configured type guard when configured", () => {
@@ -89,6 +89,6 @@ test("is uses the configured type guard when configured", () => {
 
   const scalar = cache.getScalar("DateTime")!;
 
-  expect(scalar.is(new Date("2024-01-01T00:00:00.000Z"))).toBe(true);
+  expect(scalar.is(new Date("2026-01-01T00:00:00.000Z"))).toBe(true);
   expect(scalar.is(new Date("invalid"))).toBe(false);
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -118,6 +118,48 @@ test("is uses the configured type guard when configured", () => {
   expect(scalar.is(new Date("invalid"))).toBe(false);
 });
 
+test("serializes parsed scalar value when writing via cache.writeQuery", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1139,3 +1139,177 @@ test("ignores scalar and emits a dev warning when a scalar option is set on a fi
     "DateTime"
   );
 });
+
+test("deep merges scalar option with policies.addTypePolices", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+      Price: priceScalar,
+      JSONObject: jsonObjectScalar,
+    },
+    typePolicies: {
+      Conference: {
+        fields: {
+          startDate: { scalar: "DateTime" },
+          endDate: { merge: (_, incoming) => incoming },
+        },
+      },
+      Schedule: {
+        fields: {
+          timeSlots: { scalar: "Price" },
+        },
+      },
+      Speaker: {
+        fields: {
+          availableTimes: { keyArgs: false },
+        },
+      },
+    },
+  });
+
+  cache.policies.addTypePolicies({
+    Conference: {
+      fields: {
+        endDate: { scalar: "DateTime" },
+        ticketPrice: { scalar: "Price" },
+      },
+    },
+    Schedule: {
+      fields: {
+        timeSlots: { scalar: "DateTime" },
+      },
+    },
+    Speaker: {
+      fields: {
+        availableTimes: { scalar: "DateTime" },
+      },
+    },
+    Session: {
+      fields: {
+        startTime: { scalar: "DateTime" },
+        metadata: { scalar: "JSONObject" },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      conference {
+        id
+        name
+        startDate
+        endDate
+        ticketPrice
+        schedule {
+          timeSlots
+        }
+        speakers {
+          id
+          name
+          availableTimes
+        }
+        sessions {
+          __typename
+          id
+          startTime
+          metadata
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      conference: {
+        __typename: "Conference",
+        id: "conf-1",
+        name: "GraphQL Summit",
+        startDate: "2026-09-15T09:00:00.000Z",
+        endDate: "2026-09-15T11:00:00.000Z",
+        ticketPrice: 19900,
+        schedule: {
+          __typename: "Schedule",
+          timeSlots: [
+            ["2026-09-15T09:00:00.000Z", "2026-09-15T10:00:00.000Z"],
+            ["2026-09-15T14:00:00.000Z", "2026-09-15T15:00:00.000Z"],
+          ],
+        },
+        speakers: [
+          {
+            __typename: "Speaker",
+            id: "speaker-1",
+            name: "Alice",
+            availableTimes: [
+              "2026-09-15T09:00:00.000Z",
+              "2026-09-15T14:00:00.000Z",
+            ],
+          },
+          {
+            __typename: "Speaker",
+            id: "speaker-2",
+            name: "Bob",
+            availableTimes: ["2026-09-15T10:00:00.000Z", null],
+          },
+        ],
+        sessions: [
+          {
+            __typename: "Session",
+            id: "session-1",
+            startTime: "2026-09-15T09:00:00.000Z",
+            metadata: { dress: "casual" },
+          },
+        ],
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    conference: {
+      __typename: "Conference",
+      id: "conf-1",
+      name: "GraphQL Summit",
+      startDate: new Date("2026-09-15T09:00:00.000Z"),
+      endDate: new Date("2026-09-15T11:00:00.000Z"),
+      ticketPrice: "199.00",
+      schedule: {
+        __typename: "Schedule",
+        timeSlots: [
+          [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T10:00:00.000Z"),
+          ],
+          [
+            new Date("2026-09-15T14:00:00.000Z"),
+            new Date("2026-09-15T15:00:00.000Z"),
+          ],
+        ],
+      },
+      speakers: [
+        {
+          __typename: "Speaker",
+          id: "speaker-1",
+          name: "Alice",
+          availableTimes: [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T14:00:00.000Z"),
+          ],
+        },
+        {
+          __typename: "Speaker",
+          id: "speaker-2",
+          name: "Bob",
+          availableTimes: [new Date("2026-09-15T10:00:00.000Z"), null],
+        },
+      ],
+      sessions: [
+        {
+          __typename: "Session",
+          id: "session-1",
+          startTime: new Date("2026-09-15T09:00:00.000Z"),
+          metadata: new Map([["dress", "casual"]]),
+        },
+      ],
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -724,6 +724,53 @@ test("parses scalar values when fields are selected through an interface fragmen
   });
 });
 
+test("returns the raw value unchanged when a scalar field policy names an unregistered scalar", () => {
+  using _ = spyOnConsole("warn");
+
+  const cache = new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: {
+            scalar: "Identity",
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        __typename
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
 test("parses scalar values across a complex nested query", () => {
   const cache = new InMemoryCache({
     scalars: {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -237,6 +237,50 @@ test("leaves parsed value unchanged when no scalar policy is configured", () => 
   });
 });
 
+test("serializes each element when writing an array of parsed scalar values", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          meetingTimes: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        meetingTimes
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-02T09:00:00.000Z"),
+        ],
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+      },
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -331,6 +331,48 @@ test("serializes each leaf element when writing a 2D array of parsed scalar valu
   });
 });
 
+test("stores null as-is when null is written to a scalar field", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          endTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        endTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        endTime: null,
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      endTime: null,
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -446,6 +446,50 @@ test("stores each element as a parsed value when writing an array of scalar valu
   });
 });
 
+test("parses each serialized element when writing an array of scalar values", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          meetingTimes: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        meetingTimes
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+      },
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-02T09:00:00.000Z"),
+        ],
+      },
+    },
+  });
+});
+
 test("stores each leaf element as a parsed value when writing a 2D array of scalar values", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1337,6 +1337,54 @@ test("stores null as-is when null is returned by a modifier for a scalar field",
   });
 });
 
+test("deletes a scalar field when returning DELETE from cache.modify", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  cache.modify({
+    id: cache.identify({ __typename: "Event", id: "1" }),
+    fields: {
+      startTime: (_, { DELETE }) => DELETE,
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+    },
+  });
+});
+
 test("stores object-based parsed scalar values when modifying via cache.modify", () => {
   const cache = new InMemoryCache({
     scalars: { JSONObject: jsonObjectScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -150,7 +150,7 @@ test("serializes parsed scalar value when writing via cache.writeQuery", () => {
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -192,7 +192,7 @@ test("leaves serialized value unchanged when writing via cache.writeQuery", () =
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -227,7 +227,7 @@ test("leaves parsed value unchanged when no scalar policy is configured", () => 
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -270,7 +270,7 @@ test("serializes parsed scalar value when the field has an alias", () => {
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -313,7 +313,7 @@ test("serializes parsed scalar value when the field has arguments with variables
     variables: { timezone: "UTC" },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -355,7 +355,7 @@ test("serializes parsed scalar value when the field has arguments with literal v
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -398,7 +398,7 @@ test("serializes each element when writing an array of parsed scalar values", ()
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
       schedule: {
@@ -445,7 +445,7 @@ test("serializes each leaf element when writing a 2D array of parsed scalar valu
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
       schedule: {
@@ -491,7 +491,7 @@ test("stores null as-is when null is written to a scalar field", () => {
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -536,7 +536,7 @@ test("serializes object-based parsed scalar values when writing", () => {
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", product: { __ref: "Product:1" } },
     "Product:1": {
       __typename: "Product",
@@ -574,14 +574,11 @@ test("serializes parsed scalar value when writing via cache.writeFragment", () =
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     "Event:1": {
       __typename: "Event",
       id: "1",
       startTime: "2026-01-01T00:00:00.000Z",
-    },
-    __META: {
-      extraRootIds: ["Event:1"],
     },
   });
 });
@@ -629,7 +626,7 @@ test("serializes parsed scalar value when overwriting an existing field", () => 
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -674,7 +671,7 @@ test("serializes parsed scalar value when a merge function is also configured on
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
       event: { __ref: "Event:1" },
@@ -722,7 +719,7 @@ test("serializes the parsed value returned by a merge function", () => {
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
       event: { __ref: "Event:1" },
@@ -771,7 +768,7 @@ test("serializes each element when writing an array of parsed scalar values with
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
       schedule: {
@@ -821,7 +818,7 @@ test("serializes each leaf element when writing a 2D array of parsed scalar valu
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
       schedule: {
@@ -959,7 +956,7 @@ test("serializes parsed scalar values across a complex nested write", () => {
     },
   });
 
-  expect(cache.extract()).toMatchObject({
+  expect(rawCacheData(cache)).toMatchObject({
     ROOT_QUERY: {
       __typename: "Query",
       conference: { __ref: "Conference:conf-1" },
@@ -1045,7 +1042,7 @@ test("serializes parsed scalar value when modifying via cache.modify", () => {
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -1094,7 +1091,7 @@ test("leaves serialized value unchanged when modifying via cache.modify", () => 
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -1136,7 +1133,7 @@ test("leaves parsed value unchanged when modifying via cache.modify with no scal
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -1188,7 +1185,7 @@ test("serializes each element when modifying an array of parsed scalar values vi
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", speaker: { __ref: "Speaker:1" } },
     "Speaker:1": {
       __typename: "Speaker",
@@ -1243,7 +1240,7 @@ test("serializes each leaf element when modifying a 2D array of parsed scalar va
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", speaker: { __ref: "Speaker:1" } },
     "Speaker:1": {
       __typename: "Speaker",
@@ -1295,7 +1292,7 @@ test("stores null as-is when null is returned by a modifier for a scalar field",
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
     "Event:1": {
       __typename: "Event",
@@ -1348,7 +1345,7 @@ test("serializes object-based parsed scalar values when modifying via cache.modi
     },
   });
 
-  expect(cache.extract()).toEqual({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: { __typename: "Query", product: { __ref: "Product:1" } },
     "Product:1": {
       __typename: "Product",
@@ -2680,3 +2677,11 @@ test("deep merges scalar option with policies.addTypePolices", () => {
     },
   });
 });
+
+// This helper function extracts the raw stored value for tests to actually
+// verify we write the parsed value. cache.extract() traverses the result and
+// serializes the scalar values which means we can't truly check if the result
+// was written correctly.
+function rawCacheData(cache: InMemoryCache) {
+  return cache["data"].toObject();
+}

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -6,6 +6,12 @@ const dateTimeScalar = new Scalar<string, Date>({
   parse: (value) => new Date(value),
 });
 
+const priceScalar = new Scalar<number, string>({
+  serialize: (dollars) => Math.round(parseFloat(dollars) * 100),
+  parse: (cents) => `${(cents / 100).toFixed(2)}`,
+  is: (value) => typeof value === "string",
+});
+
 test("getScalar returns a scalar object for a configured scalar", () => {
   const cache = new InMemoryCache({
     scalars: {
@@ -360,12 +366,6 @@ test("parses object-based scalar values (e.g. JSON) when reading from cache", ()
 });
 
 test("parses primitive-to-primitive scalar values when reading from cache", () => {
-  const priceScalar = new Scalar<number, string>({
-    serialize: (dollars) => Math.round(parseFloat(dollars) * 100),
-    parse: (cents) => `${(cents / 100).toFixed(2)}`,
-    is: (value) => typeof value === "string",
-  });
-
   const cache = new InMemoryCache({
     scalars: { Price: priceScalar },
     typePolicies: {
@@ -450,5 +450,54 @@ test("parses scalar fields within each object in an array", () => {
         startTime: new Date("2026-01-02T09:00:00.000Z"),
       },
     ],
+  });
+});
+
+test("parses multiple scalar fields on the same object", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar, Price: priceScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          endTime: { scalar: "DateTime" },
+          ticketPrice: { scalar: "Price" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+        endTime
+        ticketPrice
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T09:00:00.000Z",
+        endTime: "2026-01-01T10:00:00.000Z",
+        ticketPrice: 2099,
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T09:00:00.000Z"),
+      endTime: new Date("2026-01-01T10:00:00.000Z"),
+      ticketPrice: "20.99",
+    },
   });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1742,6 +1742,297 @@ test("cache.extract() serializes all stored parsed scalar values", () => {
   });
 });
 
+test("cache.restore() parses all serialized scalar values before storing them", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+      Price: priceScalar,
+      JSONObject: jsonObjectScalar,
+    },
+    possibleTypes: {
+      Schedulable: ["Session", "Workshop"],
+    },
+    typePolicies: {
+      Conference: {
+        fields: {
+          startDate: { scalar: "DateTime" },
+          endDate: { scalar: "DateTime" },
+          ticketPrice: { scalar: "Price" },
+        },
+      },
+      Schedule: {
+        fields: {
+          meetingTimes: { scalar: "DateTime" },
+          availabilitySlots: { scalar: "DateTime" },
+        },
+      },
+      Speaker: {
+        fields: {
+          availableTimes: { scalar: "DateTime" },
+        },
+      },
+      Session: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+      Workshop: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+    },
+  });
+
+  cache.restore({
+    ROOT_QUERY: {
+      __typename: "Query",
+      conference: { __ref: "Conference:conf-1" },
+    },
+    "Conference:conf-1": {
+      __typename: "Conference",
+      id: "conf-1",
+      name: "GraphQL Summit",
+      startDate: "2026-09-15T09:00:00.000Z",
+      endDate: null,
+      ticketPrice: 19900,
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: ["2026-09-15T09:00:00.000Z", "2026-09-15T14:00:00.000Z"],
+        availabilitySlots: [
+          ["2026-09-15T09:00:00.000Z", "2026-09-15T10:00:00.000Z"],
+          ["2026-09-15T14:00:00.000Z"],
+        ],
+      },
+      scheduledItems: [
+        { __ref: "Session:session-1" },
+        { __ref: "Workshop:workshop-1" },
+      ],
+      speakers: [
+        { __ref: "Speaker:speaker-1" },
+        { __ref: "Speaker:speaker-2" },
+      ],
+    },
+    "Speaker:speaker-1": {
+      __typename: "Speaker",
+      id: "speaker-1",
+      name: "Alice",
+      'availableTimes({"timezone":"UTC"})': [
+        "2026-09-15T09:00:00.000Z",
+        "2026-09-15T14:00:00.000Z",
+      ],
+    },
+    "Speaker:speaker-2": {
+      __typename: "Speaker",
+      id: "speaker-2",
+      name: "Bob",
+      'availableTimes({"timezone":"UTC"})': ["2026-09-15T10:00:00.000Z", null],
+    },
+    "Session:session-1": {
+      __typename: "Session",
+      id: "session-1",
+      'startTime({"timezone":"UTC"})': "2026-09-15T09:00:00.000Z",
+      metadata: { dress: "casual" },
+    },
+    "Workshop:workshop-1": {
+      __typename: "Workshop",
+      id: "workshop-1",
+      'startTime({"timezone":"UTC"})': "2026-09-15T14:00:00.000Z",
+      metadata: { venue: "The Workshop Building" },
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      conference: { __ref: "Conference:conf-1" },
+    },
+    "Conference:conf-1": {
+      __typename: "Conference",
+      id: "conf-1",
+      name: "GraphQL Summit",
+      startDate: new Date("2026-09-15T09:00:00.000Z"),
+      endDate: null,
+      ticketPrice: "199.00",
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: [
+          new Date("2026-09-15T09:00:00.000Z"),
+          new Date("2026-09-15T14:00:00.000Z"),
+        ],
+        availabilitySlots: [
+          [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T10:00:00.000Z"),
+          ],
+          [new Date("2026-09-15T14:00:00.000Z")],
+        ],
+      },
+      scheduledItems: [
+        { __ref: "Session:session-1" },
+        { __ref: "Workshop:workshop-1" },
+      ],
+      speakers: [
+        { __ref: "Speaker:speaker-1" },
+        { __ref: "Speaker:speaker-2" },
+      ],
+    },
+    "Speaker:speaker-1": {
+      __typename: "Speaker",
+      id: "speaker-1",
+      name: "Alice",
+      'availableTimes({"timezone":"UTC"})': [
+        new Date("2026-09-15T09:00:00.000Z"),
+        new Date("2026-09-15T14:00:00.000Z"),
+      ],
+    },
+    "Speaker:speaker-2": {
+      __typename: "Speaker",
+      id: "speaker-2",
+      name: "Bob",
+      'availableTimes({"timezone":"UTC"})': [
+        new Date("2026-09-15T10:00:00.000Z"),
+        null,
+      ],
+    },
+    "Session:session-1": {
+      __typename: "Session",
+      id: "session-1",
+      'startTime({"timezone":"UTC"})': new Date("2026-09-15T09:00:00.000Z"),
+      metadata: new Map([["dress", "casual"]]),
+    },
+    "Workshop:workshop-1": {
+      __typename: "Workshop",
+      id: "workshop-1",
+      'startTime({"timezone":"UTC"})': new Date("2026-09-15T14:00:00.000Z"),
+      metadata: new Map([["venue", "The Workshop Building"]]),
+    },
+  });
+});
+
+test("cache.restore() leaves values as-is when no scalar policy is configured for the field", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+  });
+
+  cache.restore({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
+test("cache.restore() parses scalar fields on root objects with an implicit typename", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Query: {
+        fields: {
+          now: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  cache.restore({
+    ROOT_QUERY: {
+      now: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: {
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("cache.restore() parses scalar fields on a custom root type with an implicit typename", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      RootQuery: {
+        queryType: true,
+        fields: {
+          now: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  cache.restore({
+    ROOT_QUERY: {
+      now: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: {
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("cache.restore() parses scalar fields in arrays of non-normalized objects", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        keyFields: false,
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  cache.restore({
+    ROOT_QUERY: {
+      __typename: "Query",
+      events: [
+        {
+          __typename: "Event",
+          startTime: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          __typename: "Event",
+          startTime: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      events: [
+        {
+          __typename: "Event",
+          startTime: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        {
+          __typename: "Event",
+          startTime: new Date("2026-02-01T00:00:00.000Z"),
+        },
+      ],
+    },
+  });
+});
+
 test("cache.extract() returns the parsed value as-is when no scalar policy is configured for the field", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -199,6 +199,89 @@ test("parses scalar value when reading a field via cache.readFragment", () => {
   });
 });
 
+test("parses scalar value when the field has literal arguments", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime(timezone: "UTC")
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("parses scalar value when the field has arguments with variables", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query ($timezone: String!) {
+      event {
+        id
+        startTime(timezone: $timezone)
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+    variables: { timezone: "UTC" },
+  });
+
+  expect(cache.readQuery({ query, variables: { timezone: "UTC" } })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
 test("parses each element when the scalar field contains an array of values", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1209,6 +1209,59 @@ test("parses serialized scalar value when modifying via cache.modify", () => {
   });
 });
 
+test("cache.modify preserves referential identity for deeply equal parsed scalar values", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  const existingStartTime = rawCacheData(cache)["Event:1"]!.startTime;
+
+  cache.modify({
+    id: cache.identify({ __typename: "Event", id: "1" }),
+    fields: {
+      startTime: () => "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(rawCacheData(cache)["Event:1"]!.startTime).toBe(existingStartTime);
+
+  cache.modify({
+    id: cache.identify({ __typename: "Event", id: "1" }),
+    fields: {
+      startTime: () => new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(rawCacheData(cache)["Event:1"]!.startTime).toBe(existingStartTime);
+});
+
 test("leaves parsed value unchanged when modifying via cache.modify with no scalar policy configured", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -771,6 +771,50 @@ test("returns the raw value unchanged when a scalar field policy names an unregi
   expect(console.warn).not.toHaveBeenCalled();
 });
 
+test("parses scalars for fields with aliases", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        __typename
+        id
+        start: startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        start: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      start: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
 test("parses scalar values across a complex nested query", () => {
   const cache = new InMemoryCache({
     scalars: {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1,4 +1,10 @@
+import { gql } from "@apollo/client";
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
+
+const dateTimeScalar = new Scalar<string, Date>({
+  serialize: (value) => value.toISOString(),
+  parse: (value) => new Date(value),
+});
 
 test("getScalar returns a scalar object for a configured scalar", () => {
   const cache = new InMemoryCache({
@@ -91,4 +97,126 @@ test("is uses the configured type guard when configured", () => {
 
   expect(scalar.is(new Date("2026-01-01T00:00:00.000Z"))).toBe(true);
   expect(scalar.is(new Date("invalid"))).toBe(false);
+});
+
+test("parses scalar value when reading a field via cache.readQuery", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("parses scalar value when reading a field via cache.readFragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(
+    cache.readFragment({
+      id: cache.identify({ __typename: "Event", id: "1" })!,
+      fragment,
+    })
+  ).toEqual({
+    __typename: "Event",
+    id: "1",
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+  });
+});
+
+test("parses each element when the scalar field contains an array of values", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          meetingTimes: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        meetingTimes
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    schedule: {
+      __typename: "Schedule",
+      meetingTimes: [
+        new Date("2026-01-01T09:00:00.000Z"),
+        new Date("2026-01-02T09:00:00.000Z"),
+      ],
+    },
+  });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -373,6 +373,51 @@ test("stores null as-is when null is written to a scalar field", () => {
   });
 });
 
+test("serializes object-based parsed scalar values when writing", () => {
+  const cache = new InMemoryCache({
+    scalars: { JSONObject: jsonObjectScalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      product {
+        id
+        metadata
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      product: {
+        __typename: "Product",
+        id: "1",
+        metadata: new Map([
+          ["color", "red"],
+          ["size", "large"],
+        ]),
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", product: { __ref: "Product:1" } },
+    "Product:1": {
+      __typename: "Product",
+      id: "1",
+      metadata: { color: "red", size: "large" },
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1262,6 +1262,58 @@ test("cache.modify preserves referential identity for deeply equal parsed scalar
   expect(rawCacheData(cache)["Event:1"]!.startTime).toBe(existingStartTime);
 });
 
+test("cache.modify preserves references when scalar values are already parsed", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        keyFields: false,
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        name
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        name: "Opening keynote",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  const replacementEvent = {
+    __typename: "Event",
+    name: "Closing keynote",
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+  };
+
+  cache.modify({
+    id: "ROOT_QUERY",
+    fields: {
+      event: () => replacementEvent,
+    },
+  });
+
+  const modifiedEvent = rawCacheData(cache).ROOT_QUERY!.event;
+
+  expect(modifiedEvent).toBe(replacementEvent);
+  expect((modifiedEvent as any).startTime).toBe(replacementEvent.startTime);
+});
+
 test("leaves parsed value unchanged when modifying via cache.modify with no scalar policy configured", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
@@ -1963,6 +2015,34 @@ test("cache.restore() parses all serialized scalar values before storing them", 
       metadata: new Map([["venue", "The Workshop Building"]]),
     },
   });
+});
+
+test("cache.restore() preserves references when scalar values are already parsed", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const event = {
+    __typename: "Event",
+    id: "1",
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+  };
+
+  cache.restore({
+    "Event:1": event,
+  });
+
+  const restoredEvent = rawCacheData(cache)["Event:1"];
+
+  expect(restoredEvent).toBe(event);
+  expect(restoredEvent!.startTime).toBe(event.startTime);
 });
 
 test("cache.restore() leaves values as-is when no scalar policy is configured for the field", () => {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -589,3 +589,66 @@ test("parses scalar values when the field is selected via an inline fragment", (
     },
   });
 });
+
+test("parses scalar values on the matching member types of a union", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: { startTime: { scalar: "DateTime" } },
+      },
+      Appointment: {
+        fields: { startTime: { scalar: "DateTime" } },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      searchResults {
+        __typename
+        ... on Event {
+          id
+          startTime
+        }
+        ... on Appointment {
+          id
+          startTime
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      searchResults: [
+        {
+          __typename: "Event",
+          id: "1",
+          startTime: "2026-01-01T09:00:00.000Z",
+        },
+        {
+          __typename: "Appointment",
+          id: "2",
+          startTime: "2026-01-02T14:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    searchResults: [
+      {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T09:00:00.000Z"),
+      },
+      {
+        __typename: "Appointment",
+        id: "2",
+        startTime: new Date("2026-01-02T14:00:00.000Z"),
+      },
+    ],
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -607,6 +607,106 @@ test("serializes the parsed value returned by a merge function", () => {
   });
 });
 
+test("serializes each element when writing an array of parsed scalar values with a merge function", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          meetingTimes: {
+            scalar: "DateTime",
+            merge: (_, incoming) => incoming,
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        meetingTimes
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-02T09:00:00.000Z"),
+        ],
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+      },
+    },
+  });
+});
+
+test("serializes each leaf element when writing a 2D array of parsed scalar values with a merge function", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          availabilitySlots: {
+            scalar: "DateTime",
+            merge: (_, incoming) => incoming,
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        availabilitySlots
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        availabilitySlots: [
+          [
+            new Date("2026-01-01T09:00:00.000Z"),
+            new Date("2026-01-01T10:00:00.000Z"),
+          ],
+          [new Date("2026-01-02T14:00:00.000Z")],
+        ],
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      schedule: {
+        __typename: "Schedule",
+        availabilitySlots: [
+          ["2026-01-01T09:00:00.000Z", "2026-01-01T10:00:00.000Z"],
+          ["2026-01-02T14:00:00.000Z"],
+        ],
+      },
+    },
+  });
+});
+
 test("serializes parsed scalar values across a complex nested write", () => {
   const cache = new InMemoryCache({
     scalars: {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -652,3 +652,67 @@ test("parses scalar values on the matching member types of a union", () => {
     ],
   });
 });
+
+test("parses scalar values when fields are selected through an interface fragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    possibleTypes: {
+      Schedulable: ["Event", "Appointment"],
+    },
+    typePolicies: {
+      Event: {
+        fields: { startTime: { scalar: "DateTime" } },
+      },
+      Appointment: {
+        fields: { startTime: { scalar: "DateTime" } },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      scheduledItems {
+        __typename
+        ...SchedulableFields
+      }
+    }
+
+    fragment SchedulableFields on Schedulable {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      scheduledItems: [
+        {
+          __typename: "Event",
+          id: "1",
+          startTime: "2026-01-01T09:00:00.000Z",
+        },
+        {
+          __typename: "Appointment",
+          id: "2",
+          startTime: "2026-01-02T14:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    scheduledItems: [
+      {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T09:00:00.000Z"),
+      },
+      {
+        __typename: "Appointment",
+        id: "2",
+        startTime: new Date("2026-01-02T14:00:00.000Z"),
+      },
+    ],
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -3333,6 +3333,63 @@ test("deep merges scalar option with policies.addTypePolices", () => {
   });
 });
 
+test("preserves an existing scalar option when policies.addTypePolicies updates another field option", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: {
+            scalar: "DateTime",
+          },
+        },
+      },
+    },
+  });
+
+  cache.policies.addTypePolicies({
+    Event: {
+      fields: {
+        startTime: {
+          merge: (_, incoming) => incoming,
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      event: { __ref: "Event:1" },
+    },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
 // This helper function extracts the raw stored value for tests to actually
 // verify we write the parsed value. cache.extract() traverses the result and
 // serializes the scalar values which means we can't truly check if the result

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -281,6 +281,56 @@ test("serializes each element when writing an array of parsed scalar values", ()
   });
 });
 
+test("serializes each leaf element when writing a 2D array of parsed scalar values", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          availabilitySlots: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        availabilitySlots
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        availabilitySlots: [
+          [
+            new Date("2026-01-01T09:00:00.000Z"),
+            new Date("2026-01-01T10:00:00.000Z"),
+          ],
+          [new Date("2026-01-02T14:00:00.000Z")],
+        ],
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      schedule: {
+        __typename: "Schedule",
+        availabilitySlots: [
+          ["2026-01-01T09:00:00.000Z", "2026-01-01T10:00:00.000Z"],
+          ["2026-01-02T14:00:00.000Z"],
+        ],
+      },
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -160,6 +160,83 @@ test("serializes parsed scalar value when writing via cache.writeQuery", () => {
   });
 });
 
+test("leaves serialized value unchanged when writing via cache.writeQuery", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
+test("leaves parsed value unchanged when no scalar policy is configured", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1006,6 +1006,358 @@ test("serializes parsed scalar values across a complex nested write", () => {
   });
 });
 
+test("serializes parsed scalar value when modifying via cache.modify", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  cache.modify({
+    id: cache.identify({ __typename: "Event", id: "1" }),
+    fields: {
+      startTime: () => new Date("2026-06-15T14:30:00.000Z"),
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-06-15T14:30:00.000Z",
+    },
+  });
+});
+
+test("leaves serialized value unchanged when modifying via cache.modify", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  cache.modify({
+    id: cache.identify({ __typename: "Event", id: "1" }),
+    fields: {
+      startTime: () => "2026-06-15T14:30:00.000Z",
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-06-15T14:30:00.000Z",
+    },
+  });
+});
+
+test("leaves parsed value unchanged when modifying via cache.modify with no scalar policy configured", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  cache.modify({
+    id: cache.identify({ __typename: "Event", id: "1" }),
+    fields: {
+      startTime: () => new Date("2026-06-15T14:30:00.000Z"),
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-06-15T14:30:00.000Z"),
+    },
+  });
+});
+
+test("serializes each element when modifying an array of parsed scalar values via cache.modify", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Speaker: {
+        fields: {
+          availableTimes: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      speaker {
+        id
+        availableTimes
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      speaker: {
+        __typename: "Speaker",
+        id: "1",
+        availableTimes: ["2026-01-01T09:00:00.000Z"],
+      },
+    },
+  });
+
+  cache.modify({
+    id: cache.identify({ __typename: "Speaker", id: "1" }),
+    fields: {
+      availableTimes: () => [
+        new Date("2026-01-01T09:00:00.000Z"),
+        new Date("2026-01-02T09:00:00.000Z"),
+      ],
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", speaker: { __ref: "Speaker:1" } },
+    "Speaker:1": {
+      __typename: "Speaker",
+      id: "1",
+      availableTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+    },
+  });
+});
+
+test("serializes each leaf element when modifying a 2D array of parsed scalar values via cache.modify", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Speaker: {
+        fields: {
+          availabilitySlots: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      speaker {
+        id
+        availabilitySlots
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      speaker: {
+        __typename: "Speaker",
+        id: "1",
+        availabilitySlots: [["2026-01-01T09:00:00.000Z"]],
+      },
+    },
+  });
+
+  cache.modify({
+    id: cache.identify({ __typename: "Speaker", id: "1" }),
+    fields: {
+      availabilitySlots: () => [
+        [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-01T10:00:00.000Z"),
+        ],
+        [new Date("2026-01-02T14:00:00.000Z")],
+      ],
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", speaker: { __ref: "Speaker:1" } },
+    "Speaker:1": {
+      __typename: "Speaker",
+      id: "1",
+      availabilitySlots: [
+        ["2026-01-01T09:00:00.000Z", "2026-01-01T10:00:00.000Z"],
+        ["2026-01-02T14:00:00.000Z"],
+      ],
+    },
+  });
+});
+
+test("stores null as-is when null is returned by a modifier for a scalar field", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          endTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        endTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        endTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  cache.modify({
+    id: cache.identify({ __typename: "Event", id: "1" }),
+    fields: {
+      endTime: () => null,
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      endTime: null,
+    },
+  });
+});
+
+test("serializes object-based parsed scalar values when modifying via cache.modify", () => {
+  const cache = new InMemoryCache({
+    scalars: { JSONObject: jsonObjectScalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      product {
+        id
+        metadata
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      product: {
+        __typename: "Product",
+        id: "1",
+        metadata: { color: "red", size: "large" },
+      },
+    },
+  });
+
+  cache.modify({
+    id: cache.identify({ __typename: "Product", id: "1" }),
+    fields: {
+      metadata: () =>
+        new Map([
+          ["color", "blue"],
+          ["size", "medium"],
+        ]),
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", product: { __ref: "Product:1" } },
+    "Product:1": {
+      __typename: "Product",
+      id: "1",
+      metadata: { color: "blue", size: "medium" },
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -237,6 +237,134 @@ test("leaves parsed value unchanged when no scalar policy is configured", () => 
   });
 });
 
+test("serializes parsed scalar value when the field has an alias", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        __typename
+        id
+        start: startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        start: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
+test("serializes parsed scalar value when the field has arguments with variables", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query ($timezone: String!) {
+      event {
+        id
+        startTime(timezone: $timezone)
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+    variables: { timezone: "UTC" },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      'startTime({"timezone":"UTC"})': "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
+test("serializes parsed scalar value when the field has arguments with literal value", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime(timezone: "UTC")
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      'startTime({"timezone":"UTC"})': "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
 test("serializes each element when writing an array of parsed scalar values", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -118,7 +118,7 @@ test("is uses the configured type guard when configured", () => {
   expect(scalar.is(new Date("invalid"))).toBe(false);
 });
 
-test("serializes parsed scalar value when writing via cache.writeQuery", () => {
+test("stores parsed scalar value in the cache when writing via cache.writeQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -155,12 +155,12 @@ test("serializes parsed scalar value when writing via cache.writeQuery", () => {
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-01-01T00:00:00.000Z",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });
 
-test("leaves serialized value unchanged when writing via cache.writeQuery", () => {
+test("parses serialized scalar value when writing via cache.writeQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -197,7 +197,7 @@ test("leaves serialized value unchanged when writing via cache.writeQuery", () =
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-01-01T00:00:00.000Z",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });
@@ -237,7 +237,7 @@ test("leaves parsed value unchanged when no scalar policy is configured", () => 
   });
 });
 
-test("serializes parsed scalar value when the field has an alias", () => {
+test("stores parsed scalar value in the cache when the field has an alias", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -275,12 +275,12 @@ test("serializes parsed scalar value when the field has an alias", () => {
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-01-01T00:00:00.000Z",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });
 
-test("serializes parsed scalar value when the field has arguments with variables", () => {
+test("stores parsed scalar value in the cache when the field has arguments with variables", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -318,12 +318,12 @@ test("serializes parsed scalar value when the field has arguments with variables
     "Event:1": {
       __typename: "Event",
       id: "1",
-      'startTime({"timezone":"UTC"})': "2026-01-01T00:00:00.000Z",
+      'startTime({"timezone":"UTC"})': new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });
 
-test("serializes parsed scalar value when the field has arguments with literal value", () => {
+test("stores parsed scalar value in the cache when the field has arguments with literal value", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -360,12 +360,12 @@ test("serializes parsed scalar value when the field has arguments with literal v
     "Event:1": {
       __typename: "Event",
       id: "1",
-      'startTime({"timezone":"UTC"})': "2026-01-01T00:00:00.000Z",
+      'startTime({"timezone":"UTC"})': new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });
 
-test("serializes each element when writing an array of parsed scalar values", () => {
+test("stores each element as a parsed value when writing an array of scalar values", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -403,13 +403,16 @@ test("serializes each element when writing an array of parsed scalar values", ()
       __typename: "Query",
       schedule: {
         __typename: "Schedule",
-        meetingTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+        meetingTimes: [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-02T09:00:00.000Z"),
+        ],
       },
     },
   });
 });
 
-test("serializes each leaf element when writing a 2D array of parsed scalar values", () => {
+test("stores each leaf element as a parsed value when writing a 2D array of scalar values", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -451,8 +454,11 @@ test("serializes each leaf element when writing a 2D array of parsed scalar valu
       schedule: {
         __typename: "Schedule",
         availabilitySlots: [
-          ["2026-01-01T09:00:00.000Z", "2026-01-01T10:00:00.000Z"],
-          ["2026-01-02T14:00:00.000Z"],
+          [
+            new Date("2026-01-01T09:00:00.000Z"),
+            new Date("2026-01-01T10:00:00.000Z"),
+          ],
+          [new Date("2026-01-02T14:00:00.000Z")],
         ],
       },
     },
@@ -501,7 +507,7 @@ test("stores null as-is when null is written to a scalar field", () => {
   });
 });
 
-test("serializes object-based parsed scalar values when writing", () => {
+test("stores object-based parsed scalar values (e.g. Map) when writing", () => {
   const cache = new InMemoryCache({
     scalars: { JSONObject: jsonObjectScalar },
     typePolicies: {
@@ -541,12 +547,15 @@ test("serializes object-based parsed scalar values when writing", () => {
     "Product:1": {
       __typename: "Product",
       id: "1",
-      metadata: { color: "red", size: "large" },
+      metadata: new Map([
+        ["color", "red"],
+        ["size", "large"],
+      ]),
     },
   });
 });
 
-test("serializes parsed scalar value when writing via cache.writeFragment", () => {
+test("stores parsed scalar value in the cache when writing via cache.writeFragment", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -578,12 +587,12 @@ test("serializes parsed scalar value when writing via cache.writeFragment", () =
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-01-01T00:00:00.000Z",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });
 
-test("serializes parsed scalar value when overwriting an existing field", () => {
+test("stores parsed scalar value in the cache when overwriting an existing field", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -631,12 +640,12 @@ test("serializes parsed scalar value when overwriting an existing field", () => 
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-06-15T14:30:00.000Z",
+      startTime: new Date("2026-06-15T14:30:00.000Z"),
     },
   });
 });
 
-test("serializes parsed scalar value when a merge function is also configured on the field", () => {
+test("stores parsed scalar value in the cache when a merge function is also configured on the field", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -679,12 +688,12 @@ test("serializes parsed scalar value when a merge function is also configured on
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-01-01T00:00:00.000Z",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });
 
-test("serializes the parsed value returned by a merge function", () => {
+test("stores the parsed value returned by a merge function in the cache", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -727,12 +736,12 @@ test("serializes the parsed value returned by a merge function", () => {
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-01-01T00:00:00.000Z",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });
 
-test("serializes each element when writing an array of parsed scalar values with a merge function", () => {
+test("stores each element as a parsed value when writing an array of scalar values with a merge function", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -773,13 +782,16 @@ test("serializes each element when writing an array of parsed scalar values with
       __typename: "Query",
       schedule: {
         __typename: "Schedule",
-        meetingTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+        meetingTimes: [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-02T09:00:00.000Z"),
+        ],
       },
     },
   });
 });
 
-test("serializes each leaf element when writing a 2D array of parsed scalar values with a merge function", () => {
+test("stores each leaf element as a parsed value when writing a 2D array of scalar values with a merge function", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -824,15 +836,18 @@ test("serializes each leaf element when writing a 2D array of parsed scalar valu
       schedule: {
         __typename: "Schedule",
         availabilitySlots: [
-          ["2026-01-01T09:00:00.000Z", "2026-01-01T10:00:00.000Z"],
-          ["2026-01-02T14:00:00.000Z"],
+          [
+            new Date("2026-01-01T09:00:00.000Z"),
+            new Date("2026-01-01T10:00:00.000Z"),
+          ],
+          [new Date("2026-01-02T14:00:00.000Z")],
         ],
       },
     },
   });
 });
 
-test("serializes parsed scalar values across a complex nested write", () => {
+test("stores parsed scalar values across a complex nested write", () => {
   const cache = new InMemoryCache({
     scalars: {
       DateTime: dateTimeScalar,
@@ -965,14 +980,17 @@ test("serializes parsed scalar values across a complex nested write", () => {
       __typename: "Conference",
       id: "conf-1",
       name: "GraphQL Summit",
-      startDate: "2026-09-15T09:00:00.000Z",
+      startDate: new Date("2026-09-15T09:00:00.000Z"),
       endDate: null,
-      ticketPrice: 19900,
+      ticketPrice: "199.00",
       schedule: {
         __typename: "Schedule",
         timeSlots: [
-          ["2026-09-15T09:00:00.000Z", "2026-09-15T10:00:00.000Z"],
-          ["2026-09-15T14:00:00.000Z"],
+          [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T10:00:00.000Z"),
+          ],
+          [new Date("2026-09-15T14:00:00.000Z")],
         ],
       },
     },
@@ -980,30 +998,33 @@ test("serializes parsed scalar values across a complex nested write", () => {
       __typename: "Speaker",
       id: "speaker-1",
       name: "Alice",
-      availableTimes: ["2026-09-15T09:00:00.000Z", "2026-09-15T14:00:00.000Z"],
+      availableTimes: [
+        new Date("2026-09-15T09:00:00.000Z"),
+        new Date("2026-09-15T14:00:00.000Z"),
+      ],
     },
     "Speaker:speaker-2": {
       __typename: "Speaker",
       id: "speaker-2",
       name: "Bob",
-      availableTimes: ["2026-09-15T10:00:00.000Z", null],
+      availableTimes: [new Date("2026-09-15T10:00:00.000Z"), null],
     },
     "Session:session-1": {
       __typename: "Session",
       id: "session-1",
-      startTime: "2026-09-15T09:00:00.000Z",
-      metadata: { dress: "casual" },
+      startTime: new Date("2026-09-15T09:00:00.000Z"),
+      metadata: new Map([["dress", "casual"]]),
     },
     "Workshop:workshop-1": {
       __typename: "Workshop",
       id: "workshop-1",
-      startTime: "2026-09-15T14:00:00.000Z",
-      metadata: { venue: "The Workshop Building" },
+      startTime: new Date("2026-09-15T14:00:00.000Z"),
+      metadata: new Map([["venue", "The Workshop Building"]]),
     },
   });
 });
 
-test("serializes parsed scalar value when modifying via cache.modify", () => {
+test("stores parsed scalar value in the cache when modifying via cache.modify", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -1047,12 +1068,12 @@ test("serializes parsed scalar value when modifying via cache.modify", () => {
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-06-15T14:30:00.000Z",
+      startTime: new Date("2026-06-15T14:30:00.000Z"),
     },
   });
 });
 
-test("leaves serialized value unchanged when modifying via cache.modify", () => {
+test("parses serialized scalar value when modifying via cache.modify", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -1096,7 +1117,7 @@ test("leaves serialized value unchanged when modifying via cache.modify", () => 
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: "2026-06-15T14:30:00.000Z",
+      startTime: new Date("2026-06-15T14:30:00.000Z"),
     },
   });
 });
@@ -1143,7 +1164,7 @@ test("leaves parsed value unchanged when modifying via cache.modify with no scal
   });
 });
 
-test("serializes each element when modifying an array of parsed scalar values via cache.modify", () => {
+test("stores each element as a parsed value when modifying an array of scalar values via cache.modify", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -1190,12 +1211,15 @@ test("serializes each element when modifying an array of parsed scalar values vi
     "Speaker:1": {
       __typename: "Speaker",
       id: "1",
-      availableTimes: ["2026-01-01T09:00:00.000Z", "2026-01-02T09:00:00.000Z"],
+      availableTimes: [
+        new Date("2026-01-01T09:00:00.000Z"),
+        new Date("2026-01-02T09:00:00.000Z"),
+      ],
     },
   });
 });
 
-test("serializes each leaf element when modifying a 2D array of parsed scalar values via cache.modify", () => {
+test("stores each leaf element as a parsed value when modifying a 2D array of scalar values via cache.modify", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -1246,8 +1270,11 @@ test("serializes each leaf element when modifying a 2D array of parsed scalar va
       __typename: "Speaker",
       id: "1",
       availabilitySlots: [
-        ["2026-01-01T09:00:00.000Z", "2026-01-01T10:00:00.000Z"],
-        ["2026-01-02T14:00:00.000Z"],
+        [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-01T10:00:00.000Z"),
+        ],
+        [new Date("2026-01-02T14:00:00.000Z")],
       ],
     },
   });
@@ -1302,7 +1329,7 @@ test("stores null as-is when null is returned by a modifier for a scalar field",
   });
 });
 
-test("serializes object-based parsed scalar values when modifying via cache.modify", () => {
+test("stores object-based parsed scalar values when modifying via cache.modify", () => {
   const cache = new InMemoryCache({
     scalars: { JSONObject: jsonObjectScalar },
     typePolicies: {
@@ -1350,7 +1377,10 @@ test("serializes object-based parsed scalar values when modifying via cache.modi
     "Product:1": {
       __typename: "Product",
       id: "1",
-      metadata: { color: "blue", size: "medium" },
+      metadata: new Map([
+        ["color", "blue"],
+        ["size", "medium"],
+      ]),
     },
   });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -458,6 +458,230 @@ test("serializes parsed scalar value when writing via cache.writeFragment", () =
   });
 });
 
+test("serializes parsed scalar value when overwriting an existing field", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-06-15T14:30:00.000Z"),
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-06-15T14:30:00.000Z",
+    },
+  });
+});
+
+test("serializes parsed scalar values across a complex nested write", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+      Price: priceScalar,
+      JSONObject: jsonObjectScalar,
+    },
+    possibleTypes: {
+      Schedulable: ["Session", "Workshop"],
+    },
+    typePolicies: {
+      Conference: {
+        fields: {
+          startDate: { scalar: "DateTime" },
+          endDate: { scalar: "DateTime" },
+          ticketPrice: { scalar: "Price" },
+        },
+      },
+      Schedule: {
+        fields: {
+          timeSlots: { scalar: "DateTime" },
+        },
+      },
+      Speaker: {
+        fields: {
+          availableTimes: { scalar: "DateTime" },
+        },
+      },
+      Session: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+      Workshop: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      conference {
+        id
+        name
+        startDate
+        endDate
+        ticketPrice
+        schedule {
+          timeSlots
+        }
+        speakers {
+          id
+          name
+          availableTimes
+        }
+        scheduledItems {
+          __typename
+          id
+          startTime
+          metadata
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      conference: {
+        __typename: "Conference",
+        id: "conf-1",
+        name: "GraphQL Summit",
+        startDate: new Date("2026-09-15T09:00:00.000Z"),
+        endDate: null,
+        ticketPrice: "199.00",
+        schedule: {
+          __typename: "Schedule",
+          timeSlots: [
+            [
+              new Date("2026-09-15T09:00:00.000Z"),
+              new Date("2026-09-15T10:00:00.000Z"),
+            ],
+            [new Date("2026-09-15T14:00:00.000Z")],
+          ],
+        },
+        speakers: [
+          {
+            __typename: "Speaker",
+            id: "speaker-1",
+            name: "Alice",
+            availableTimes: [
+              new Date("2026-09-15T09:00:00.000Z"),
+              new Date("2026-09-15T14:00:00.000Z"),
+            ],
+          },
+          {
+            __typename: "Speaker",
+            id: "speaker-2",
+            name: "Bob",
+            availableTimes: [new Date("2026-09-15T10:00:00.000Z"), null],
+          },
+        ],
+        scheduledItems: [
+          {
+            __typename: "Session",
+            id: "session-1",
+            startTime: new Date("2026-09-15T09:00:00.000Z"),
+            metadata: new Map([["dress", "casual"]]),
+          },
+          {
+            __typename: "Workshop",
+            id: "workshop-1",
+            startTime: new Date("2026-09-15T14:00:00.000Z"),
+            metadata: new Map([["venue", "The Workshop Building"]]),
+          },
+        ],
+      },
+    },
+  });
+
+  expect(cache.extract()).toMatchObject({
+    ROOT_QUERY: {
+      __typename: "Query",
+      conference: { __ref: "Conference:conf-1" },
+    },
+    "Conference:conf-1": {
+      __typename: "Conference",
+      id: "conf-1",
+      name: "GraphQL Summit",
+      startDate: "2026-09-15T09:00:00.000Z",
+      endDate: null,
+      ticketPrice: 19900,
+      schedule: {
+        __typename: "Schedule",
+        timeSlots: [
+          ["2026-09-15T09:00:00.000Z", "2026-09-15T10:00:00.000Z"],
+          ["2026-09-15T14:00:00.000Z"],
+        ],
+      },
+    },
+    "Speaker:speaker-1": {
+      __typename: "Speaker",
+      id: "speaker-1",
+      name: "Alice",
+      availableTimes: ["2026-09-15T09:00:00.000Z", "2026-09-15T14:00:00.000Z"],
+    },
+    "Speaker:speaker-2": {
+      __typename: "Speaker",
+      id: "speaker-2",
+      name: "Bob",
+      availableTimes: ["2026-09-15T10:00:00.000Z", null],
+    },
+    "Session:session-1": {
+      __typename: "Session",
+      id: "session-1",
+      startTime: "2026-09-15T09:00:00.000Z",
+      metadata: { dress: "casual" },
+    },
+    "Workshop:workshop-1": {
+      __typename: "Workshop",
+      id: "workshop-1",
+      startTime: "2026-09-15T14:00:00.000Z",
+      metadata: { venue: "The Workshop Building" },
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -501,3 +501,91 @@ test("parses multiple scalar fields on the same object", () => {
     },
   });
 });
+
+test("parses scalar values when the field is selected via a named fragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        ...EventFields
+      }
+    }
+
+    fragment EventFields on Event {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("parses scalar values when the field is selected via an inline fragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        ... @defer {
+          id
+          startTime
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -405,3 +405,50 @@ test("parses primitive-to-primitive scalar values when reading from cache", () =
     },
   });
 });
+
+test("parses scalar fields within each object in an array", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      events {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      events: [
+        { __typename: "Event", id: "1", startTime: "2026-01-01T09:00:00.000Z" },
+        { __typename: "Event", id: "2", startTime: "2026-01-02T09:00:00.000Z" },
+      ],
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    events: [
+      {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T09:00:00.000Z"),
+      },
+      {
+        __typename: "Event",
+        id: "2",
+        startTime: new Date("2026-01-02T09:00:00.000Z"),
+      },
+    ],
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1666,6 +1666,121 @@ test("cache.extract() returns the parsed value as-is when no scalar policy is co
   });
 });
 
+test("cache.extract() serializes scalar fields in arrays of non-normalized objects written with cache.writeQuery", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        keyFields: false,
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      events {
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          startTime: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          __typename: "Event",
+          startTime: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      events: [
+        {
+          __typename: "Event",
+          startTime: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          __typename: "Event",
+          startTime: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    },
+  });
+});
+
+test("cache.extract() serializes scalar fields in arrays of non-normalized objects written with cache.writeFragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        keyFields: false,
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const fragment = gql`
+    fragment ScheduleFields on Schedule {
+      id
+      events {
+        startTime
+      }
+    }
+  `;
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Schedule",
+      id: "1",
+      events: [
+        {
+          __typename: "Event",
+          startTime: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          __typename: "Event",
+          startTime: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    "Schedule:1": {
+      __typename: "Schedule",
+      id: "1",
+      events: [
+        {
+          __typename: "Event",
+          startTime: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          __typename: "Event",
+          startTime: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+    },
+    __META: {
+      extraRootIds: ["Schedule:1"],
+    },
+  });
+});
+
 test("cache.extract(true) serializes scalar values from the optimistic layer", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -220,3 +220,50 @@ test("parses each element when the scalar field contains an array of values", ()
     },
   });
 });
+
+test("parses each leaf element when the scalar field contains a 2D array", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Schedule: {
+        fields: {
+          availabilitySlots: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      schedule {
+        availabilitySlots
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      schedule: {
+        __typename: "Schedule",
+        availabilitySlots: [
+          ["2026-01-01T09:00:00.000Z", "2026-01-01T10:00:00.000Z"],
+          ["2026-01-02T14:00:00.000Z"],
+        ],
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    schedule: {
+      __typename: "Schedule",
+      availabilitySlots: [
+        [
+          new Date("2026-01-01T09:00:00.000Z"),
+          new Date("2026-01-01T10:00:00.000Z"),
+        ],
+        [new Date("2026-01-02T14:00:00.000Z")],
+      ],
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -418,6 +418,46 @@ test("serializes object-based parsed scalar values when writing", () => {
   });
 });
 
+test("serializes parsed scalar value when writing via cache.writeFragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startTime
+    }
+  `;
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+    __META: {
+      extraRootIds: ["Event:1"],
+    },
+  });
+});
+
 test("parses scalar value when reading a field via cache.readQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
+import { spyOnConsole } from "@apollo/client/testing/internal";
 
 const dateTimeScalar = new Scalar<string, Date>({
   serialize: (value) => value.toISOString(),
@@ -951,4 +952,54 @@ test("parses scalar values across a complex nested query", () => {
       ],
     },
   });
+});
+
+test("ignores scalar and emits a dev warning when a scalar option is set on a field with a selection set", () => {
+  using _ = spyOnConsole("warn");
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Query: {
+        fields: {
+          event: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    "The field policy for '%s' is configured as a '%s' scalar, but the field is not a scalar field because it contains a selection set. The field value remains unchanged.",
+    "Query.event",
+    "DateTime"
+  );
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -202,6 +202,40 @@ test("parses serialized scalar value when writing via cache.writeQuery", () => {
   });
 });
 
+test("stores a parsed scalar value on a custom root type when writing via cache.writeQuery", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      RootQuery: {
+        queryType: true,
+        fields: {
+          now: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      now
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      now: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: {
+      __typename: "RootQuery",
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
 test("leaves parsed value unchanged when no scalar policy is configured", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
@@ -1691,6 +1725,40 @@ test("cache.extract() serializes scalar fields on root objects with an implicit 
   });
 });
 
+test("cache.extract() serializes scalar fields on a custom root type with an implicit typename", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      RootQuery: {
+        queryType: true,
+        fields: {
+          now: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      now
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "RootQuery",
+      now: "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
 test("cache.extract() serializes scalar fields in arrays of non-normalized objects written with cache.writeQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
@@ -1911,6 +1979,37 @@ test("parses scalar value when reading a field via cache.readQuery", () => {
   });
 });
 
+test("parses a scalar field on a custom root type via cache.readQuery", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      RootQuery: {
+        queryType: true,
+        fields: {
+          now: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      now
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      now: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    now: new Date("2026-01-01T00:00:00.000Z"),
+  });
+});
+
 test("parses scalar value when reading a field via cache.readFragment", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
@@ -1948,6 +2047,47 @@ test("parses scalar value when reading a field via cache.readFragment", () => {
     __typename: "Event",
     id: "1",
     startTime: new Date("2026-01-01T00:00:00.000Z"),
+  });
+});
+
+test("parses a scalar field on a custom root type via cache.readFragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      RootQuery: {
+        queryType: true,
+        fields: {
+          now: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      now
+    }
+  `;
+  const fragment = gql`
+    fragment RootQueryFields on RootQuery {
+      now
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      now: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(
+    cache.readFragment({
+      id: "ROOT_QUERY",
+      fragment,
+    })
+  ).toEqual({
+    now: new Date("2026-01-01T00:00:00.000Z"),
   });
 });
 

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -971,7 +971,7 @@ test("stores parsed scalar values across a complex nested write", () => {
     },
   });
 
-  expect(rawCacheData(cache)).toMatchObject({
+  expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
       conference: { __ref: "Conference:conf-1" },
@@ -993,6 +993,14 @@ test("stores parsed scalar values across a complex nested write", () => {
           [new Date("2026-09-15T14:00:00.000Z")],
         ],
       },
+      scheduledItems: [
+        { __ref: "Session:session-1" },
+        { __ref: "Workshop:workshop-1" },
+      ],
+      speakers: [
+        { __ref: "Speaker:speaker-1" },
+        { __ref: "Speaker:speaker-2" },
+      ],
     },
     "Speaker:speaker-1": {
       __typename: "Speaker",
@@ -1381,6 +1389,295 @@ test("stores object-based parsed scalar values when modifying via cache.modify",
         ["color", "blue"],
         ["size", "medium"],
       ]),
+    },
+  });
+});
+
+test("cache.extract() serializes all stored parsed scalar values", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      DateTime: dateTimeScalar,
+      Price: priceScalar,
+      JSONObject: jsonObjectScalar,
+    },
+    possibleTypes: {
+      Schedulable: ["Session", "Workshop"],
+    },
+    typePolicies: {
+      Conference: {
+        fields: {
+          startDate: { scalar: "DateTime" },
+          endDate: { scalar: "DateTime" },
+          ticketPrice: { scalar: "Price" },
+        },
+      },
+      Schedule: {
+        fields: {
+          meetingTimes: { scalar: "DateTime" },
+          availabilitySlots: { scalar: "DateTime" },
+        },
+      },
+      Speaker: {
+        fields: {
+          availableTimes: { scalar: "DateTime" },
+        },
+      },
+      Session: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+      Workshop: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query ($timezone: String) {
+      conference {
+        id
+        name
+        startDate
+        endDate
+        ticketPrice
+        schedule {
+          meetingTimes
+          availabilitySlots
+        }
+        speakers {
+          id
+          name
+          availableTimes(timezone: "UTC")
+        }
+        scheduledItems {
+          __typename
+          id
+          startTime(timezone: $timezone)
+          metadata
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    variables: { timezone: "UTC" },
+    data: {
+      conference: {
+        __typename: "Conference",
+        id: "conf-1",
+        name: "GraphQL Summit",
+        startDate: new Date("2026-09-15T09:00:00.000Z"),
+        endDate: null,
+        ticketPrice: "199.00",
+        schedule: {
+          __typename: "Schedule",
+          meetingTimes: [
+            new Date("2026-09-15T09:00:00.000Z"),
+            new Date("2026-09-15T14:00:00.000Z"),
+          ],
+          availabilitySlots: [
+            [
+              new Date("2026-09-15T09:00:00.000Z"),
+              new Date("2026-09-15T10:00:00.000Z"),
+            ],
+            [new Date("2026-09-15T14:00:00.000Z")],
+          ],
+        },
+        speakers: [
+          {
+            __typename: "Speaker",
+            id: "speaker-1",
+            name: "Alice",
+            availableTimes: [
+              new Date("2026-09-15T09:00:00.000Z"),
+              new Date("2026-09-15T14:00:00.000Z"),
+            ],
+          },
+          {
+            __typename: "Speaker",
+            id: "speaker-2",
+            name: "Bob",
+            availableTimes: [new Date("2026-09-15T10:00:00.000Z"), null],
+          },
+        ],
+        scheduledItems: [
+          {
+            __typename: "Session",
+            id: "session-1",
+            startTime: new Date("2026-09-15T09:00:00.000Z"),
+            metadata: new Map([["dress", "casual"]]),
+          },
+          {
+            __typename: "Workshop",
+            id: "workshop-1",
+            startTime: new Date("2026-09-15T14:00:00.000Z"),
+            metadata: new Map([["venue", "The Workshop Building"]]),
+          },
+        ],
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      conference: { __ref: "Conference:conf-1" },
+    },
+    "Conference:conf-1": {
+      __typename: "Conference",
+      id: "conf-1",
+      name: "GraphQL Summit",
+      startDate: "2026-09-15T09:00:00.000Z",
+      endDate: null,
+      ticketPrice: 19900,
+      schedule: {
+        __typename: "Schedule",
+        meetingTimes: ["2026-09-15T09:00:00.000Z", "2026-09-15T14:00:00.000Z"],
+        availabilitySlots: [
+          ["2026-09-15T09:00:00.000Z", "2026-09-15T10:00:00.000Z"],
+          ["2026-09-15T14:00:00.000Z"],
+        ],
+      },
+      scheduledItems: [
+        { __ref: "Session:session-1" },
+        { __ref: "Workshop:workshop-1" },
+      ],
+      speakers: [
+        { __ref: "Speaker:speaker-1" },
+        { __ref: "Speaker:speaker-2" },
+      ],
+    },
+    "Speaker:speaker-1": {
+      __typename: "Speaker",
+      id: "speaker-1",
+      name: "Alice",
+      'availableTimes({"timezone":"UTC"})': [
+        "2026-09-15T09:00:00.000Z",
+        "2026-09-15T14:00:00.000Z",
+      ],
+    },
+    "Speaker:speaker-2": {
+      __typename: "Speaker",
+      id: "speaker-2",
+      name: "Bob",
+      'availableTimes({"timezone":"UTC"})': ["2026-09-15T10:00:00.000Z", null],
+    },
+    "Session:session-1": {
+      __typename: "Session",
+      id: "session-1",
+      'startTime({"timezone":"UTC"})': "2026-09-15T09:00:00.000Z",
+      metadata: { dress: "casual" },
+    },
+    "Workshop:workshop-1": {
+      __typename: "Workshop",
+      id: "workshop-1",
+      'startTime({"timezone":"UTC"})': "2026-09-15T14:00:00.000Z",
+      metadata: { venue: "The Workshop Building" },
+    },
+  });
+});
+
+test("cache.extract() returns the parsed value as-is when no scalar policy is configured for the field", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("cache.extract(true) serializes scalar values from the optimistic layer", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    },
+  });
+
+  cache.recordOptimisticTransaction((proxy) => {
+    proxy.writeQuery({
+      query,
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startTime: new Date("2026-06-15T14:30:00.000Z"),
+        },
+      },
+    });
+  }, "optimistic-update");
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(cache.extract(true)).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-06-15T14:30:00.000Z",
     },
   });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -559,6 +559,54 @@ test("serializes parsed scalar value when a merge function is also configured on
   });
 });
 
+test("serializes the parsed value returned by a merge function", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: {
+            scalar: "DateTime",
+            merge: (_, incoming) => new Date(incoming),
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      __typename: "Query",
+      event: { __ref: "Event:1" },
+    },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
 test("serializes parsed scalar values across a complex nested write", () => {
   const cache = new InMemoryCache({
     scalars: {

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1666,6 +1666,31 @@ test("cache.extract() returns the parsed value as-is when no scalar policy is co
   });
 });
 
+test("cache.extract() serializes scalar fields on root objects with an implicit typename", () => {
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Query: {
+        fields: {
+          now: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  cache.restore({
+    ROOT_QUERY: {
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(cache.extract()).toEqual({
+    ROOT_QUERY: {
+      now: "2026-01-01T00:00:00.000Z",
+    },
+  });
+});
+
 test("cache.extract() serializes scalar fields in arrays of non-normalized objects written with cache.writeQuery", () => {
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -137,7 +137,7 @@ export abstract class EntityStore implements NormalizedCache {
     // deep compare the parsed value with the existing value
     incoming = this.coerceStoreObject(
       incoming,
-      (value, scalar) => scalar.coerceToParsed(value),
+      (scalar, value) => scalar.coerceToParsed(value),
       incoming.__typename ||
         existing?.__typename ||
         this.policies.rootTypenamesById[dataId]
@@ -408,7 +408,7 @@ export abstract class EntityStore implements NormalizedCache {
         storeObject &&
           this.coerceStoreObject(
             storeObject,
-            (value, scalar) => scalar.coerceToSerialized(value),
+            (scalar, value) => scalar.coerceToSerialized(value),
             storeObject?.__typename || this.policies.rootTypenamesById[dataId]
           ),
       ])
@@ -428,7 +428,7 @@ export abstract class EntityStore implements NormalizedCache {
 
   private coerceStoreObject(
     obj: StoreObject,
-    coerce: (value: unknown, scalar: Scalar<any, any>) => unknown,
+    coerce: (scalar: Scalar<any, any>, value: unknown) => unknown,
     typename = obj.__typename
   ): StoreObject {
     if (!typename) {
@@ -454,7 +454,7 @@ export abstract class EntityStore implements NormalizedCache {
 
   private coerceValue(
     value: unknown,
-    coerce: (value: unknown, scalar: Scalar<any, any>) => unknown,
+    coerce: (scalar: Scalar<any, any>, value: unknown) => unknown,
     scalar?: Scalar<any, any>
   ): unknown {
     if (value == null) {
@@ -466,7 +466,7 @@ export abstract class EntityStore implements NormalizedCache {
     }
 
     if (scalar) {
-      return coerce(value, scalar);
+      return coerce(scalar, value);
     }
 
     if (isPlainObject(value) && "__typename" in value) {

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -405,9 +405,13 @@ export abstract class EntityStore implements NormalizedCache {
 
   public extract(): NormalizedCacheObject {
     const obj = Object.fromEntries(
-      Object.entries(this.toObject()).map(([key, storeObject]) => [
-        key,
-        storeObject && this.serializeStoreObject(storeObject),
+      Object.entries(this.toObject()).map(([dataId, storeObject]) => [
+        dataId,
+        storeObject &&
+          this.serializeStoreObject(
+            storeObject,
+            storeObject?.__typename || this.policies.rootTypenamesById[dataId]
+          ),
       ])
     );
 
@@ -423,9 +427,10 @@ export abstract class EntityStore implements NormalizedCache {
     return obj;
   }
 
-  private serializeStoreObject(obj: StoreObject): StoreObject {
-    const typename = obj.__typename;
-
+  private serializeStoreObject(
+    obj: StoreObject,
+    typename = obj.__typename
+  ): StoreObject {
     if (!typename) {
       return obj;
     }

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -435,16 +435,21 @@ export abstract class EntityStore implements NormalizedCache {
       return obj;
     }
 
+    let changed = false;
+
     const entries = Object.entries(obj).map(([storeFieldName, value]) => {
       const scalar = this.policies.getScalarForField(
         typename,
         fieldNameFromStoreName(storeFieldName)
       );
 
+      const newValue = this.coerceValue(value, coerce, scalar);
+      changed ||= newValue !== value;
+
       return [storeFieldName, this.coerceValue(value, coerce, scalar)];
     });
 
-    return Object.fromEntries(entries);
+    return changed ? Object.fromEntries(entries) : obj;
   }
 
   private coerceValue(

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -138,7 +138,9 @@ export abstract class EntityStore implements NormalizedCache {
     incoming = this.coerceStoreObject(
       incoming,
       (value, scalar) => scalar.coerceToParsed(value),
-      incoming.__typename || this.policies.rootTypenamesById[dataId]
+      incoming.__typename ||
+        existing?.__typename ||
+        this.policies.rootTypenamesById[dataId]
     );
 
     const merged: StoreObject = new DeepMerger({
@@ -269,19 +271,6 @@ export abstract class EntityStore implements NormalizedCache {
           } else {
             if (newValue === DELETE) newValue = void 0;
             if (newValue !== fieldValue) {
-              const typename =
-                this.policies.readField<string>(
-                  { from: storeObject, fieldName: "__typename" },
-                  { store: this }
-                ) ?? this.policies.rootTypenamesById[dataId];
-
-              if (typename && newValue != null) {
-                newValue = this.policies.maybeCoerceToScalarValue(
-                  newValue as StoreValue,
-                  { fieldName, typename }
-                );
-              }
-
               changedFields[storeFieldName] = newValue;
               needToMerge = true;
               fieldValue = newValue as StoreValue;

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -265,7 +265,7 @@ export abstract class EntityStore implements NormalizedCache {
               );
 
               if (typename) {
-                newValue = this.policies.maybeCoerceToSerializedValue(
+                newValue = this.policies.maybeCoerceToScalarValue(
                   newValue as StoreValue,
                   { fieldName, typename }
                 );

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -264,7 +264,7 @@ export abstract class EntityStore implements NormalizedCache {
                 { store: this }
               );
 
-              if (typename) {
+              if (typename && newValue != null) {
                 newValue = this.policies.maybeCoerceToScalarValue(
                   newValue as StoreValue,
                   { fieldName, typename }

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -409,8 +409,9 @@ export abstract class EntityStore implements NormalizedCache {
       Object.entries(this.toObject()).map(([dataId, storeObject]) => [
         dataId,
         storeObject &&
-          this.serializeStoreObject(
+          this.coerceStoreObject(
             storeObject,
+            (value, scalar) => scalar.coerceToSerialized(value),
             storeObject?.__typename || this.policies.rootTypenamesById[dataId]
           ),
       ])
@@ -428,8 +429,9 @@ export abstract class EntityStore implements NormalizedCache {
     return obj;
   }
 
-  private serializeStoreObject(
+  private coerceStoreObject(
     obj: StoreObject,
+    coerce: (value: unknown, scalar: Scalar<any, any>) => unknown,
     typename = obj.__typename
   ): StoreObject {
     if (!typename) {
@@ -442,27 +444,31 @@ export abstract class EntityStore implements NormalizedCache {
         fieldNameFromStoreName(storeFieldName)
       );
 
-      return [storeFieldName, this.serializeValue(value, scalar)];
+      return [storeFieldName, this.coerceValue(value, coerce, scalar)];
     });
 
     return Object.fromEntries(entries);
   }
 
-  private serializeValue(value: unknown, scalar?: Scalar<any, any>): unknown {
+  private coerceValue(
+    value: unknown,
+    coerce: (value: unknown, scalar: Scalar<any, any>) => unknown,
+    scalar?: Scalar<any, any>
+  ): unknown {
     if (value == null) {
       return value;
     }
 
     if (Array.isArray(value)) {
-      return value.map((item) => this.serializeValue(item, scalar));
+      return value.map((item) => this.coerceValue(item, coerce, scalar));
     }
 
     if (scalar) {
-      return scalar.coerceToSerialized(value);
+      return coerce(value, scalar);
     }
 
     if (isPlainObject(value) && "__typename" in value) {
-      return this.serializeStoreObject(value);
+      return this.coerceStoreObject(value, coerce);
     }
 
     return value;

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -261,10 +261,11 @@ export abstract class EntityStore implements NormalizedCache {
           } else {
             if (newValue === DELETE) newValue = void 0;
             if (newValue !== fieldValue) {
-              const typename = this.policies.readField<string>(
-                { from: storeObject, fieldName: "__typename" },
-                { store: this }
-              );
+              const typename =
+                this.policies.readField<string>(
+                  { from: storeObject, fieldName: "__typename" },
+                  { store: this }
+                ) ?? this.policies.rootTypenamesById[dataId];
 
               if (typename && newValue != null) {
                 newValue = this.policies.maybeCoerceToScalarValue(

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -259,6 +259,18 @@ export abstract class EntityStore implements NormalizedCache {
           } else {
             if (newValue === DELETE) newValue = void 0;
             if (newValue !== fieldValue) {
+              const typename = this.policies.readField<string>(
+                { from: storeObject, fieldName: "__typename" },
+                { store: this }
+              );
+
+              if (typename) {
+                newValue = this.policies.maybeCoerceSerializedValue(
+                  newValue as StoreValue,
+                  { fieldName, typename }
+                );
+              }
+
               changedFields[storeFieldName] = newValue;
               needToMerge = true;
               fieldValue = newValue as StoreValue;

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -446,7 +446,7 @@ export abstract class EntityStore implements NormalizedCache {
       const newValue = this.coerceValue(value, coerce, scalar);
       changed ||= newValue !== value;
 
-      return [storeFieldName, this.coerceValue(value, coerce, scalar)];
+      return [storeFieldName, newValue];
     });
 
     return changed ? Object.fromEntries(entries) : obj;

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -265,7 +265,7 @@ export abstract class EntityStore implements NormalizedCache {
               );
 
               if (typename) {
-                newValue = this.policies.maybeCoerceSerializedValue(
+                newValue = this.policies.maybeCoerceToSerializedValue(
                   newValue as StoreValue,
                   { fieldName, typename }
                 );

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -124,7 +124,7 @@ export abstract class EntityStore implements NormalizedCache {
     const existing: StoreObject | undefined =
       typeof older === "string" ? this.lookup((dataId = older)) : older;
 
-    const incoming: StoreObject | undefined =
+    let incoming: StoreObject | undefined =
       typeof newer === "string" ? this.lookup((dataId = newer)) : newer;
 
     // If newer was a string ID, but that ID was not defined in this store,
@@ -132,6 +132,14 @@ export abstract class EntityStore implements NormalizedCache {
     if (!incoming) return;
 
     invariant(typeof dataId === "string", "store.merge expects a string ID");
+
+    // Parse all scalars before merging so that the storeObjectReconciler can
+    // deep compare the parsed value with the existing value
+    incoming = this.coerceStoreObject(
+      incoming,
+      (value, scalar) => scalar.coerceToParsed(value),
+      incoming.__typename || this.policies.rootTypenamesById[dataId]
+    );
 
     const merged: StoreObject = new DeepMerger({
       reconciler: storeObjectReconciler,

--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -14,11 +14,13 @@ import { __DEV__ } from "@apollo/client/utilities/environment";
 import {
   DeepMerger,
   isNonNullObject,
+  isPlainObject,
   makeReference,
   maybeDeepFreeze,
 } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
+import type { Scalar } from "../core/Scalar.js";
 import type { Cache } from "../core/types/Cache.js";
 import type {
   CanReadFunction,
@@ -402,7 +404,13 @@ export abstract class EntityStore implements NormalizedCache {
   }
 
   public extract(): NormalizedCacheObject {
-    const obj = this.toObject();
+    const obj = Object.fromEntries(
+      Object.entries(this.toObject()).map(([key, storeObject]) => [
+        key,
+        storeObject && this.serializeStoreObject(storeObject),
+      ])
+    );
+
     const extraRootIds: string[] = [];
     this.getRootIdSet().forEach((id) => {
       if (!hasOwn.call(this.policies.rootTypenamesById, id)) {
@@ -413,6 +421,45 @@ export abstract class EntityStore implements NormalizedCache {
       obj.__META = { extraRootIds: extraRootIds.sort() };
     }
     return obj;
+  }
+
+  private serializeStoreObject(obj: StoreObject): StoreObject {
+    const typename = obj.__typename;
+
+    if (!typename) {
+      return obj;
+    }
+
+    const entries = Object.entries(obj).map(([storeFieldName, value]) => {
+      const scalar = this.policies.getScalarForField(
+        typename,
+        fieldNameFromStoreName(storeFieldName)
+      );
+
+      return [storeFieldName, this.serializeValue(value, scalar)];
+    });
+
+    return Object.fromEntries(entries);
+  }
+
+  private serializeValue(value: unknown, scalar?: Scalar<any, any>): unknown {
+    if (value == null) {
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item) => this.serializeValue(item, scalar));
+    }
+
+    if (scalar) {
+      return scalar.coerceToSerialized(value);
+    }
+
+    if (isPlainObject(value) && "__typename" in value) {
+      return this.serializeStoreObject(value);
+    }
+
+    return value;
   }
 
   public replace(newData: NormalizedCacheObject | null): void {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -23,7 +23,10 @@ import {
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
 import type { IsLooselyEqual } from "@apollo/client/utilities/internal";
-import { getInMemoryCacheMemoryInternals } from "@apollo/client/utilities/internal";
+import {
+  getInMemoryCacheMemoryInternals,
+  isPlainObject,
+} from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
 import { defaultCacheSizes } from "../../utilities/caching/sizes.js";
@@ -32,7 +35,7 @@ import type { Scalar } from "../core/Scalar.js";
 import type { Cache } from "../core/types/Cache.js";
 
 import { EntityStore, supportsResultCaching } from "./entityStore.js";
-import { hasOwn, normalizeConfig } from "./helpers.js";
+import { fieldNameFromStoreName, hasOwn, normalizeConfig } from "./helpers.js";
 import { Policies } from "./policies.js";
 import { forgetCache, makeVar, recallCache } from "./reactiveVars.js";
 import { StoreReader } from "./readFromStore.js";
@@ -220,7 +223,57 @@ export class InMemoryCache extends ApolloCache {
   }
 
   public extract(optimistic: boolean = false): NormalizedCacheObject {
-    return (optimistic ? this.optimisticData : this.data).extract();
+    const serialize = (
+      value: unknown,
+      isRoot: boolean = true,
+      scalar?: Scalar<any, any>
+    ): NormalizedCacheObject => {
+      if (isRoot) {
+        const entries = Object.entries(value as object).map(([key, value]) => {
+          return [key, serialize(value, false)];
+        });
+
+        return Object.fromEntries(entries);
+      }
+
+      if (Array.isArray(value)) {
+        return value.map((item) => serialize(item, false, scalar)) as any;
+      }
+
+      if (value != null && scalar) {
+        return scalar.coerceToSerialized(value);
+      }
+
+      if (isPlainObject(value)) {
+        const typename =
+          "__typename" in value && typeof value.__typename === "string" ?
+            value.__typename
+          : undefined;
+
+        const entries = Object.entries(value).map(([storeFieldName, value]) => {
+          if (typename && value != null) {
+            const fieldName = fieldNameFromStoreName(storeFieldName);
+            const scalar = this.policies.getScalarForField(typename, fieldName);
+
+            if (scalar) {
+              return [storeFieldName, serialize(value, false, scalar)];
+            }
+          }
+
+          if (isPlainObject(value)) {
+            return [storeFieldName, serialize(value, false)];
+          }
+
+          return [storeFieldName, value];
+        });
+
+        return Object.fromEntries(entries);
+      }
+
+      return value as NormalizedCacheObject;
+    };
+
+    return serialize((optimistic ? this.optimisticData : this.data).extract());
   }
 
   public read<TData = unknown>(

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -260,7 +260,7 @@ export class InMemoryCache extends ApolloCache {
             }
           }
 
-          if (isPlainObject(value)) {
+          if (isPlainObject(value) || Array.isArray(value)) {
             return [storeFieldName, serialize(value, false)];
           }
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -22,10 +22,7 @@ import {
   print,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import type {
-  IsLooselyEqual,
-  RemoveIndexSignature,
-} from "@apollo/client/utilities/internal";
+import type { IsLooselyEqual } from "@apollo/client/utilities/internal";
 import { getInMemoryCacheMemoryInternals } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
@@ -39,15 +36,17 @@ import { hasOwn, normalizeConfig } from "./helpers.js";
 import { Policies } from "./policies.js";
 import { forgetCache, makeVar, recallCache } from "./reactiveVars.js";
 import { StoreReader } from "./readFromStore.js";
-import type { InMemoryCacheConfig, NormalizedCacheObject } from "./types.js";
+import type {
+  InMemoryCacheConfig,
+  KnownScalars,
+  NormalizedCacheObject,
+} from "./types.js";
 import { StoreWriter } from "./writeToStore.js";
 
 type BroadcastOptions = Pick<
   Cache.BatchOptions<InMemoryCache>,
   "optimistic" | "onWatchUpdated"
 >;
-
-type KnownScalars = RemoveIndexSignature<ApolloCache.Scalars>;
 
 export declare namespace InMemoryCache {
   export type ScalarsOption = {

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -223,57 +223,7 @@ export class InMemoryCache extends ApolloCache {
   }
 
   public extract(optimistic: boolean = false): NormalizedCacheObject {
-    const serialize = (
-      value: unknown,
-      isRoot: boolean = true,
-      scalar?: Scalar<any, any>
-    ): NormalizedCacheObject => {
-      if (isRoot) {
-        const entries = Object.entries(value as object).map(([key, value]) => {
-          return [key, serialize(value, false)];
-        });
-
-        return Object.fromEntries(entries);
-      }
-
-      if (Array.isArray(value)) {
-        return value.map((item) => serialize(item, false, scalar)) as any;
-      }
-
-      if (value != null && scalar) {
-        return scalar.coerceToSerialized(value);
-      }
-
-      if (isPlainObject(value)) {
-        const typename =
-          "__typename" in value && typeof value.__typename === "string" ?
-            value.__typename
-          : undefined;
-
-        const entries = Object.entries(value).map(([storeFieldName, value]) => {
-          if (typename && value != null) {
-            const fieldName = fieldNameFromStoreName(storeFieldName);
-            const scalar = this.policies.getScalarForField(typename, fieldName);
-
-            if (scalar) {
-              return [storeFieldName, serialize(value, false, scalar)];
-            }
-          }
-
-          if (isPlainObject(value) || Array.isArray(value)) {
-            return [storeFieldName, serialize(value, false)];
-          }
-
-          return [storeFieldName, value];
-        });
-
-        return Object.fromEntries(entries);
-      }
-
-      return value as NormalizedCacheObject;
-    };
-
-    return serialize((optimistic ? this.optimisticData : this.data).extract());
+    return (optimistic ? this.optimisticData : this.data).extract();
   }
 
   public read<TData = unknown>(

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -23,10 +23,7 @@ import {
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
 import type { IsLooselyEqual } from "@apollo/client/utilities/internal";
-import {
-  getInMemoryCacheMemoryInternals,
-  isPlainObject,
-} from "@apollo/client/utilities/internal";
+import { getInMemoryCacheMemoryInternals } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
 import { defaultCacheSizes } from "../../utilities/caching/sizes.js";
@@ -35,7 +32,7 @@ import type { Scalar } from "../core/Scalar.js";
 import type { Cache } from "../core/types/Cache.js";
 
 import { EntityStore, supportsResultCaching } from "./entityStore.js";
-import { fieldNameFromStoreName, hasOwn, normalizeConfig } from "./helpers.js";
+import { hasOwn, normalizeConfig } from "./helpers.js";
 import { Policies } from "./policies.js";
 import { forgetCache, makeVar, recallCache } from "./reactiveVars.js";
 import { StoreReader } from "./readFromStore.js";

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -31,6 +31,7 @@ import {
   newInvariantError,
 } from "@apollo/client/utilities/invariant";
 
+import type { ApolloCache } from "../core/cache.js";
 import type {
   CanReadFunction,
   FieldSpecifier,
@@ -173,6 +174,7 @@ export type FieldPolicy<
   keyArgs?: KeySpecifier | KeyArgsFunction | false;
   read?: FieldReadFunction<TExisting, TReadResult, TReadOptions>;
   merge?: FieldMergeFunction<TExisting, TIncoming, TMergeOptions> | boolean;
+  scalar?: keyof ApolloCache.Scalars;
 };
 
 export type StorageType = Record<string, any>;

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -930,7 +930,7 @@ export class Policies {
   private maybeCoerce(
     value: StoreValue,
     options: CoerceValueOptions,
-    transform: (value: StoreValue, scalar: Scalar<any, any>) => StoreValue,
+    coerce: (value: StoreValue, scalar: Scalar<any, any>) => StoreValue,
     scalar?: Scalar<any, any>
   ): StoreValue {
     // null is never coerced
@@ -948,11 +948,11 @@ export class Policies {
 
     if (Array.isArray(value)) {
       return value.map((item) =>
-        this.maybeCoerce(item, options, transform, scalar)
+        this.maybeCoerce(item, options, coerce, scalar)
       );
     }
 
-    return transform(value, scalar);
+    return coerce(value, scalar);
   }
 
   public getScalarForField(

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -903,19 +903,17 @@ export class Policies {
     // A selection set indicates this is not a scalar field so bail early
     if (options.field && options.field.selectionSet) return value;
 
-    let typename = options.typename;
-    const objectOrReference = options.from;
+    if (options.typename === void 0) {
+      if (!options.from) return value;
 
-    if (!typename && !objectOrReference) return value;
-    if (typename === void 0) {
-      typename = context.store.getFieldValue<string>(
-        objectOrReference,
+      options.typename = context.store.getFieldValue<string>(
+        options.from,
         "__typename"
       );
     }
 
     const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
-    const policy = this.getFieldPolicy(typename, fieldName);
+    const policy = this.getFieldPolicy(options.typename, fieldName);
 
     if (!policy?.scalar) return value;
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -568,7 +568,9 @@ export class Policies {
         if (typeof incoming === "function") {
           existing.read = incoming;
         } else {
-          const { keyArgs, read, merge } = incoming;
+          const { keyArgs, read, merge, scalar } = incoming;
+
+          existing.scalar = scalar;
 
           existing.keyFn =
             // Pass false to disable argument-based differentiation of

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -277,6 +277,11 @@ export interface FieldMergeFunctionOptions<
   existingData: unknown;
 }
 
+interface CoerceValueOptions {
+  typename: string;
+  field: FieldNode;
+}
+
 type MergeObjectsFunction = <T extends StoreObject | Reference>(
   existing: T,
   incoming: T
@@ -895,26 +900,17 @@ export class Policies {
 
   public maybeCoerceScalarValue(
     value: StoreValue,
-    options: ReadFieldOptions,
-    context: ReadMergeModifyContext
+    options: CoerceValueOptions
   ) {
     // null is never coerced
     if (value === null) return value;
 
+    const { field, typename } = options;
+
     // A selection set indicates this is not a scalar field so bail early
-    if (options.field && options.field.selectionSet) return value;
+    if (field && field.selectionSet) return value;
 
-    if (options.typename === void 0) {
-      if (!options.from) return value;
-
-      options.typename = context.store.getFieldValue<string>(
-        options.from,
-        "__typename"
-      );
-    }
-
-    const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
-    const policy = this.getFieldPolicy(options.typename, fieldName);
+    const policy = this.getFieldPolicy(typename, field.name.value);
 
     if (!policy?.scalar) return value;
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -585,7 +585,9 @@ export class Policies {
         } else {
           const { keyArgs, read, merge, scalar } = incoming;
 
-          existing.scalar = scalar;
+          if (scalar) {
+            existing.scalar = scalar;
+          }
 
           existing.keyFn =
             // Pass false to disable argument-based differentiation of

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -925,7 +925,7 @@ export class Policies {
     return scalar ? scalar.coerceToParsed(value) : value;
   }
 
-  public maybeCoerceSerializedValue(
+  public maybeCoerceToSerializedValue(
     value: StoreValue,
     options: CoerceValueOptions & { scalar?: Scalar<any, any> }
   ): StoreValue {
@@ -945,7 +945,7 @@ export class Policies {
 
     if (Array.isArray(value)) {
       return value.map((item) =>
-        this.maybeCoerceSerializedValue(item, { ...options, scalar })
+        this.maybeCoerceToSerializedValue(item, { ...options, scalar })
       );
     }
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -60,6 +60,7 @@ import type {
   MergeInfo,
   NormalizedCache,
   ReadMergeModifyContext,
+  ScalarNames,
 } from "./types.js";
 import type { WriteContext } from "./writeToStore.js";
 
@@ -174,7 +175,7 @@ export type FieldPolicy<
   keyArgs?: KeySpecifier | KeyArgsFunction | false;
   read?: FieldReadFunction<TExisting, TReadResult, TReadOptions>;
   merge?: FieldMergeFunction<TExisting, TIncoming, TMergeOptions> | boolean;
-  scalar?: keyof ApolloCache.Scalars;
+  scalar?: ScalarNames;
 };
 
 export type StorageType = Record<string, any>;

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -898,7 +898,7 @@ export class Policies {
       : fieldName + ":" + storeFieldName;
   }
 
-  public maybeCoerceScalarValue(
+  public maybeCoerceToScalarValue(
     value: StoreValue,
     options: CoerceValueOptions
   ) {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -278,10 +278,18 @@ export interface FieldMergeFunctionOptions<
   existingData: unknown;
 }
 
-interface CoerceValueOptions {
+type CoerceValueOptions = {
   typename: string;
-  field: FieldNode;
-}
+} & (
+  | {
+      field: FieldNode;
+      fieldName?: never;
+    }
+  | {
+      field?: never;
+      fieldName: string;
+    }
+);
 
 type MergeObjectsFunction = <T extends StoreObject | Reference>(
   existing: T,
@@ -911,7 +919,9 @@ export class Policies {
     // A selection set indicates this is not a scalar field so bail early
     if (field && field.selectionSet) return value;
 
-    const scalar = this.getScalarForField(typename, field.name.value);
+    const fieldName = field ? field.name.value : options.fieldName;
+
+    const scalar = this.getScalarForField(typename, fieldName);
     return scalar ? scalar.coerceToParsed(value) : value;
   }
 
@@ -922,12 +932,14 @@ export class Policies {
     // null is never coerced
     if (value === null) return value;
 
-    let { field, scalar, typename } = options;
+    const { field, typename } = options;
+    let { scalar } = options;
 
     // A selection set indicates this is not a scalar field so bail early
     if (field && field.selectionSet) return value;
 
-    scalar ||= this.getScalarForField(typename, field.name.value);
+    const fieldName = field ? field.name.value : options.fieldName;
+    scalar ||= this.getScalarForField(typename, fieldName);
 
     if (!scalar) return value;
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -921,21 +921,18 @@ export class Policies {
 
   public maybeCoerceSerializedValue(
     value: StoreValue,
-    options: FieldSpecifier & { scalar?: Scalar<any, any> }
+    options: CoerceValueOptions & { scalar?: Scalar<any, any> }
   ): StoreValue {
     // null is never coerced
     if (value === null) return value;
 
+    let { field, scalar, typename } = options;
+
     // A selection set indicates this is not a scalar field so bail early
-    if (options.field && options.field.selectionSet) return value;
+    if (field && field.selectionSet) return value;
 
-    if (options.typename === void 0) return value;
-
-    const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
-
-    let scalar = options.scalar;
     if (!scalar) {
-      const policy = this.getFieldPolicy(options.typename, fieldName);
+      const policy = this.getFieldPolicy(typename, field.name.value);
 
       scalar = policy?.scalar ? this.cache.getScalar(policy.scalar) : undefined;
     }
@@ -944,7 +941,7 @@ export class Policies {
 
     if (Array.isArray(value)) {
       return value.map((item) =>
-        this.maybeCoerceSerializedValue(item, { ...options, fieldName, scalar })
+        this.maybeCoerceSerializedValue(item, { ...options, scalar })
       );
     }
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -952,7 +952,7 @@ export class Policies {
     return scalar.coerceToSerialized(value);
   }
 
-  private getScalarForField(
+  public getScalarForField(
     typename: string,
     fieldName: string
   ): Scalar<any, any> | undefined {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -929,13 +929,13 @@ export class Policies {
 
   public maybeCoerceToSerializedValue(
     value: StoreValue,
-    options: CoerceValueOptions & { scalar?: Scalar<any, any> }
+    options: CoerceValueOptions,
+    scalar?: Scalar<any, any>
   ): StoreValue {
     // null is never coerced
     if (value === null) return value;
 
     const { field, typename } = options;
-    let { scalar } = options;
 
     // A selection set indicates this is not a scalar field so bail early
     if (field && field.selectionSet) return value;
@@ -947,7 +947,7 @@ export class Policies {
 
     if (Array.isArray(value)) {
       return value.map((item) =>
-        this.maybeCoerceToSerializedValue(item, { ...options, scalar })
+        this.maybeCoerceToSerializedValue(item, options, scalar)
       );
     }
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -911,11 +911,7 @@ export class Policies {
     // A selection set indicates this is not a scalar field so bail early
     if (field && field.selectionSet) return value;
 
-    const policy = this.getFieldPolicy(typename, field.name.value);
-
-    if (!policy?.scalar) return value;
-
-    const scalar = this.cache.getScalar(policy.scalar);
+    const scalar = this.getScalarForField(typename, field.name.value);
     return scalar ? scalar.coerceToParsed(value) : value;
   }
 
@@ -931,11 +927,7 @@ export class Policies {
     // A selection set indicates this is not a scalar field so bail early
     if (field && field.selectionSet) return value;
 
-    if (!scalar) {
-      const policy = this.getFieldPolicy(typename, field.name.value);
-
-      scalar = policy?.scalar ? this.cache.getScalar(policy.scalar) : undefined;
-    }
+    scalar ||= this.getScalarForField(typename, field.name.value);
 
     if (!scalar) return value;
 
@@ -946,6 +938,15 @@ export class Policies {
     }
 
     return scalar.coerceToSerialized(value);
+  }
+
+  private getScalarForField(
+    typename: string,
+    fieldName: string
+  ): Scalar<any, any> | undefined {
+    const policy = this.getFieldPolicy(typename, fieldName);
+
+    return policy?.scalar ? this.cache.getScalar(policy.scalar) : undefined;
   }
 
   public readField<V = StoreValue>(

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -892,6 +892,34 @@ export class Policies {
       : fieldName + ":" + storeFieldName;
   }
 
+  public maybeCoerceScalarValue(
+    value: StoreValue,
+    options: ReadFieldOptions,
+    context: ReadMergeModifyContext
+  ) {
+    // A selection set indicates this is not a scalar field so bail early
+    if (options.field && options.field.selectionSet) return value;
+
+    let typename = options.typename;
+    const objectOrReference = options.from;
+
+    if (!typename && !objectOrReference) return value;
+    if (typename === void 0) {
+      typename = context.store.getFieldValue<string>(
+        objectOrReference,
+        "__typename"
+      );
+    }
+
+    const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
+    const policy = this.getFieldPolicy(typename, fieldName);
+
+    if (!policy?.scalar) return value;
+
+    const scalar = this.cache.getScalar(policy.scalar);
+    return scalar ? scalar.coerceToParsed(value) : value;
+  }
+
   public readField<V = StoreValue>(
     options: ReadFieldOptions,
     context: ReadMergeModifyContext

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -32,6 +32,7 @@ import {
 } from "@apollo/client/utilities/invariant";
 
 import type { ApolloCache } from "../core/cache.js";
+import type { Scalar } from "../core/Scalar.js";
 import type {
   CanReadFunction,
   FieldSpecifier,
@@ -920,8 +921,8 @@ export class Policies {
 
   public maybeCoerceSerializedValue(
     value: StoreValue,
-    options: FieldSpecifier
-  ) {
+    options: FieldSpecifier & { scalar?: Scalar<any, any> }
+  ): StoreValue {
     // null is never coerced
     if (value === null) return value;
 
@@ -931,12 +932,23 @@ export class Policies {
     if (options.typename === void 0) return value;
 
     const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
-    const policy = this.getFieldPolicy(options.typename, fieldName);
 
-    if (!policy?.scalar) return value;
+    let scalar = options.scalar;
+    if (!scalar) {
+      const policy = this.getFieldPolicy(options.typename, fieldName);
 
-    const scalar = this.cache.getScalar(policy.scalar);
-    return scalar ? scalar.coerceToSerialized(value) : value;
+      scalar = policy?.scalar ? this.cache.getScalar(policy.scalar) : undefined;
+    }
+
+    if (!scalar) return value;
+
+    if (Array.isArray(value)) {
+      return value.map((item) =>
+        this.maybeCoerceSerializedValue(item, { ...options, fieldName, scalar })
+      );
+    }
+
+    return scalar.coerceToSerialized(value);
   }
 
   public readField<V = StoreValue>(

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -356,6 +356,7 @@ type InternalFieldPolicy = {
   keyFn?: KeyArgsFunction;
   read?: FieldReadFunction<any>;
   merge?: FieldMergeFunction<any>;
+  scalar?: keyof ApolloCache.Scalars;
 };
 
 export class Policies {

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -918,6 +918,27 @@ export class Policies {
     return scalar ? scalar.coerceToParsed(value) : value;
   }
 
+  public maybeCoerceSerializedValue(
+    value: StoreValue,
+    options: FieldSpecifier
+  ) {
+    // null is never coerced
+    if (value === null) return value;
+
+    // A selection set indicates this is not a scalar field so bail early
+    if (options.field && options.field.selectionSet) return value;
+
+    if (options.typename === void 0) return value;
+
+    const fieldName = fieldNameFromStoreName(this.getStoreFieldName(options));
+    const policy = this.getFieldPolicy(options.typename, fieldName);
+
+    if (!policy?.scalar) return value;
+
+    const scalar = this.cache.getScalar(policy.scalar);
+    return scalar ? scalar.coerceToSerialized(value) : value;
+  }
+
   public readField<V = StoreValue>(
     options: ReadFieldOptions,
     context: ReadMergeModifyContext

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -911,8 +911,9 @@ export class Policies {
 
   public maybeCoerceToScalarValue(
     value: StoreValue,
-    options: CoerceValueOptions
-  ) {
+    options: CoerceValueOptions,
+    scalar?: Scalar<any, any>
+  ): StoreValue {
     // null is never coerced
     if (value === null) return value;
 
@@ -922,9 +923,17 @@ export class Policies {
     if (field && field.selectionSet) return value;
 
     const fieldName = field ? field.name.value : options.fieldName;
+    scalar ||= this.getScalarForField(typename, fieldName);
 
-    const scalar = this.getScalarForField(typename, fieldName);
-    return scalar ? scalar.coerceToParsed(value) : value;
+    if (!scalar) return value;
+
+    if (Array.isArray(value)) {
+      return value.map((item) =>
+        this.maybeCoerceToScalarValue(item, options, scalar)
+      );
+    }
+
+    return scalar.coerceToParsed(value);
   }
 
   public maybeCoerceToSerializedValue(

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -897,6 +897,9 @@ export class Policies {
     options: ReadFieldOptions,
     context: ReadMergeModifyContext
   ) {
+    // null is never coerced
+    if (value === null) return value;
+
     // A selection set indicates this is not a scalar field so bail early
     if (options.field && options.field.selectionSet) return value;
 

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -911,34 +911,26 @@ export class Policies {
 
   public maybeCoerceToScalarValue(
     value: StoreValue,
-    options: CoerceValueOptions,
-    scalar?: Scalar<any, any>
+    options: CoerceValueOptions
   ): StoreValue {
-    // null is never coerced
-    if (value === null) return value;
-
-    const { field, typename } = options;
-
-    // A selection set indicates this is not a scalar field so bail early
-    if (field && field.selectionSet) return value;
-
-    const fieldName = field ? field.name.value : options.fieldName;
-    scalar ||= this.getScalarForField(typename, fieldName);
-
-    if (!scalar) return value;
-
-    if (Array.isArray(value)) {
-      return value.map((item) =>
-        this.maybeCoerceToScalarValue(item, options, scalar)
-      );
-    }
-
-    return scalar.coerceToParsed(value);
+    return this.maybeCoerce(value, options, (item, scalar) => {
+      return scalar.coerceToParsed(item);
+    });
   }
 
   public maybeCoerceToSerializedValue(
     value: StoreValue,
+    options: CoerceValueOptions
+  ): StoreValue {
+    return this.maybeCoerce(value, options, (item, scalar) => {
+      return scalar.coerceToSerialized(item);
+    });
+  }
+
+  private maybeCoerce(
+    value: StoreValue,
     options: CoerceValueOptions,
+    transform: (value: StoreValue, scalar: Scalar<any, any>) => StoreValue,
     scalar?: Scalar<any, any>
   ): StoreValue {
     // null is never coerced
@@ -956,11 +948,11 @@ export class Policies {
 
     if (Array.isArray(value)) {
       return value.map((item) =>
-        this.maybeCoerceToSerializedValue(item, options, scalar)
+        this.maybeCoerce(item, options, transform, scalar)
       );
     }
 
-    return scalar.coerceToSerialized(value);
+    return transform(value, scalar);
   }
 
   public getScalarForField(

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -278,19 +278,6 @@ export interface FieldMergeFunctionOptions<
   existingData: unknown;
 }
 
-type CoerceValueOptions = {
-  typename: string;
-} & (
-  | {
-      field: FieldNode;
-      fieldName?: never;
-    }
-  | {
-      field?: never;
-      fieldName: string;
-    }
-);
-
 type MergeObjectsFunction = <T extends StoreObject | Reference>(
   existing: T,
   incoming: T
@@ -907,52 +894,6 @@ export class Policies {
     // StoreObject correspond to which original field names.
     return fieldName === fieldNameFromStoreName(storeFieldName) ? storeFieldName
       : fieldName + ":" + storeFieldName;
-  }
-
-  public maybeCoerceToScalarValue(
-    value: StoreValue,
-    options: CoerceValueOptions
-  ): StoreValue {
-    return this.maybeCoerce(value, options, (item, scalar) => {
-      return scalar.coerceToParsed(item);
-    });
-  }
-
-  public maybeCoerceToSerializedValue(
-    value: StoreValue,
-    options: CoerceValueOptions
-  ): StoreValue {
-    return this.maybeCoerce(value, options, (item, scalar) => {
-      return scalar.coerceToSerialized(item);
-    });
-  }
-
-  private maybeCoerce(
-    value: StoreValue,
-    options: CoerceValueOptions,
-    coerce: (value: StoreValue, scalar: Scalar<any, any>) => StoreValue,
-    scalar?: Scalar<any, any>
-  ): StoreValue {
-    // null is never coerced
-    if (value === null) return value;
-
-    const { field, typename } = options;
-
-    // A selection set indicates this is not a scalar field so bail early
-    if (field && field.selectionSet) return value;
-
-    const fieldName = field ? field.name.value : options.fieldName;
-    scalar ||= this.getScalarForField(typename, fieldName);
-
-    if (!scalar) return value;
-
-    if (Array.isArray(value)) {
-      return value.map((item) =>
-        this.maybeCoerce(item, options, coerce, scalar)
-      );
-    }
-
-    return coerce(value, scalar);
   }
 
   public getScalarForField(

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -85,6 +85,7 @@ type ExecSubSelectedArrayOptions = {
   array: readonly any[];
   enclosingRef: Reference;
   context: ReadContext;
+  parentObjectOrReference: StoreObject | Reference;
 };
 
 interface StoreReaderConfig {
@@ -357,15 +358,10 @@ export class StoreReader {
                 array: fieldValue,
                 enclosingRef,
                 context,
+                parentObjectOrReference: objectOrReference,
               }),
               resultName
             );
-
-            if (Array.isArray(fieldValue)) {
-              fieldValue = fieldValue.map((item) =>
-                policies.maybeCoerceScalarValue(item, readFieldOptions, context)
-              );
-            }
           }
         } else if (!selection.selectionSet) {
           fieldValue = policies.maybeCoerceScalarValue(
@@ -427,6 +423,7 @@ export class StoreReader {
     array,
     enclosingRef,
     context,
+    parentObjectOrReference,
   }: ExecSubSelectedArrayOptions): ExecResult {
     let missing: MissingTree | undefined;
     let missingMerger = new DeepMerger();
@@ -458,6 +455,7 @@ export class StoreReader {
             array: item,
             enclosingRef,
             context,
+            parentObjectOrReference,
           }),
           i
         );
@@ -480,7 +478,15 @@ export class StoreReader {
         assertSelectionSetForIdValue(context.store, field, item);
       }
 
-      return item;
+      return context.policies.maybeCoerceScalarValue(
+        item,
+        {
+          fieldName: field.name.value,
+          field,
+          from: parentObjectOrReference,
+        },
+        context
+      );
     });
 
     return {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -3,7 +3,11 @@ import { Kind } from "graphql";
 import type { OptimisticWrapperFunction } from "optimism";
 import { wrap } from "optimism";
 
-import type { Reference, StoreObject } from "@apollo/client/utilities";
+import type {
+  Reference,
+  StoreObject,
+  StoreValue,
+} from "@apollo/client/utilities";
 import {
   addTypenameToDocument,
   cacheSizes,
@@ -324,15 +328,14 @@ export class StoreReader {
       if (!shouldInclude(selection, variables)) return;
 
       if (isField(selection)) {
-        let fieldValue = policies.readField(
-          {
-            fieldName: selection.name.value,
-            field: selection,
-            variables: context.variables,
-            from: objectOrReference,
-          },
-          context
-        );
+        const readFieldOptions = {
+          fieldName: selection.name.value,
+          field: selection,
+          variables: context.variables,
+          from: objectOrReference,
+        };
+
+        let fieldValue = policies.readField(readFieldOptions, context);
 
         const resultName = resultKeyNameFromField(selection);
 
@@ -357,8 +360,19 @@ export class StoreReader {
               }),
               resultName
             );
+
+            if (Array.isArray(fieldValue)) {
+              fieldValue = fieldValue.map((item) =>
+                policies.maybeCoerceScalarValue(item, readFieldOptions, context)
+              );
+            }
           }
         } else if (!selection.selectionSet) {
+          fieldValue = policies.maybeCoerceScalarValue(
+            fieldValue,
+            readFieldOptions,
+            context
+          );
           // do nothing
         } else if (fieldValue != null) {
           // In this case, because we know the field has a selection set,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -81,7 +81,6 @@ type ExecSubSelectedArrayOptions = {
   array: readonly any[];
   enclosingRef: Reference;
   context: ReadContext;
-  parentObjectOrReference: StoreObject | Reference;
 };
 
 interface StoreReaderConfig {
@@ -355,19 +354,12 @@ export class StoreReader {
                 array: fieldValue,
                 enclosingRef,
                 context,
-                parentObjectOrReference: objectOrReference,
               }),
               resultName
             );
           }
         } else if (!selection.selectionSet) {
-          fieldValue = policies.maybeCoerceToScalarValue(fieldValue, {
-            field: selection,
-            typename: context.store.getFieldValue<string>(
-              objectOrReference,
-              "__typename"
-            ),
-          });
+          // do nothing
         } else if (fieldValue != null) {
           if (__DEV__) {
             const typename = context.store.getFieldValue<string>(
@@ -440,7 +432,6 @@ export class StoreReader {
     array,
     enclosingRef,
     context,
-    parentObjectOrReference,
   }: ExecSubSelectedArrayOptions): ExecResult {
     let missing: MissingTree | undefined;
     let missingMerger = new DeepMerger();
@@ -472,7 +463,6 @@ export class StoreReader {
             array: item,
             enclosingRef,
             context,
-            parentObjectOrReference,
           }),
           i
         );
@@ -495,13 +485,7 @@ export class StoreReader {
         assertSelectionSetForIdValue(context.store, field, item);
       }
 
-      return context.policies.maybeCoerceToScalarValue(item, {
-        field,
-        typename: context.store.getFieldValue<string>(
-          parentObjectOrReference,
-          "__typename"
-        ),
-      });
+      return item;
     });
 
     return {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -370,7 +370,6 @@ export class StoreReader {
             readFieldOptions,
             context
           );
-          // do nothing
         } else if (fieldValue != null) {
           if (__DEV__) {
             const typename = context.store.getFieldValue<string>(

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -361,7 +361,7 @@ export class StoreReader {
             );
           }
         } else if (!selection.selectionSet) {
-          fieldValue = policies.maybeCoerceScalarValue(fieldValue, {
+          fieldValue = policies.maybeCoerceToScalarValue(fieldValue, {
             field: selection,
             typename: context.store.getFieldValue<string>(
               objectOrReference,
@@ -495,7 +495,7 @@ export class StoreReader {
         assertSelectionSetForIdValue(context.store, field, item);
       }
 
-      return context.policies.maybeCoerceScalarValue(item, {
+      return context.policies.maybeCoerceToScalarValue(item, {
         field,
         typename: context.store.getFieldValue<string>(
           parentObjectOrReference,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -3,11 +3,7 @@ import { Kind } from "graphql";
 import type { OptimisticWrapperFunction } from "optimism";
 import { wrap } from "optimism";
 
-import type {
-  Reference,
-  StoreObject,
-  StoreValue,
-} from "@apollo/client/utilities";
+import type { Reference, StoreObject } from "@apollo/client/utilities";
 import {
   addTypenameToDocument,
   cacheSizes,

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -46,7 +46,6 @@ import {
 } from "./entityStore.js";
 import {
   extractFragmentContext,
-  fieldNameFromStoreName,
   getTypenameFromStoreObject,
 } from "./helpers.js";
 import type { InMemoryCache } from "./inMemoryCache.js";
@@ -326,14 +325,15 @@ export class StoreReader {
       if (!shouldInclude(selection, variables)) return;
 
       if (isField(selection)) {
-        const readFieldOptions = {
-          fieldName: selection.name.value,
-          field: selection,
-          variables: context.variables,
-          from: objectOrReference,
-        };
-
-        let fieldValue = policies.readField(readFieldOptions, context);
+        let fieldValue = policies.readField(
+          {
+            fieldName: selection.name.value,
+            field: selection,
+            variables: context.variables,
+            from: objectOrReference,
+          },
+          context
+        );
 
         const resultName = resultKeyNameFromField(selection);
 
@@ -361,20 +361,20 @@ export class StoreReader {
             );
           }
         } else if (!selection.selectionSet) {
-          fieldValue = policies.maybeCoerceScalarValue(
-            fieldValue,
-            readFieldOptions,
-            context
-          );
+          fieldValue = policies.maybeCoerceScalarValue(fieldValue, {
+            field: selection,
+            typename: context.store.getFieldValue<string>(
+              objectOrReference,
+              "__typename"
+            ),
+          });
         } else if (fieldValue != null) {
           if (__DEV__) {
             const typename = context.store.getFieldValue<string>(
               objectOrReference,
               "__typename"
             );
-            const fieldName = fieldNameFromStoreName(
-              policies.getStoreFieldName(readFieldOptions)
-            );
+            const fieldName = selection.name.value;
 
             if (typename) {
               const policy = policies["getFieldPolicy"](typename, fieldName);
@@ -495,15 +495,13 @@ export class StoreReader {
         assertSelectionSetForIdValue(context.store, field, item);
       }
 
-      return context.policies.maybeCoerceScalarValue(
-        item,
-        {
-          fieldName: field.name.value,
-          field,
-          from: parentObjectOrReference,
-        },
-        context
-      );
+      return context.policies.maybeCoerceScalarValue(item, {
+        field,
+        typename: context.store.getFieldValue<string>(
+          parentObjectOrReference,
+          "__typename"
+        ),
+      });
     });
 
     return {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -50,6 +50,7 @@ import {
 } from "./entityStore.js";
 import {
   extractFragmentContext,
+  fieldNameFromStoreName,
   getTypenameFromStoreObject,
 } from "./helpers.js";
 import type { InMemoryCache } from "./inMemoryCache.js";
@@ -371,6 +372,27 @@ export class StoreReader {
           );
           // do nothing
         } else if (fieldValue != null) {
+          if (__DEV__) {
+            const typename = context.store.getFieldValue<string>(
+              objectOrReference,
+              "__typename"
+            );
+            const fieldName = fieldNameFromStoreName(
+              policies.getStoreFieldName(readFieldOptions)
+            );
+
+            if (typename) {
+              const policy = policies["getFieldPolicy"](typename, fieldName);
+
+              if (policy?.scalar) {
+                invariant.warn(
+                  "The field policy for '%s' is configured as a '%s' scalar, but the field is not a scalar field because it contains a selection set. The field value remains unchanged.",
+                  `${typename}.${fieldName}`,
+                  policy.scalar
+                );
+              }
+            }
+          }
           // In this case, because we know the field has a selection set,
           // it must be trying to query a GraphQLObjectType, which is why
           // fieldValue must be != null.

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -6,9 +6,12 @@ import type {
   StoreObject,
   StoreValue,
 } from "@apollo/client/utilities";
-import type { ExtensionsWithStreamInfo } from "@apollo/client/utilities/internal";
+import type {
+  ExtensionsWithStreamInfo,
+  RemoveIndexSignature,
+} from "@apollo/client/utilities/internal";
 
-import type { Transaction } from "../core/cache.js";
+import type { ApolloCache, Transaction } from "../core/cache.js";
 import type {
   AllFieldsModifier,
   CanReadFunction,
@@ -171,3 +174,5 @@ export interface ReadMergeModifyContext {
   varString?: string;
   extensions?: ExtensionsWithStreamInfo;
 }
+
+export type KnownScalars = RemoveIndexSignature<ApolloCache.Scalars>;

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -176,3 +176,6 @@ export interface ReadMergeModifyContext {
 }
 
 export type KnownScalars = RemoveIndexSignature<ApolloCache.Scalars>;
+export type ScalarNames =
+  | keyof KnownScalars
+  | (string extends keyof ApolloCache.Scalars ? string & {} : never);

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -411,25 +411,12 @@ export class StoreWriter {
         } else {
           maybeRecycleChildMergeTree(mergeTree, storeFieldName);
 
-          // If a merge function isn't present, serialize the incoming
-          // value since it wasn't coerced after running the merge function
-          const coerceToSerializedValue = (value: StoreValue): StoreValue => {
-            if (!typename) {
-              return value;
-            }
-
-            if (Array.isArray(value)) {
-              return value.map((item) => coerceToSerializedValue(item));
-            }
-
-            return this.cache.policies.maybeCoerceSerializedValue(value, {
-              fieldName: field.name.value,
-              field,
-              typename,
-            });
-          };
-
-          incomingValue = coerceToSerializedValue(incomingValue);
+          if (typename) {
+            incomingValue = this.cache.policies.maybeCoerceSerializedValue(
+              incomingValue,
+              { fieldName: field.name.value, field, typename }
+            );
+          }
         }
 
         incoming = context.merge(incoming, {

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -412,7 +412,7 @@ export class StoreWriter {
           maybeRecycleChildMergeTree(mergeTree, storeFieldName);
 
           if (typename) {
-            incomingValue = this.cache.policies.maybeCoerceSerializedValue(
+            incomingValue = this.cache.policies.maybeCoerceToSerializedValue(
               incomingValue,
               { field, typename }
             );
@@ -777,7 +777,7 @@ export class StoreWriter {
     if (mergeTree.info?.typename) {
       const { field, typename } = mergeTree.info;
 
-      return this.cache.policies.maybeCoerceSerializedValue(incoming, {
+      return this.cache.policies.maybeCoerceToSerializedValue(incoming, {
         field,
         typename,
       }) as T;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -781,7 +781,7 @@ export class StoreWriter {
         fieldName: field.name.value,
         field,
         typename,
-      });
+      }) as T;
     }
 
     return incoming;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -410,6 +410,15 @@ export class StoreWriter {
           };
         } else {
           maybeRecycleChildMergeTree(mergeTree, storeFieldName);
+
+          // If a merge function isn't present, serialize the incoming
+          // value since it wasn't coerced after running the merge function
+          if (typename) {
+            incomingValue = this.cache.policies.maybeCoerceSerializedValue(
+              incomingValue,
+              { fieldName: field.name.value, field, typename }
+            );
+          }
         }
 
         incoming = context.merge(incoming, {

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -414,7 +414,7 @@ export class StoreWriter {
           if (typename) {
             incomingValue = this.cache.policies.maybeCoerceSerializedValue(
               incomingValue,
-              { fieldName: field.name.value, field, typename }
+              { field, typename }
             );
           }
         }
@@ -778,7 +778,6 @@ export class StoreWriter {
       const { field, typename } = mergeTree.info;
 
       return this.cache.policies.maybeCoerceSerializedValue(incoming, {
-        fieldName: field.name.value,
         field,
         typename,
       }) as T;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -778,13 +778,23 @@ export class StoreWriter {
     }
 
     if (mergeTree.info) {
-      return this.cache.policies.runMergeFunction(
+      incoming = this.cache.policies.runMergeFunction(
         existing,
         incoming,
         mergeTree.info,
         context,
         getStorageArgs && context.store.getStorage(...getStorageArgs)
       );
+    }
+
+    if (mergeTree.info?.typename) {
+      const { field, typename } = mergeTree.info;
+
+      return this.cache.policies.maybeCoerceSerializedValue(incoming, {
+        fieldName: field.name.value,
+        field,
+        typename,
+      });
     }
 
     return incoming;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -413,12 +413,23 @@ export class StoreWriter {
 
           // If a merge function isn't present, serialize the incoming
           // value since it wasn't coerced after running the merge function
-          if (typename) {
-            incomingValue = this.cache.policies.maybeCoerceSerializedValue(
-              incomingValue,
-              { fieldName: field.name.value, field, typename }
-            );
-          }
+          const coerceToSerializedValue = (value: StoreValue): StoreValue => {
+            if (!typename) {
+              return value;
+            }
+
+            if (Array.isArray(value)) {
+              return value.map((item) => coerceToSerializedValue(item));
+            }
+
+            return this.cache.policies.maybeCoerceSerializedValue(value, {
+              fieldName: field.name.value,
+              field,
+              typename,
+            });
+          };
+
+          incomingValue = coerceToSerializedValue(incomingValue);
         }
 
         incoming = context.merge(incoming, {

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -410,13 +410,6 @@ export class StoreWriter {
           };
         } else {
           maybeRecycleChildMergeTree(mergeTree, storeFieldName);
-
-          if (typename) {
-            incomingValue = this.cache.policies.maybeCoerceToScalarValue(
-              incomingValue,
-              { field, typename }
-            );
-          }
         }
 
         incoming = context.merge(incoming, {
@@ -765,22 +758,13 @@ export class StoreWriter {
     }
 
     if (mergeTree.info) {
-      incoming = this.cache.policies.runMergeFunction(
+      return this.cache.policies.runMergeFunction(
         existing,
         incoming,
         mergeTree.info,
         context,
         getStorageArgs && context.store.getStorage(...getStorageArgs)
       );
-    }
-
-    if (mergeTree.info?.typename) {
-      const { field, typename } = mergeTree.info;
-
-      return this.cache.policies.maybeCoerceToScalarValue(incoming, {
-        field,
-        typename,
-      }) as T;
     }
 
     return incoming;

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -412,7 +412,7 @@ export class StoreWriter {
           maybeRecycleChildMergeTree(mergeTree, storeFieldName);
 
           if (typename) {
-            incomingValue = this.cache.policies.maybeCoerceToSerializedValue(
+            incomingValue = this.cache.policies.maybeCoerceToScalarValue(
               incomingValue,
               { field, typename }
             );
@@ -777,7 +777,7 @@ export class StoreWriter {
     if (mergeTree.info?.typename) {
       const { field, typename } = mergeTree.info;
 
-      return this.cache.policies.maybeCoerceToSerializedValue(incoming, {
+      return this.cache.policies.maybeCoerceToScalarValue(incoming, {
         field,
         typename,
       }) as T;


### PR DESCRIPTION
_Part of the custom scalars work: https://github.com/apollographql/apollo-client/issues/13227_

Adds scalar value serialization for scalar fields during cache writes. This allows users to provide either the parsed or serialized value to the cache and have it work as expected.