### PR TITLE
Fix scalar parsing for subscriptions and mutations + add tests for all fetch policies

### DIFF
--- a/src/cache/inmemory/__tests__/cache.diff/customScalars.test.ts
+++ b/src/cache/inmemory/__tests__/cache.diff/customScalars.test.ts
@@ -1,0 +1,212 @@
+import { gql } from "@apollo/client";
+import { InMemoryCache } from "@apollo/client/cache";
+import { dateScalar } from "@apollo/client/testing/internal";
+
+test("serializes scalar variables used in field arguments", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      Date: dateScalar,
+    },
+  });
+
+  const query = gql`
+    query Event($date: Date!) {
+      event(date: $date) {
+        name
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    variables: {
+      date: "2026-01-01",
+    },
+    data: {
+      event: {
+        __typename: "Event",
+        name: "GraphQL Summit",
+      },
+    },
+  });
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: false,
+      variables: {
+        date: new Date(2026, 0, 1),
+      },
+    })
+  ).toStrictEqualTyped({
+    complete: true,
+    missing: undefined,
+    result: {
+      event: {
+        __typename: "Event",
+        name: "GraphQL Summit",
+      },
+    },
+  });
+});
+
+test("serializes scalar variables used in directive arguments", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      Date: dateScalar,
+    },
+    typePolicies: {
+      Query: {
+        fields: {
+          event: {
+            keyArgs: ["@on", ["date"]],
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event($date: Date!) {
+      event @on(date: $date) {
+        name
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    variables: {
+      date: "2026-01-01",
+    },
+    data: {
+      event: {
+        __typename: "Event",
+        name: "GraphQL Summit",
+      },
+    },
+  });
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: false,
+      variables: {
+        date: new Date(2026, 0, 1),
+      },
+    })
+  ).toStrictEqualTyped({
+    complete: true,
+    missing: undefined,
+    result: {
+      event: {
+        __typename: "Event",
+        name: "GraphQL Summit",
+      },
+    },
+  });
+});
+
+test("serializes scalar fields in input object variables", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      Date: dateScalar,
+    },
+    inputObjects: {
+      EventFilter: {
+        fields: {
+          date: "Date",
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event($filter: EventFilter!) {
+      event(filter: $filter) {
+        name
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    variables: {
+      filter: {
+        date: "2026-01-01",
+      },
+    },
+    data: {
+      event: {
+        __typename: "Event",
+        name: "GraphQL Summit",
+      },
+    },
+  });
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: false,
+      variables: {
+        filter: {
+          date: new Date(2026, 0, 1),
+        },
+      },
+    })
+  ).toStrictEqualTyped({
+    complete: true,
+    missing: undefined,
+    result: {
+      event: {
+        __typename: "Event",
+        name: "GraphQL Summit",
+      },
+    },
+  });
+});
+
+test("returns parsed custom scalar fields", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      Date: dateScalar,
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "Date",
+          },
+        },
+      },
+    },
+  });
+  const query = gql`
+    query Event {
+      event {
+        startDate
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  expect(cache.diff({ query, optimistic: false })).toStrictEqualTyped({
+    complete: true,
+    missing: undefined,
+    result: {
+      event: {
+        __typename: "Event",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+});

--- a/src/cache/inmemory/__tests__/cache.readFragment/customScalars.test.ts
+++ b/src/cache/inmemory/__tests__/cache.readFragment/customScalars.test.ts
@@ -1,0 +1,42 @@
+import { gql } from "@apollo/client";
+import { InMemoryCache } from "@apollo/client/cache";
+import { dateScalar } from "@apollo/client/testing/internal";
+
+test("returns parsed custom scalar fields", () => {
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startDate
+    }
+  `;
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  cache.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  });
+
+  expect(
+    cache.readFragment({
+      fragment,
+      id: "Event:1",
+    })
+  ).toStrictEqualTyped({
+    __typename: "Event",
+    id: "1",
+    startDate: new Date(2026, 0, 1),
+  });
+});

--- a/src/cache/inmemory/__tests__/cache.readQuery/customScalars.test.ts
+++ b/src/cache/inmemory/__tests__/cache.readQuery/customScalars.test.ts
@@ -150,3 +150,44 @@ test("serializes scalar fields in input object variables", () => {
     },
   });
 });
+
+test("returns parsed custom scalar fields", () => {
+  const cache = new InMemoryCache({
+    scalars: {
+      Date: dateScalar,
+    },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: {
+            scalar: "Date",
+          },
+        },
+      },
+    },
+  });
+  const query = gql`
+    query Event {
+      event {
+        startDate
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -480,43 +480,39 @@ export class QueryInfo<
             // Determine whether result is a SingleExecutionResult,
             // or the final ExecutionPatchResult.
 
-            if (update) {
-              if (!skipCache) {
-                // Re-read the ROOT_MUTATION data we just wrote into the cache
-                // (the first cache.write call in the cacheWrites.forEach loop
-                // above), so field read functions have a chance to run for
-                // fields within mutation result objects.
-                const diff = cache.diff<TData>({
-                  id: "ROOT_MUTATION",
-                  // The cache complains if passed a mutation where it expects a
-                  // query, so we transform mutations and subscriptions to queries
-                  // (only once, thanks to this.transformCache).
-                  query: this.queryManager.getDocumentInfo(mutation.document)
-                    .asQuery,
+            // Re-read from the cache after writing to it to update `result`
+            // with any parsed scalar values that might have been written.
+            if (!skipCache) {
+              const diff = cache.diff<TData>({
+                id: "ROOT_MUTATION",
+                // The cache complains if passed a mutation where it expects a
+                // query, so we transform mutations and subscriptions to queries
+                // (only once, thanks to this.transformCache).
+                query: this.queryManager.getDocumentInfo(mutation.document)
+                  .asQuery,
+                variables: mutation.variables,
+                optimistic: false,
+                returnPartialData: true,
+              });
+
+              if (diff.complete) {
+                result = {
+                  ...result,
+                  data: diff.result,
+                };
+              }
+            }
+
+            // If we've received the whole response, call the update function.
+            if (update && !this.hasNext) {
+              update(
+                cache as TCache,
+                result as FormattedExecutionResult<Unmasked<TData>>,
+                {
+                  context: mutation.context,
                   variables: mutation.variables,
-                  optimistic: false,
-                  returnPartialData: true,
-                });
-
-                if (diff.complete) {
-                  result = {
-                    ...result,
-                    data: diff.result,
-                  };
                 }
-              }
-
-              // If we've received the whole response, call the update function.
-              if (!this.hasNext) {
-                update(
-                  cache as TCache,
-                  result as FormattedExecutionResult<Unmasked<TData>>,
-                  {
-                    context: mutation.context,
-                    variables: mutation.variables,
-                  }
-                );
-              }
+              );
             }
 
             // TODO Do this with cache.evict({ id: 'ROOT_MUTATION' }) but make it

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -610,6 +610,22 @@ export class QueryInfo<
           variables: variables,
           extensions: result.extensions,
         });
+
+        // Re-read from the cache to get parsed scalar values
+        const diff = this.cache.diff({
+          // The cache complains if passed a mutation where it expects a
+          // query, so we transform mutations and subscriptions to queries
+          // (only once, thanks to this.transformCache).
+          query: this.queryManager.getDocumentInfo(document).asQuery,
+          id: "ROOT_SUBSCRIPTION",
+          variables,
+          optimistic: false,
+          returnPartialData: true,
+        });
+
+        if (diff.complete) {
+          result.data = diff.result as any;
+        }
       }
 
       this.queryManager.broadcastQueries();

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -314,7 +314,7 @@ export class QueryManager {
       this.mutationStore &&
       (this.mutationStore[queryInfo.id] = {
         mutation,
-        variables: this.client.cache.serializeVariables(mutation, variables),
+        variables: this.cache.serializeVariables(mutation, variables),
         loading: true,
         error: null,
       } as MutationStoreValue);

--- a/src/core/__tests__/client.mutate/customScalars.test.ts
+++ b/src/core/__tests__/client.mutate/customScalars.test.ts
@@ -267,3 +267,157 @@ test.failing(
     });
   }
 );
+
+test("parses parsed custom scalar fields in optimistic responses", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const fragment = gql`
+    fragment EventFragment on Event {
+      id
+      startDate
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-02-02",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  const promise = client.mutate({
+    mutation,
+    optimisticResponse: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  expect(
+    client.cache.readFragment({
+      id: "Event:1",
+      fragment,
+      optimistic: true,
+    })
+  ).toStrictEqualTyped({
+    __typename: "Event",
+    id: "1",
+    startDate: new Date(2026, 0, 1),
+  });
+
+  await expect(promise).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+});
+
+test("parses serialized custom scalar fields in optimistic responses", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const fragment = gql`
+    fragment EventFragment on Event {
+      id
+      startDate
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-02-02",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  const promise = client.mutate({
+    mutation,
+    optimisticResponse: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  expect(
+    client.cache.readFragment({
+      id: "Event:1",
+      fragment,
+      optimistic: true,
+    })
+  ).toStrictEqualTyped({
+    __typename: "Event",
+    id: "1",
+    startDate: new Date(2026, 0, 1),
+  });
+
+  await expect(promise).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+});

--- a/src/core/__tests__/client.mutate/customScalars.test.ts
+++ b/src/core/__tests__/client.mutate/customScalars.test.ts
@@ -1,4 +1,4 @@
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql } from "@apollo/client";
@@ -158,3 +158,112 @@ test("serializes scalar fields in input object variables", async () => {
     },
   });
 });
+
+test("parses custom scalar fields with a network-only fetch policy", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.mutate({
+      mutation,
+      fetchPolicy: "network-only",
+    })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const mutation = gql`
+      mutation CreateEvent {
+        createEvent {
+          id
+          startDate
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: {
+          Date: dateScalar,
+        },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: {
+                scalar: "Date",
+              },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(() =>
+        of({
+          data: {
+            createEvent: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }).pipe(delay(20))
+      ),
+    });
+
+    await expect(
+      client.mutate({
+        mutation,
+        fetchPolicy: "no-cache",
+      })
+    ).resolves.toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+    });
+  }
+);

--- a/src/core/__tests__/client.mutate/customScalars.test.ts
+++ b/src/core/__tests__/client.mutate/customScalars.test.ts
@@ -1,6 +1,6 @@
 import { delay, of } from "rxjs";
 
-import type { OperationVariables } from "@apollo/client";
+import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
 import { dateScalar } from "@apollo/client/testing/internal";
@@ -418,6 +418,94 @@ test("parses serialized custom scalar fields in optimistic responses", async () 
         id: "1",
         startDate: new Date(2026, 1, 2),
       },
+    },
+  });
+});
+
+test("passes parsed custom scalar fields to mutation updater callbacks", async () => {
+  const mutation: TypedDocumentNode<{
+    createEvent: { __typename: "Event"; id: string; startDate: Date };
+  }> = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const query = gql`
+    query LastCreatedEvent {
+      lastCreatedEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.mutate({
+      mutation,
+      update(cache, result) {
+        expect(result).toStrictEqualTyped({
+          data: {
+            createEvent: {
+              __typename: "Event",
+              id: "1",
+              startDate: new Date(2026, 0, 1),
+            },
+          },
+        });
+
+        cache.writeQuery({
+          query,
+          data: {
+            lastCreatedEvent: result.data!.createEvent,
+          },
+        });
+      },
+    })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  expect(client.readQuery({ query })).toStrictEqualTyped({
+    lastCreatedEvent: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
     },
   });
 });

--- a/src/core/__tests__/client.mutate/customScalars.test.ts
+++ b/src/core/__tests__/client.mutate/customScalars.test.ts
@@ -1,9 +1,10 @@
 import { delay, of } from "rxjs";
 
 import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql } from "@apollo/client";
+import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
-import { dateScalar } from "@apollo/client/testing/internal";
+import { MockLink } from "@apollo/client/testing";
+import { dateScalar, ObservableStream } from "@apollo/client/testing/internal";
 
 test("serializes scalar variables used in field arguments", async () => {
   let requestVariables!: OperationVariables;
@@ -506,6 +507,154 @@ test("passes parsed custom scalar fields to mutation updater callbacks", async (
       __typename: "Event",
       id: "1",
       startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields in queries triggered by refetchQueries", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  let requestCount = 0;
+  const link = new MockLink([
+    {
+      request: { query },
+      maxUsageCount: 2,
+      delay: 20,
+      result: () => {
+        requestCount++;
+
+        return {
+          data: {
+            event: {
+              __typename: "Event",
+              id: "1",
+              startDate: requestCount === 1 ? "2026-01-01" : "2026-03-03",
+            },
+          },
+        };
+      },
+    },
+    {
+      request: { query: mutation },
+      delay: 20,
+      result: {
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        },
+      },
+    },
+  ]);
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link,
+  });
+
+  using stream = new ObservableStream(client.watchQuery({ query }));
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(
+    client.mutate({
+      mutation,
+      refetchQueries: [query],
+      awaitRefetchQueries: true,
+    })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "2",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 2, 3),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+
+  expect(client.readQuery({ query })).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 2, 3),
     },
   });
 });

--- a/src/core/__tests__/client.query/customScalars.test.ts
+++ b/src/core/__tests__/client.query/customScalars.test.ts
@@ -1,4 +1,4 @@
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql } from "@apollo/client";
@@ -205,3 +205,241 @@ test("serializes scalar fields in input object variables", async () => {
     },
   });
 });
+
+test("parses cached custom scalar fields with a cache-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  await expect(
+    client.query({ query, fetchPolicy: "cache-only" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+});
+
+test("parses cached custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  await expect(
+    client.query({ query, fetchPolicy: "cache-first" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+});
+
+test("parses network custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.query({ query, fetchPolicy: "cache-first" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+});
+
+test("parses network custom scalar fields with a network-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.query({ query, fetchPolicy: "network-only" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const query = gql`
+      query Event {
+        event {
+          id
+          startDate
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: { Date: dateScalar },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: { scalar: "Date" },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(() =>
+        of({
+          data: {
+            event: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }).pipe(delay(20))
+      ),
+    });
+
+    await expect(
+      client.query({
+        query,
+        fetchPolicy: "no-cache",
+      })
+    ).resolves.toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+    });
+  }
+);

--- a/src/core/__tests__/client.readFragment/customScalars.test.ts
+++ b/src/core/__tests__/client.readFragment/customScalars.test.ts
@@ -1,0 +1,45 @@
+import { ApolloClient, ApolloLink, gql } from "@apollo/client";
+import { InMemoryCache } from "@apollo/client/cache";
+import { dateScalar } from "@apollo/client/testing/internal";
+
+test("returns parsed custom scalar fields", () => {
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startDate
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  });
+
+  expect(
+    client.readFragment({
+      fragment,
+      id: "Event:1",
+    })
+  ).toStrictEqualTyped({
+    __typename: "Event",
+    id: "1",
+    startDate: new Date(2026, 0, 1),
+  });
+});

--- a/src/core/__tests__/client.readQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.readQuery/customScalars.test.ts
@@ -118,3 +118,47 @@ test("serializes scalar fields in input object variables", () => {
     event: { __typename: "Event", name: "GraphQL Summit" },
   });
 });
+
+test("returns parsed custom scalar fields", () => {
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        startDate
+      }
+    }
+  `;
+
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  expect(client.readQuery({ query })).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});

--- a/src/core/__tests__/client.refetchQueries/customScalars.test.ts
+++ b/src/core/__tests__/client.refetchQueries/customScalars.test.ts
@@ -1,6 +1,6 @@
 import { of } from "rxjs";
 
-import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
+import type { OperationVariables } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
 import { MockLink } from "@apollo/client/testing";

--- a/src/core/__tests__/client.refetchQueries/customScalars.test.ts
+++ b/src/core/__tests__/client.refetchQueries/customScalars.test.ts
@@ -1,8 +1,9 @@
 import { of } from "rxjs";
 
-import type { OperationVariables } from "@apollo/client";
+import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
+import { MockLink } from "@apollo/client/testing";
 import { dateScalar, ObservableStream } from "@apollo/client/testing/internal";
 
 test("serializes scalar variables when refetching an active query", async () => {
@@ -88,4 +89,112 @@ test("serializes scalar variables when refetching an active query", async () => 
   await expect(stream).not.toEmitAnything();
 
   expect(requestVariables).toStrictEqualTyped({ date: "2026-01-01" });
+});
+
+test("parses custom scalar fields in refetched queries", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  let requestCount = 0;
+  const link = new MockLink([
+    {
+      request: { query },
+      maxUsageCount: 2,
+      delay: 20,
+      result: () => {
+        requestCount++;
+
+        return {
+          data: {
+            event: {
+              __typename: "Event",
+              id: "1",
+              startDate: requestCount === 1 ? "2026-01-01" : "2026-02-02",
+            },
+          },
+        };
+      },
+    },
+  ]);
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link,
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      notifyOnNetworkStatusChange: false,
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(
+    client.refetchQueries({ include: [query] })
+  ).resolves.toStrictEqualTyped([
+    {
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 1, 2),
+        },
+      },
+    },
+  ]);
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+
+  expect(client.readQuery({ query })).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 1, 2),
+    },
+  });
 });

--- a/src/core/__tests__/client.subscribe/customScalars.test.ts
+++ b/src/core/__tests__/client.subscribe/customScalars.test.ts
@@ -1,4 +1,4 @@
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql } from "@apollo/client";
@@ -170,3 +170,234 @@ test("serializes scalar fields in input object variables", async () => {
     },
   });
 });
+
+test("parses custom scalar fields with a cache-only fetch policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.subscribe({
+      query: subscription,
+      fetchPolicy: "cache-only",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  await expect(stream).toComplete();
+});
+
+test("parses custom scalar fields with a cache-first fetch policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.subscribe({
+      query: subscription,
+      fetchPolicy: "cache-first",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  await expect(stream).toComplete();
+});
+
+test("parses custom scalar fields with a network-only fetch policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: {
+        Date: dateScalar,
+      },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: {
+              scalar: "Date",
+            },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.subscribe({
+      query: subscription,
+      fetchPolicy: "network-only",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  await expect(stream).toComplete();
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const subscription = gql`
+      subscription EventCreated {
+        eventCreated {
+          id
+          startDate
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: {
+          Date: dateScalar,
+        },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: {
+                scalar: "Date",
+              },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(() =>
+        of({
+          data: {
+            eventCreated: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }).pipe(delay(20))
+      ),
+    });
+
+    using stream = new ObservableStream(
+      client.subscribe({
+        query: subscription,
+        fetchPolicy: "no-cache",
+      })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        eventCreated: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+    });
+
+    await expect(stream).toComplete();
+  }
+);

--- a/src/core/__tests__/client.watchFragment/customScalars.test.ts
+++ b/src/core/__tests__/client.watchFragment/customScalars.test.ts
@@ -1,0 +1,71 @@
+import { ApolloClient, ApolloLink, gql } from "@apollo/client";
+import { InMemoryCache } from "@apollo/client/cache";
+import { dateScalar, ObservableStream } from "@apollo/client/testing/internal";
+
+test("emits parsed custom scalar fields", async () => {
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startDate
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  });
+
+  using stream = new ObservableStream(
+    client.watchFragment({
+      fragment,
+      from: { __typename: "Event", id: "1" },
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+
+  client.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-02-02",
+    },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 1, 2),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+  await expect(stream).not.toEmitAnything();
+});

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -1,4 +1,4 @@
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
@@ -496,3 +496,427 @@ test("serializes scalar variables passed to subscribeToMore", async () => {
 
   expect(requestVariables).toStrictEqualTyped({ date: "2026-01-01" });
 });
+
+test("parses cached custom scalar fields with a cache-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-only" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses cached custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-first" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses network custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-first" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses cached and network custom scalar fields with a cache-and-network fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-02-02",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-and-network" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: false,
+  });
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses network custom scalar fields with a cache-and-network fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-and-network" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses network custom scalar fields with a network-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "network-only" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  await expect(stream).not.toEmitAnything();
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const query = gql`
+      query Event {
+        event {
+          id
+          startDate
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: { Date: dateScalar },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: { scalar: "Date" },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(() =>
+        of({
+          data: {
+            event: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }).pipe(delay(20))
+      ),
+    });
+
+    using stream = new ObservableStream(
+      client.watchQuery({
+        query,
+        fetchPolicy: "no-cache",
+      })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+    await expect(stream).toEmitTypedValue({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+  }
+);

--- a/src/react/hooks/__tests__/useFragment/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useFragment/customScalars.test.tsx
@@ -1,0 +1,83 @@
+import {
+  disableActEnvironment,
+  renderHookToSnapshotStream,
+} from "@testing-library/react-render-stream";
+
+import { ApolloClient, ApolloLink, gql } from "@apollo/client";
+import { InMemoryCache } from "@apollo/client/cache";
+import { useFragment } from "@apollo/client/react";
+import {
+  createClientWrapper,
+  dateScalar,
+} from "@apollo/client/testing/internal";
+
+test("returns parsed custom scalar fields", async () => {
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startDate
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () =>
+      useFragment({
+        fragment,
+        from: { __typename: "Event", id: "1" },
+      }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+
+  client.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-02-02",
+    },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 1, 2),
+    },
+    dataState: "complete",
+    complete: true,
+  });
+  await expect(takeSnapshot).not.toRerender();
+});

--- a/src/react/hooks/__tests__/useLazyQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery/customScalars.test.tsx
@@ -347,3 +347,712 @@ test("serializes scalar fields in input object variables", async () => {
     },
   });
 });
+
+test("parses cached custom scalar fields with a cache-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { fetchPolicy: "cache-only" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses cached custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { fetchPolicy: "cache-first" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses network custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { fetchPolicy: "cache-first" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses cached and network custom scalar fields with a cache-and-network fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-02-02",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { fetchPolicy: "cache-and-network" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses network custom scalar fields with a cache-and-network fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { fetchPolicy: "cache-and-network" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses network custom scalar fields with a network-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { fetchPolicy: "network-only" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const query = gql`
+      query Event {
+        event {
+          id
+          startDate
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: { Date: dateScalar },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: { scalar: "Date" },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(() =>
+        of({
+          data: {
+            event: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }).pipe(delay(20))
+      ),
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot, getCurrentSnapshot } =
+      await renderHookToSnapshotStream(
+        () => useLazyQuery(query, { fetchPolicy: "no-cache" }),
+        { wrapper: createClientWrapper(client) }
+      );
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        dataState: "empty",
+        called: false,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+    const [execute] = getCurrentSnapshot();
+
+    await expect(execute()).resolves.toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+    });
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: undefined,
+        dataState: "empty",
+        called: true,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+
+    {
+      const [, result] = await takeSnapshot();
+
+      expect(result).toStrictEqualTyped({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        },
+        dataState: "complete",
+        called: true,
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+    }
+  }
+);

--- a/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
@@ -5,9 +5,10 @@ import {
 import { delay, of } from "rxjs";
 
 import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql } from "@apollo/client";
+import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
-import { useMutation } from "@apollo/client/react";
+import { useMutation, useQuery } from "@apollo/client/react";
+import { MockLink } from "@apollo/client/testing";
 import {
   createClientWrapper,
   dateScalar,
@@ -813,6 +814,296 @@ test("passes parsed custom scalar fields to mutation updater callbacks", async (
       __typename: "Event",
       id: "1",
       startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields in queries triggered by refetchQueries", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  let requestCount = 0;
+  const link = new MockLink([
+    {
+      request: { query },
+      maxUsageCount: 2,
+      delay: 20,
+      result: () => {
+        requestCount++;
+
+        return {
+          data: {
+            event: {
+              __typename: "Event",
+              id: "1",
+              startDate: requestCount === 1 ? "2026-01-01" : "2026-03-03",
+            },
+          },
+        };
+      },
+    },
+    {
+      request: { query: mutation },
+      delay: 20,
+      result: {
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        },
+      },
+    },
+  ]);
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link,
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => ({
+      query: useQuery(query),
+      mutation: useMutation(mutation),
+    }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const {
+      query,
+      mutation: [, mutation],
+    } = await takeSnapshot();
+
+    expect(query).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+
+    expect(mutation).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  {
+    const {
+      query,
+      mutation: [, mutation],
+    } = await takeSnapshot();
+
+    expect(query).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+
+    expect(mutation).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const {
+    mutation: [mutate],
+  } = getCurrentSnapshot();
+
+  await expect(
+    mutate({
+      refetchQueries: [query],
+      awaitRefetchQueries: true,
+    })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "2",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+
+  {
+    const {
+      query,
+      mutation: [, mutation],
+    } = await takeSnapshot();
+
+    expect(query).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+
+    expect(mutation).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const {
+      query,
+      mutation: [, mutation],
+    } = await takeSnapshot();
+
+    expect(query).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      loading: true,
+      networkStatus: NetworkStatus.refetch,
+      previousData: undefined,
+      variables: {},
+    });
+
+    expect(mutation).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const {
+      query,
+      mutation: [, mutation],
+    } = await takeSnapshot();
+
+    expect(query).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 2, 3),
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      variables: {},
+    });
+
+    expect(mutation).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const {
+      query,
+      mutation: [, mutation],
+    } = await takeSnapshot();
+
+    expect(query).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 2, 3),
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      variables: {},
+    });
+
+    expect(mutation).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "2",
+          startDate: new Date(2026, 1, 2),
+        },
+      },
+      error: undefined,
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+
+  expect(client.readQuery({ query })).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 2, 3),
     },
   });
 });

--- a/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
@@ -444,3 +444,243 @@ test.failing(
     });
   }
 );
+
+test("parses parsed custom scalar fields in optimistic responses", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const fragment = gql`
+    fragment EventFragment on Event {
+      id
+      startDate
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-02-02",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+  const promise = mutate({
+    optimisticResponse: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  expect(
+    client.cache.readFragment({
+      id: "Event:1",
+      fragment,
+      optimistic: true,
+    })
+  ).toStrictEqualTyped({
+    __typename: "Event",
+    id: "1",
+    startDate: new Date(2026, 0, 1),
+  });
+
+  await expect(promise).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 1, 2),
+        },
+      },
+      error: undefined,
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses serialized custom scalar fields in optimistic responses", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const fragment = gql`
+    fragment EventFragment on Event {
+      id
+      startDate
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-02-02",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+  const promise = mutate({
+    optimisticResponse: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  expect(
+    client.cache.readFragment({
+      id: "Event:1",
+      fragment,
+      optimistic: true,
+    })
+  ).toStrictEqualTyped({
+    __typename: "Event",
+    id: "1",
+    startDate: new Date(2026, 0, 1),
+  });
+
+  await expect(promise).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 1, 2),
+        },
+      },
+      error: undefined,
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});

--- a/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
@@ -4,7 +4,7 @@ import {
 } from "@testing-library/react-render-stream";
 import { delay, of } from "rxjs";
 
-import type { OperationVariables } from "@apollo/client";
+import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
 import { useMutation } from "@apollo/client/react";
@@ -683,4 +683,136 @@ test("parses serialized custom scalar fields in optimistic responses", async () 
   }
 
   await expect(takeSnapshot).not.toRerender();
+});
+
+test("passes parsed custom scalar fields to mutation updater callbacks", async () => {
+  const mutation: TypedDocumentNode<{
+    createEvent: { __typename: "Event"; id: string; startDate: Date };
+  }> = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const query = gql`
+    query LastCreatedEvent {
+      lastCreatedEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+
+  await expect(
+    mutate({
+      update(cache, result) {
+        expect(result).toStrictEqualTyped({
+          data: {
+            createEvent: {
+              __typename: "Event",
+              id: "1",
+              startDate: new Date(2026, 0, 1),
+            },
+          },
+        });
+
+        cache.writeQuery({
+          query,
+          data: {
+            lastCreatedEvent: result.data!.createEvent,
+          },
+        });
+      },
+    })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      error: undefined,
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+
+  expect(client.readQuery({ query })).toStrictEqualTyped({
+    lastCreatedEvent: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
 });

--- a/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
@@ -291,3 +291,156 @@ test("serializes scalar fields in input object variables", async () => {
     input: { date: "2026-01-01" },
   });
 });
+
+test("parses custom scalar fields with a network-only fetch policy", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+
+  await expect(
+    mutate({ fetchPolicy: "network-only" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      error: undefined,
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const mutation = gql`
+      mutation CreateEvent {
+        createEvent {
+          id
+          startDate
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: { Date: dateScalar },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: { scalar: "Date" },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(() =>
+        of({
+          data: {
+            createEvent: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }).pipe(delay(20))
+      ),
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot, getCurrentSnapshot } =
+      await renderHookToSnapshotStream(() => useMutation(mutation), {
+        wrapper: createClientWrapper(client),
+      });
+
+    await takeSnapshot();
+    const [mutate] = getCurrentSnapshot();
+
+    await expect(
+      mutate({ fetchPolicy: "no-cache" })
+    ).resolves.toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+    });
+  }
+);

--- a/src/react/hooks/__tests__/useQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useQuery/customScalars.test.tsx
@@ -2,7 +2,7 @@ import {
   disableActEnvironment,
   renderHookToSnapshotStream,
 } from "@testing-library/react-render-stream";
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
@@ -239,3 +239,460 @@ test("serializes scalar fields in input object variables", async () => {
     },
   });
 });
+
+test("parses cached custom scalar fields with a cache-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { fetchPolicy: "cache-only" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses cached custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { fetchPolicy: "cache-first" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses network custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { fetchPolicy: "cache-first" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses cached and network custom scalar fields with a cache-and-network fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-02-02",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { fetchPolicy: "cache-and-network" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    variables: {},
+  });
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses network custom scalar fields with a cache-and-network fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { fetchPolicy: "cache-and-network" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses network custom scalar fields with a network-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { fetchPolicy: "network-only" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const query = gql`
+      query Event {
+        event {
+          id
+          startDate
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: { Date: dateScalar },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: { scalar: "Date" },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(() =>
+        of({
+          data: {
+            event: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }).pipe(delay(20))
+      ),
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
+      () => useQuery(query, { fetchPolicy: "no-cache" }),
+      { wrapper: createClientWrapper(client) }
+    );
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+);

--- a/src/react/hooks/__tests__/useSubscription/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription/customScalars.test.tsx
@@ -203,3 +203,270 @@ test("serializes scalar fields in input object variables", async () => {
     filter: { date: "2026-01-01" },
   });
 });
+
+test("parses custom scalar fields with a cache-only fetch policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+      }
+    }
+  `;
+  const link = new MockSubscriptionLink();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link,
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useSubscription(subscription, { fetchPolicy: "cache-only" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    error: undefined,
+    loading: true,
+  });
+
+  link.simulateResult(
+    {
+      result: {
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      },
+    },
+    true
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    error: undefined,
+    loading: false,
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields with a cache-first fetch policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+      }
+    }
+  `;
+  const link = new MockSubscriptionLink();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link,
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useSubscription(subscription, { fetchPolicy: "cache-first" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    error: undefined,
+    loading: true,
+  });
+
+  link.simulateResult(
+    {
+      result: {
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      },
+    },
+    true
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    error: undefined,
+    loading: false,
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields with a network-only fetch policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+      }
+    }
+  `;
+  const link = new MockSubscriptionLink();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link,
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useSubscription(subscription, { fetchPolicy: "network-only" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    error: undefined,
+    loading: true,
+  });
+
+  link.simulateResult(
+    {
+      result: {
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      },
+    },
+    true
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    error: undefined,
+    loading: false,
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const subscription = gql`
+      subscription EventCreated {
+        eventCreated {
+          id
+          startDate
+        }
+      }
+    `;
+    const link = new MockSubscriptionLink();
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: { Date: dateScalar },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: { scalar: "Date" },
+            },
+          },
+        },
+      }),
+      link,
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot } = await renderHookToSnapshotStream(
+      () => useSubscription(subscription, { fetchPolicy: "no-cache" }),
+      { wrapper: createClientWrapper(client) }
+    );
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+    });
+
+    link.simulateResult(
+      {
+        result: {
+          data: {
+            eventCreated: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        },
+      },
+      true
+    );
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: {
+        eventCreated: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      error: undefined,
+      loading: false,
+    });
+
+    await expect(takeSnapshot).not.toRerender();
+  }
+);

--- a/src/react/hooks/__tests__/useSuspenseFragment/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseFragment/customScalars.test.tsx
@@ -1,0 +1,79 @@
+import {
+  disableActEnvironment,
+  renderHookToSnapshotStream,
+} from "@testing-library/react-render-stream";
+
+import { ApolloClient, ApolloLink, gql } from "@apollo/client";
+import { InMemoryCache } from "@apollo/client/cache";
+import { useSuspenseFragment } from "@apollo/client/react";
+import {
+  createClientWrapper,
+  dateScalar,
+} from "@apollo/client/testing/internal";
+
+test("returns parsed custom scalar fields", async () => {
+  const fragment = gql`
+    fragment EventFields on Event {
+      id
+      startDate
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () =>
+      useSuspenseFragment({
+        fragment,
+        from: { __typename: "Event", id: "1" },
+      }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+
+  client.writeFragment({
+    fragment,
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-02-02",
+    },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 1, 2),
+    },
+  });
+  await expect(takeSnapshot).not.toRerender();
+});

--- a/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
@@ -1,5 +1,5 @@
 import { disableActEnvironment } from "@testing-library/react-render-stream";
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
 import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
@@ -216,3 +216,416 @@ test("serializes scalar fields in input object variables", async () => {
     },
   });
 });
+
+test("parses cached custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query, { fetchPolicy: "cache-first" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses network custom scalar fields with a cache-first fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query, { fetchPolicy: "cache-first" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses cached and network custom scalar fields with a cache-and-network fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-02-02",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query, { fetchPolicy: "cache-and-network" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.loading,
+      error: undefined,
+    });
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses network custom scalar fields with a cache-and-network fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query, { fetchPolicy: "cache-and-network" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses network custom scalar fields with a network-only fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query, { fetchPolicy: "network-only" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test.failing(
+  "parses custom scalar fields with a no-cache fetch policy",
+  async () => {
+    const query = gql`
+      query Event {
+        event {
+          id
+          startDate
+        }
+      }
+    `;
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        scalars: { Date: dateScalar },
+        typePolicies: {
+          Event: {
+            fields: {
+              startDate: { scalar: "Date" },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(() =>
+        of({
+          data: {
+            event: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }).pipe(delay(20))
+      ),
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeRender } = await renderUseSuspenseQuery(
+      () => useSuspenseQuery(query, { fetchPolicy: "no-cache" }),
+      { wrapper: createClientWrapper(client) }
+    );
+
+    {
+      const { renderedComponents } = await takeRender();
+
+      expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+    }
+
+    {
+      const { snapshot, renderedComponents } = await takeRender();
+
+      expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+      expect(snapshot).toStrictEqualTyped({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        },
+        dataState: "complete",
+        networkStatus: NetworkStatus.ready,
+        error: undefined,
+      });
+    }
+  }
+);


### PR DESCRIPTION
Adds tests for all APIs to test parsing scalars for all fetch policies. This revealed an issue with mutations and subscriptions where the parsed scalar value wasn't used correctly. This has been fixed in this PR.