### PR TITLE
Tweak renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,8 +39,8 @@
     "glob",
     "prettier",
     "eslint-plugin-react-compiler",
-    "graphql-17-alpha-2",
-    "graphql-17-alpha-9"
+    "graphql-17-alpha2",
+    "graphql-17-alpha9"
   ],
   "reviewers": [],
   "reviewersFromCodeOwners": false,

--- a/renovate.json
+++ b/renovate.json
@@ -46,5 +46,6 @@
   ],
   "reviewers": [],
   "reviewersFromCodeOwners": false,
-  "ignoreReviewers": ["team:@apollographql/client-typescript"]
+  "ignoreReviewers": ["team:@apollographql/client-typescript"],
+  "minimumReleaseAge": "7 days"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,9 @@
     "prettier",
     "eslint-plugin-react-compiler",
     "graphql-17-alpha2",
-    "graphql-17-alpha9"
+    "graphql-17-alpha9",
+    "rxjs-min",
+    "jsdom"
   ],
   "reviewers": [],
   "reviewersFromCodeOwners": false,


### PR DESCRIPTION
Changes:
- `graphql-17-alpha-2`: Wrong name, changed to `graphql-17-alpha2` since this should never be updated
- `graphql-17-alpha-9`: Wrong name, changed to `graphql-17-alpha9` since this should never be updated
- `rxjs-min`: Added. This should never be updated since we need to test with this exact min version.
- `jsdom`: We've had troubles with newer versions, so we'll update this manually

I've also set `minimumReleaseAge` to `7 days` to add one more layer of protection against supply chain attacks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve the overall handling of automated version updates for development dependencies. These configuration adjustments modify which packages are included in automatic update processes, providing greater control over dependency management and ensuring more predictable and reliable version update behavior across the entire development environment and workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->