### PR TITLE
Persist credentials so cleanup works

### DIFF
--- a/.github/workflows/cleanup-checks.yml
+++ b/.github/workflows/cleanup-checks.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          persist-credentials: false
+          # git-auto-commit-action requires persist-credentials set to true
+          # https://github.com/stefanzweifel/git-auto-commit-action#action-does-not-push-commit-to-repository-authentication-issue
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6


### PR DESCRIPTION
This should fix the failing cleanup action: https://github.com/apollographql/apollo-client/actions/runs/27289056045/job/80604278133?pr=13259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to ensure proper credential handling for automated tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->