### PR TITLE
🤖🤖🤖 Fix readFragment optimistic option

### DIFF
--- a/.changeset/fresh-birds-read.md
+++ b/.changeset/fresh-birds-read.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix `ApolloClient.readFragment` to respect the `optimistic` option passed in the options object.

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -1663,7 +1663,7 @@ export class ApolloClient {
     TVariables extends OperationVariables = OperationVariables,
   >(
     options: ApolloClient.ReadFragmentOptions<TData, TVariables>,
-    optimistic: boolean = false
+    optimistic: boolean = !!options.optimistic
   ): Unmasked<TData> | null {
     return this.cache.readFragment<TData, TVariables>(
       { ...options, fragment: this.transform(options.fragment) },

--- a/src/core/__tests__/client.readFragment/general.test.ts
+++ b/src/core/__tests__/client.readFragment/general.test.ts
@@ -49,3 +49,51 @@ test("can use `from` with readFragment", async () => {
     })
   ).toStrictEqualTyped({ __typename: "Foo", bar: true, baz: false });
 });
+
+test("respects the optimistic option", () => {
+  const fragment: TypedDocumentNode<
+    {
+      text: string;
+      __typename: "Todo";
+    },
+    Record<string, never>
+  > = gql`
+    fragment TodoFragment on Todo {
+      text
+    }
+  `;
+
+  const client = new ApolloClient({
+    link: ApolloLink.empty(),
+    cache: new InMemoryCache().restore({
+      "Todo:1": {
+        __typename: "Todo",
+        id: 1,
+        text: "base",
+      },
+    }),
+  });
+
+  client.cache.recordOptimisticTransaction((cache) => {
+    cache.writeFragment({
+      id: "Todo:1",
+      fragment,
+      data: { __typename: "Todo", text: "optimistic" },
+    });
+  }, "optimistic Todo");
+
+  expect(
+    client.readFragment({
+      fragment,
+      from: "Todo:1",
+    })
+  ).toStrictEqualTyped({ __typename: "Todo", text: "base" });
+
+  expect(
+    client.readFragment({
+      fragment,
+      from: "Todo:1",
+      optimistic: true,
+    })
+  ).toStrictEqualTyped({ __typename: "Todo", text: "optimistic" });
+});


### PR DESCRIPTION
Fixes #13276

## Summary
- Default `ApolloClient.readFragment`'s positional `optimistic` argument to `options.optimistic`.
- Add a regression test for optimistic fragment reads via the options object.
- Add a changeset for the patch release note.

## Testing
- `npm run test -- --runInBand --testRegex src/core/__tests__/client.readFragment/general.test.ts`
- `git diff --check`
- `npx prettier --check src/core/ApolloClient.ts src/core/__tests__/client.readFragment/general.test.ts .changeset/fresh-birds-read.md`
- `npm run changeset-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `ApolloClient.readFragment` now respects the `optimistic` option supplied in the options object.

* **Tests**
  * Added test coverage validating `readFragment` honors the `optimistic` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->