### PR TITLE
Add test for cache write after error with `errorPolicy: "all"`

### DIFF
--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4055,7 +4055,9 @@ describe("useQuery Hook", () => {
       const query = gql`
         query {
           goodField
-          badField
+          badField {
+            subField
+          }
         }
       `;
 

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -4051,6 +4051,76 @@ describe("useQuery Hook", () => {
       await expect(takeSnapshot).not.toRerender();
     });
 
+    it('rerenders with updates to non-errored fields from cache writes after a partial GraphQL error with errorPolicy: "all" and returnPartialData: true', async () => {
+      const query = gql`
+        query {
+          goodField
+          badField
+        }
+      `;
+
+      const client = new ApolloClient({
+        link: new MockLink([
+          {
+            request: { query },
+            result: {
+              data: { goodField: "initial", badField: null },
+              errors: [{ message: 'Error fetching field "badField".' }],
+            },
+          },
+        ]),
+        cache: new InMemoryCache(),
+      });
+
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot } = await renderHookToSnapshotStream(
+        () => useQuery(query, { errorPolicy: "all", returnPartialData: true }),
+        { wrapper: createClientWrapper(client) }
+      );
+
+      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+
+      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+        data: { goodField: "initial", badField: null },
+        dataState: "complete",
+        error: new CombinedGraphQLErrors({
+          data: { goodField: "initial", badField: null },
+          errors: [{ message: 'Error fetching field "badField".' }],
+        }),
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        previousData: undefined,
+        variables: {},
+      });
+
+      client.writeQuery({
+        query: gql`
+          query {
+            goodField
+          }
+        `,
+        data: { goodField: "updated" },
+      });
+
+      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+        data: { goodField: "updated", badField: null },
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: { goodField: "initial", badField: null },
+        variables: {},
+      });
+
+      await expect(takeSnapshot).not.toRerender();
+    });
+
     it("should persist errors on re-render if they are still valid", async () => {
       const query = gql`
         {


### PR DESCRIPTION
Closes #13279

Add test demonstrating cache write after error with `errorPolicy: "all"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error handling behavior when partial GraphQL errors occur with data caching enabled, verifying correct state management and cache updates in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->