### PR TITLE
Add a `fromGraphQLScalarType` helper

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -998,7 +998,7 @@ export class Scalar<TSerialized, TParsed> {
     // (undocumented)
     coerceToSerialized(value: TSerialized | TParsed): TSerialized;
     // (undocumented)
-    static fromGraphQLScalarType<TSerialized, TParsed>(scalarType: GraphQLScalarType<TParsed, TSerialized>, options: Pick<Scalar.Options<NoInfer_2<TSerialized>, NoInfer_2<TParsed>>, "is">): Scalar<TSerialized, TParsed>;
+    static fromGraphQLScalarType<TSerialized, TParsed>(scalarType: GraphQLScalarType<TParsed, TSerialized>, options?: Pick<Scalar.Options<NoInfer_2<TSerialized>, NoInfer_2<TParsed>>, "is">): Scalar<TSerialized, TParsed>;
     // (undocumented)
     is(value: TSerialized | TParsed): value is TParsed;
     // (undocumented)

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -20,6 +20,7 @@ import type { FragmentType } from '@apollo/client/masking';
 import { getApolloCacheMemoryInternals } from '@apollo/client/utilities/internal';
 import type { GetDataState } from '@apollo/client';
 import { getInMemoryCacheMemoryInternals } from '@apollo/client/utilities/internal';
+import type { GraphQLScalarType } from 'graphql';
 import type { Incremental } from '@apollo/client/incremental';
 import type { InlineFragmentNode } from 'graphql';
 import type { IsAny } from '@apollo/client/utilities/internal';
@@ -996,6 +997,8 @@ export class Scalar<TSerialized, TParsed> {
     coerceToParsed(value: TSerialized | TParsed): TParsed;
     // (undocumented)
     coerceToSerialized(value: TSerialized | TParsed): TSerialized;
+    // (undocumented)
+    static fromGraphQLScalarType<TSerialized, TParsed>(scalarType: GraphQLScalarType<TParsed, TSerialized>, options: Pick<Scalar.Options<NoInfer_2<TSerialized>, NoInfer_2<TParsed>>, "is">): Scalar<TSerialized, TParsed>;
     // (undocumented)
     is(value: TSerialized | TParsed): value is TParsed;
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -15,6 +15,7 @@ import type { FormattedExecutionResult } from 'graphql';
 import type { FragmentDefinitionNode } from 'graphql';
 import { gql } from 'graphql-tag';
 import type { GraphQLFormattedError } from 'graphql';
+import type { GraphQLScalarType } from 'graphql';
 import type { InlineFragmentNode } from 'graphql';
 import type { InteropObservable } from 'rxjs';
 import type { NextNotification } from 'rxjs';
@@ -2822,6 +2823,8 @@ export class Scalar<TSerialized, TParsed> {
     coerceToParsed(value: TSerialized | TParsed): TParsed;
     // (undocumented)
     coerceToSerialized(value: TSerialized | TParsed): TSerialized;
+    // (undocumented)
+    static fromGraphQLScalarType<TSerialized, TParsed>(scalarType: GraphQLScalarType<TParsed, TSerialized>, options: Pick<Scalar.Options<NoInfer_2<TSerialized>, NoInfer_2<TParsed>>, "is">): Scalar<TSerialized, TParsed>;
     // (undocumented)
     is(value: TSerialized | TParsed): value is TParsed;
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2824,7 +2824,7 @@ export class Scalar<TSerialized, TParsed> {
     // (undocumented)
     coerceToSerialized(value: TSerialized | TParsed): TSerialized;
     // (undocumented)
-    static fromGraphQLScalarType<TSerialized, TParsed>(scalarType: GraphQLScalarType<TParsed, TSerialized>, options: Pick<Scalar.Options<NoInfer_2<TSerialized>, NoInfer_2<TParsed>>, "is">): Scalar<TSerialized, TParsed>;
+    static fromGraphQLScalarType<TSerialized, TParsed>(scalarType: GraphQLScalarType<TParsed, TSerialized>, options?: Pick<Scalar.Options<NoInfer_2<TSerialized>, NoInfer_2<TParsed>>, "is">): Scalar<TSerialized, TParsed>;
     // (undocumented)
     is(value: TSerialized | TParsed): value is TParsed;
     // (undocumented)

--- a/.changeset/cold-comics-add.md
+++ b/.changeset/cold-comics-add.md
@@ -1,0 +1,18 @@
+---
+"@apollo/client": minor
+---
+
+Adds `Scalar.fromGraphQLScalarType` helper to create a `Scalar` instance from an existing graphql.js `GraphQLScalarType`.
+
+```ts
+import { GraphQLScalarType } from "graphql";
+import { Scalar } from "@apollo/client";
+
+const dateTimeScalarType = new GraphQLScalarType<Date, string>({
+  // ...
+});
+
+const dateTimeScalar = Scalar.fromGraphQLScalarType(dateTimeScalarType, {
+  is: (value) => value instanceof Date,
+});
+```

--- a/integration-tests/type-tests/customScalars/differentTypes/index.ts
+++ b/integration-tests/type-tests/customScalars/differentTypes/index.ts
@@ -1,5 +1,6 @@
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
 import { expectTypeOf } from "expect-type";
+import { GraphQLScalarType } from "graphql";
 
 declare function test(name: string, fn: () => void): void;
 declare const maybeDate: string | Date;
@@ -61,6 +62,35 @@ test("serialize receives the parsed type and parse receives the serialized type"
       }),
     },
   });
+});
+
+test("fromGraphQLScalarType infers the serialized and parsed types", () => {
+  const graphQLScalar = new GraphQLScalarType<Date, string>({
+    name: "DateTime",
+    serialize: (value) => {
+      if (!(value instanceof Date)) {
+        throw new TypeError("Expected a Date");
+      }
+
+      return value.toISOString();
+    },
+    parseValue: (value) => {
+      if (typeof value !== "string") {
+        throw new TypeError("Expected a string");
+      }
+
+      return new Date(value);
+    },
+  });
+
+  const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {
+    is: (value) => {
+      expectTypeOf(value).toEqualTypeOf<string | Date>();
+      return value instanceof Date;
+    },
+  });
+
+  expectTypeOf(scalar).toEqualTypeOf<Scalar<string, Date>>();
 });
 
 test("serialize must return the serialized type", () => {

--- a/src/cache/core/Scalar.ts
+++ b/src/cache/core/Scalar.ts
@@ -1,3 +1,5 @@
+import type { GraphQLScalarType } from "graphql";
+
 import type { NoInfer } from "@apollo/client/utilities/internal";
 
 export declare namespace Scalar {
@@ -14,6 +16,17 @@ export declare namespace Scalar {
 
 export class Scalar<TSerialized, TParsed> {
   private options: Scalar.Options<TSerialized, TParsed>;
+
+  static fromGraphQLScalarType<TSerialized, TParsed>(
+    scalarType: GraphQLScalarType<TParsed, TSerialized>,
+    options: Pick<Scalar.Options<NoInfer<TSerialized>, NoInfer<TParsed>>, "is">
+  ): Scalar<TSerialized, TParsed> {
+    return new Scalar<TSerialized, TParsed>({
+      ...options,
+      parse: scalarType.parseValue,
+      serialize: scalarType.serialize,
+    });
+  }
 
   constructor(options: Scalar.Options<TSerialized, TParsed>) {
     this.options = options;

--- a/src/cache/core/Scalar.ts
+++ b/src/cache/core/Scalar.ts
@@ -19,7 +19,7 @@ export class Scalar<TSerialized, TParsed> {
 
   static fromGraphQLScalarType<TSerialized, TParsed>(
     scalarType: GraphQLScalarType<TParsed, TSerialized>,
-    options: Pick<Scalar.Options<NoInfer<TSerialized>, NoInfer<TParsed>>, "is">
+    options?: Pick<Scalar.Options<NoInfer<TSerialized>, NoInfer<TParsed>>, "is">
   ): Scalar<TSerialized, TParsed> {
     return new Scalar<TSerialized, TParsed>({
       ...options,

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -1,3 +1,5 @@
+import { GraphQLScalarType, version as graphqlVersion } from "graphql";
+
 import type { TypedDocumentNode } from "@apollo/client";
 import { gql } from "@apollo/client";
 import { InMemoryCache, Scalar } from "@apollo/client/cache";
@@ -5,6 +7,8 @@ import {
   ObservableStream,
   spyOnConsole,
 } from "@apollo/client/testing/internal";
+
+const IS_GRAPHQL_17 = graphqlVersion.startsWith("17");
 
 const dateTimeScalar = new Scalar<string, Date>({
   serialize: (value) => value.toISOString(),
@@ -25,6 +29,166 @@ const jsonObjectScalar = new Scalar<
   parse: (value) => new Map(Object.entries(value)),
   is: (value) => value instanceof Map,
 });
+
+test("creates a scalar from a GraphQLScalarType", () => {
+  const graphQLScalar = new GraphQLScalarType<Date, string>({
+    name: "DateTime",
+    serialize: (value) => {
+      if (!(value instanceof Date)) {
+        throw new TypeError("Expected a Date");
+      }
+
+      return value.toISOString();
+    },
+    parseValue: (value) => {
+      if (typeof value !== "string") {
+        throw new TypeError("Expected a string");
+      }
+
+      return new Date(value);
+    },
+  });
+
+  const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {});
+
+  expect(scalar.parse("2026-01-01T00:00:00.000Z")).toEqual(
+    new Date("2026-01-01T00:00:00.000Z")
+  );
+  expect(scalar.serialize(new Date("2026-01-01T00:00:00.000Z"))).toBe(
+    "2026-01-01T00:00:00.000Z"
+  );
+});
+
+if (IS_GRAPHQL_17) {
+  test("creates a scalar from a GraphQLScalarType using GraphQL 17 initializer", () => {
+    const graphQLScalar = new GraphQLScalarType<Date, string>({
+      name: "DateTime",
+      coerceOutputValue: (value) => {
+        if (!(value instanceof Date)) {
+          throw new TypeError("Expected a Date");
+        }
+
+        return value.toISOString();
+      },
+      coerceInputValue: (value) => {
+        if (typeof value !== "string") {
+          throw new TypeError("Expected a string");
+        }
+
+        return new Date(value);
+      },
+    });
+
+    const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {});
+
+    expect(scalar.parse("2026-01-01T00:00:00.000Z")).toEqual(
+      new Date("2026-01-01T00:00:00.000Z")
+    );
+    expect(scalar.serialize(new Date("2026-01-01T00:00:00.000Z"))).toBe(
+      "2026-01-01T00:00:00.000Z"
+    );
+  });
+}
+
+test("uses the configured type guard when coercing values", () => {
+  const graphQLScalar = new GraphQLScalarType<number, string>({
+    name: "Price",
+    serialize: (value) => {
+      if (typeof value !== "number") {
+        throw new TypeError("Expected a number");
+      }
+
+      return value.toFixed(2);
+    },
+    parseValue: (value) => {
+      if (typeof value !== "string") {
+        throw new TypeError("Expected a string");
+      }
+
+      return Number(value);
+    },
+  });
+
+  const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {
+    is: (value) => typeof value === "number",
+  });
+
+  expect(scalar.coerceToParsed("12.34")).toBe(12.34);
+  expect(scalar.coerceToParsed(12.34)).toBe(12.34);
+  expect(scalar.coerceToSerialized(12.34)).toBe("12.34");
+  expect(scalar.coerceToSerialized("12.34")).toBe("12.34");
+});
+
+if (IS_GRAPHQL_17) {
+  test("uses the configured type guard with a GraphQL 17 initializer", () => {
+    const graphQLScalar = new GraphQLScalarType<number, string>({
+      name: "Price",
+      coerceOutputValue: (value) => {
+        if (typeof value !== "number") {
+          throw new TypeError("Expected a number");
+        }
+
+        return value.toFixed(2);
+      },
+      coerceInputValue: (value) => {
+        if (typeof value !== "string") {
+          throw new TypeError("Expected a string");
+        }
+
+        return Number(value);
+      },
+    });
+
+    const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {
+      is: (value) => typeof value === "number",
+    });
+
+    expect(scalar.coerceToParsed("12.34")).toBe(12.34);
+    expect(scalar.coerceToParsed(12.34)).toBe(12.34);
+    expect(scalar.coerceToSerialized(12.34)).toBe("12.34");
+    expect(scalar.coerceToSerialized("12.34")).toBe("12.34");
+  });
+}
+
+test("preserves errors thrown by the GraphQLScalarType", () => {
+  const graphQLScalar = new GraphQLScalarType<Date, string>({
+    name: "DateTime",
+    serialize: () => {
+      throw new TypeError("Unable to serialize DateTime");
+    },
+    parseValue: () => {
+      throw new TypeError("Unable to parse DateTime");
+    },
+  });
+
+  const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {});
+
+  expect(() => scalar.parse("invalid")).toThrow("Unable to parse DateTime");
+  expect(() => scalar.serialize(new Date())).toThrow(
+    "Unable to serialize DateTime"
+  );
+});
+
+if (IS_GRAPHQL_17) {
+  test("preserves errors thrown by a GraphQL 17 initializer", () => {
+    const graphQLScalar = new GraphQLScalarType<Date, string>({
+      name: "DateTime",
+      coerceOutputValue: () => {
+        throw new TypeError("Unable to serialize DateTime");
+      },
+      coerceInputValue: () => {
+        throw new TypeError("Unable to parse DateTime");
+      },
+    });
+
+    const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {});
+
+    expect(() => scalar.parse("invalid")).toThrow("Unable to parse DateTime");
+    expect(() => scalar.serialize(new Date())).toThrow(
+      "Unable to serialize DateTime"
+    );
+  });
+}
 
 test("getScalar returns a scalar object for a configured scalar", () => {
   const cache = new InMemoryCache({

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -49,7 +49,7 @@ test("creates a scalar from a GraphQLScalarType", () => {
     },
   });
 
-  const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {});
+  const scalar = Scalar.fromGraphQLScalarType(graphQLScalar);
 
   expect(scalar.parse("2026-01-01T00:00:00.000Z")).toEqual(
     new Date("2026-01-01T00:00:00.000Z")
@@ -79,7 +79,7 @@ if (IS_GRAPHQL_17) {
       },
     });
 
-    const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {});
+    const scalar = Scalar.fromGraphQLScalarType(graphQLScalar);
 
     expect(scalar.parse("2026-01-01T00:00:00.000Z")).toEqual(
       new Date("2026-01-01T00:00:00.000Z")
@@ -161,7 +161,7 @@ test("preserves errors thrown by the GraphQLScalarType", () => {
     },
   });
 
-  const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {});
+  const scalar = Scalar.fromGraphQLScalarType(graphQLScalar);
 
   expect(() => scalar.parse("invalid")).toThrow("Unable to parse DateTime");
   expect(() => scalar.serialize(new Date())).toThrow(
@@ -181,7 +181,7 @@ if (IS_GRAPHQL_17) {
       },
     });
 
-    const scalar = Scalar.fromGraphQLScalarType(graphQLScalar, {});
+    const scalar = Scalar.fromGraphQLScalarType(graphQLScalar);
 
     expect(() => scalar.parse("invalid")).toThrow("Unable to parse DateTime");
     expect(() => scalar.serialize(new Date())).toThrow(


### PR DESCRIPTION
Adds a new `Scalar.fromGraphQLScalarType` helper that is used to create a `Scalar` instance from an existing `GraphQLScalarType` instance from the `graphql` package. This makes it easier to use scalar definitions from packages such as [`graphql-scalars`](https://the-guild.dev/graphql/scalars)