### PR TITLE
fix: tighten cache implementation constraints

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -668,7 +668,7 @@ export type InternalRefetchQueriesInclude = InternalRefetchQueryDescriptor[] | R
 export type InternalRefetchQueriesMap<TResult> = Map<ObservableQuery<any>, InternalRefetchQueriesResult<TResult>>;
 
 // @public (undocumented)
-export interface InternalRefetchQueriesOptions<TCache extends ApolloCache, TResult> extends Omit<ApolloClient.RefetchQueriesOptions<TCache, TResult>, "include"> {
+export interface InternalRefetchQueriesOptions<TCache extends Cache_2.Implementation, TResult> extends Omit<ApolloClient.RefetchQueriesOptions<TCache, TResult>, "include"> {
     // (undocumented)
     include?: InternalRefetchQueriesInclude;
     // (undocumented)

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import type { ApolloCache } from '@apollo/client/cache';
-import type { ApolloCache as ApolloCache_2 } from '@apollo/client';
 import type { ApolloClient } from '@apollo/client';
 import type { Cache as Cache_2 } from '@apollo/client/cache';
 import type { DataState } from '@apollo/client';
@@ -131,16 +130,16 @@ type MakeRequiredVariablesOptional<TVariables extends OperationVariables, TConfi
 } & Omit<TVariables, keyof TConfiguredVariables>>;
 
 // @public @deprecated (undocumented)
-export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
+export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
-export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.Options<TData, TVariables, TCache>;
+export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.Options<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
 export type MutationResult<TData = unknown> = useMutation.Result<TData>;
 
 // @public @deprecated (undocumented)
-export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache_2 = ApolloCache_2> = useMutation.ResultTuple<TData, TVariables, TCache>;
+export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.ResultTuple<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
 export type OnDataOptions<TData = unknown> = useSubscription.OnDataOptions<TData>;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1646,7 +1646,7 @@ export type InternalRefetchQueriesInclude = InternalRefetchQueryDescriptor[] | R
 export type InternalRefetchQueriesMap<TResult> = Map<ObservableQuery<any>, InternalRefetchQueriesResult<TResult>>;
 
 // @public (undocumented)
-export interface InternalRefetchQueriesOptions<TCache extends ApolloCache, TResult> extends Omit<ApolloClient.RefetchQueriesOptions<TCache, TResult>, "include"> {
+export interface InternalRefetchQueriesOptions<TCache extends Cache_2.Implementation, TResult> extends Omit<ApolloClient.RefetchQueriesOptions<TCache, TResult>, "include"> {
     // (undocumented)
     include?: InternalRefetchQueriesInclude;
     // (undocumented)

--- a/.changeset/tidy-cache-type-constraints.md
+++ b/.changeset/tidy-cache-type-constraints.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Align the remaining cache generic constraints with `Cache.Implementation`. The deprecated React mutation types (`MutationHookOptions`, `MutationFunctionOptions`, `MutationTuple`) and the internal `InternalRefetchQueriesOptions` and `QueryInfo` types still constrained their cache type parameter to `ApolloCache`, so they now match the rest of the overridable cache API.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 47873,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 42183,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35925,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29449
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 47998,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 42268,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35960,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29486
 }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -96,7 +96,7 @@ const queryInfoIds = new WeakMap<QueryManager, number>();
 export class QueryInfo<
   TData,
   TVariables extends OperationVariables = OperationVariables,
-  TCache extends ApolloCache = ApolloCache,
+  TCache extends Cache.Implementation = Cache.Implementation,
 > {
   // TODO remove soon - this should be able to be handled by cancelling old operations before starting new ones
   lastRequestId = 1;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,7 +5,6 @@ import type {
   ObservableNotification,
 } from "rxjs";
 
-import type { ApolloCache } from "@apollo/client/cache";
 import type { Cache } from "@apollo/client/cache";
 import type { ClientAwarenessLink } from "@apollo/client/link/client-awareness";
 import type { Unmasked } from "@apollo/client/masking";
@@ -273,7 +272,7 @@ export type RefetchQueriesPromiseResults<TResult> =
 
 // Used by QueryManager["refetchQueries"]
 export interface InternalRefetchQueriesOptions<
-  TCache extends ApolloCache,
+  TCache extends Cache.Implementation,
   TResult,
 > extends Omit<ApolloClient.RefetchQueriesOptions<TCache, TResult>, "include"> {
   // Just like the refetchQueries option for a mutation, an array of strings,

--- a/src/react/types/deprecated.ts
+++ b/src/react/types/deprecated.ts
@@ -1,8 +1,5 @@
-import type {
-  ApolloCache,
-  DefaultContext,
-  OperationVariables,
-} from "@apollo/client";
+import type { DefaultContext, OperationVariables } from "@apollo/client";
+import type { Cache } from "@apollo/client/cache";
 
 import type { useBackgroundQuery } from "../hooks/useBackgroundQuery.js";
 import type { useFragment } from "../hooks/useFragment.js";
@@ -62,7 +59,7 @@ export type MutationHookOptions<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
   _TContext = DefaultContext,
-  TCache extends ApolloCache = ApolloCache,
+  TCache extends Cache.Implementation = Cache.Implementation,
 > = useMutation.Options<TData, TVariables, TCache>;
 
 /** @deprecated Use `useMutation.Result` instead */
@@ -73,7 +70,7 @@ export type MutationFunctionOptions<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
   _TContext = DefaultContext,
-  TCache extends ApolloCache = ApolloCache,
+  TCache extends Cache.Implementation = Cache.Implementation,
 > = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
 
 /** @deprecated Use `useMutation.ResultTuple` instead */
@@ -81,7 +78,7 @@ export type MutationTuple<
   TData,
   TVariables extends OperationVariables,
   _TContext = DefaultContext,
-  TCache extends ApolloCache = ApolloCache,
+  TCache extends Cache.Implementation = Cache.Implementation,
 > = useMutation.ResultTuple<TData, TVariables, TCache>;
 
 /** @deprecated Use `useSubscription.Result` instead */


### PR DESCRIPTION
As a quick follow-up to PR #13250, this fixes some cache override typing paths that still allowed `ApolloCache`, while the public mutation and refetch APIs now expect `Cache.Implementation`. Keeping these constraints aligned ensures that user-declared cache overrides work consistently through `QueryInfo`, internal refetch options, and deprecated React mutation aliases. We also regenerated the API reports so that the published type surface shows the corrected constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Aligned cache-related type constraints across the library for consistency. TypeScript users working with custom cache implementations may notice updated type signatures in mutation helpers and query-related APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->