### PR TITLE
docs: unify d.ts example filename to apollo.d.ts

### DIFF
--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -1402,7 +1402,7 @@ To use GraphQL Codegen's masking format with your operation types, you need to t
 
 Create a TypeScript file that will be used to modify the `TypeOverrides` interface. Extend `TypeOverrides` with the `GraphQLCodegenDataMasking.TypeOverrides` interface.
 
-```ts title="apollo-client.d.ts"
+```ts title="apollo.d.ts"
 // This import is necessary to ensure all Apollo Client imports
 // are still available to the rest of the application.
 import "@apollo/client";
@@ -1415,7 +1415,7 @@ declare module "@apollo/client" {
 
 <Note>
 
-This example uses `apollo-client.d.ts` as the file name to make it easily identifiable. You can give this file any name.
+This example uses `apollo.d.ts` as the file name to make it easily identifiable. You can give this file any name.
 
 </Note>
 
@@ -1751,7 +1751,7 @@ Apollo Client uses [declaration merging](https://www.typescriptlang.org/docs/han
 
 Let's add type overrides for our custom type implementations. Create a TypeScript file and define a `TypeOverrides` interface for the `@apollo/client` module.
 
-```ts title=apollo-client.d.ts
+```ts title="apollo.d.ts"
 // This import is necessary to ensure all Apollo Client imports
 // are still available to the rest of the application.
 import "@apollo/client";
@@ -1765,7 +1765,7 @@ declare module "@apollo/client" {
 
 Now we'll import our HKT types and add them as keys in the `TypeOverrides` interface.
 
-```ts {4,8-9} title=apollo-client.d.ts
+```ts {4,8-9} title="apollo.d.ts"
 // This import is necessary to ensure all Apollo Client imports
 // are still available to the rest of the application.
 import "@apollo/client";

--- a/docs/source/data/typescript.mdx
+++ b/docs/source/data/typescript.mdx
@@ -518,7 +518,7 @@ You can define your own context types for better type safety in Apollo Client us
 
 To define types for your custom context properties, create a TypeScript file and define the `DefaultContext` interface.
 
-```ts title="apollo-client.d.ts"
+```ts title="apollo.d.ts"
 // This import is necessary to ensure all Apollo Client imports
 // are still available to the rest of the application.
 import "@apollo/client";
@@ -560,7 +560,7 @@ Some links provided by Apollo Client have built-in context option types. You can
 
 The following example adds `HttpLink`'s context types to `DefaultContext`:
 
-```ts title="apollo-client.d.ts"
+```ts title="apollo.d.ts"
 import "@apollo/client";
 import { HttpLink } from "@apollo/client";
 
@@ -587,7 +587,7 @@ const { data } = useQuery(MY_QUERY, {
 
 If you are using more than one link that has context options, you can extend from each link's context options:
 
-```ts title="apollo-client.d.ts"
+```ts title="apollo.d.ts"
 import "@apollo/client";
 import type { BaseHttpLink } from "@apollo/client/link/http";
 import type { ClientAwarenessLink } from "@apollo/client/link/client-awareness";
@@ -900,7 +900,7 @@ Once your HKT type is created, you tell Apollo Client about it by using [declara
 
 Create a TypeScript file that defines the `TypeOverrides` interface for the `@apollo/client` module.
 
-```ts title=apollo-client.d.ts
+```ts title="apollo.d.ts"
 // This import is necessary to ensure all Apollo Client imports
 // are still available to the rest of the application.
 import "@apollo/client";
@@ -1001,7 +1001,7 @@ With our HKT types in place, we now need to tell Apollo Client about them. We'll
 
 Create a TypeScript file and define a `TypeOverrides` interface for the `@apollo/client` module.
 
-```ts title="apollo-client.d.ts"
+```ts title="apollo.d.ts"
 // This import is necessary to ensure all Apollo Client imports
 // are still available to the rest of the application.
 import "@apollo/client";

--- a/docs/source/migrating/apollo-client-4-migration.mdx
+++ b/docs/source/migrating/apollo-client-4-migration.mdx
@@ -887,9 +887,9 @@ const client = new ApolloClient({
 
 To provide accurate TypeScript types, you will also need to tell Apollo Client to use the types associated with the `Defer20220824Handler` in order to provide accurate types for incremental chunks, used with the `ApolloLink.Result` type. This ensures that you properly handle incremental results in your custom links that might access the result directly.
 
-Create a new `.d.ts` file in your project (e.g. `apollo-client.d.ts`) and add the following content:
+Create a new `.d.ts` file in your project (e.g. `apollo.d.ts`) and add the following content:
 
-```ts title="apollo-client.d.ts
+```ts title="apollo.d.ts"
 import { Defer20220824Handler } from "@apollo/client/incremental";// [!code highlight]
 
 declare module "@apollo/client" {
@@ -911,7 +911,7 @@ In Apollo Client 4, the data masking types are now configurable to allow for mor
 
 To configure the data masking types to be the same as they were in Apollo Client 3, create a `.d.ts` file in your project with the following content:
 
-```ts title="apollo-client.d.ts
+```ts title="apollo.d.ts"
 import { GraphQLCodegenDataMasking } from "@apollo/client/masking";// [!code highlight]
 
 declare module "@apollo/client" {
@@ -924,7 +924,7 @@ declare module "@apollo/client" {
 
 You can combine multiple `TypeOverrides` of different kinds. For example, you can combine the data masking types with the `Defer20220824Handler` type overrides from the previous section.
 
-```ts title="apollo-client.d.ts disableCopy=true
+```ts title="apollo.d.ts" disableCopy=true
 import { Defer20220824Handler } from "@apollo/client/incremental";
 import { GraphQLCodegenDataMasking } from "@apollo/client/masking";// [!code ++]
 
@@ -1692,7 +1692,7 @@ Apollo Client 4 removes the `TContext` generic argument in favor of using [decla
 
 To define types for your custom context properties, create a TypeScript file and define the `DefaultContext` interface.
 
-```ts title="apollo-client.d.ts"
+```ts title="apollo.d.ts"
 // This import is necessary to ensure all Apollo Client imports
 // are still available to the rest of the application.
 import "@apollo/client";
@@ -2055,7 +2055,7 @@ The `context` type can be extended by using declaration merging to allow you to 
 
 For example, to make your context type-safe for usage with `HttpLink`, place this snippet in a `.d.ts` file in your project:
 
-```ts title="apollo-client.d.ts"
+```ts title="apollo.d.ts"
 import { HttpLink } from "@apollo/client";
 
 declare module "@apollo/client" {


### PR DESCRIPTION
I noticed that the TypeScript docs is inconsistent about the name for the declaration file used for module augmentation. Some examples refer to it as `apollo-client.d.ts`, while others call it `apollo.d.ts`, and this can happen even within the same page and section. I'm concerned that this inconsistency can confuse readers and make them question if the two names have different meanings. So, I've standardized all the `.d.ts` examples to `apollo.d.ts`, which is the name used in [the Apollo Client 4.2 blog post](https://www.apollographql.com/blog/whats-new-in-apollo-client-4-2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TypeScript declaration file examples throughout the documentation guides to maintain consistent filename references in code samples for better clarity across data fragments, type definitions, and migration sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->