### PR TITLE
Minor improvements

### DIFF
--- a/src/cache/inmemory/entityStore.ts
+++ b/src/cache/inmemory/entityStore.ts
@@ -402,17 +402,21 @@ export abstract class EntityStore implements NormalizedCache {
   }
 
   public extract(): NormalizedCacheObject {
-    const obj = Object.fromEntries(
-      Object.entries(this.toObject()).map(([dataId, storeObject]) => [
-        dataId,
-        storeObject &&
-          this.coerceStoreObject(
-            storeObject,
-            (scalar, value) => scalar.coerceToSerialized(value),
-            storeObject?.__typename || this.policies.rootTypenamesById[dataId]
-          ),
-      ])
-    );
+    let obj = this.toObject();
+
+    if (this.hasScalarConfig()) {
+      obj = Object.fromEntries(
+        Object.entries(obj).map(([dataId, storeObject]) => [
+          dataId,
+          storeObject &&
+            this.coerceStoreObject(
+              storeObject,
+              (scalar, value) => scalar.coerceToSerialized(value),
+              storeObject?.__typename || this.policies.rootTypenamesById[dataId]
+            ),
+        ])
+      );
+    }
 
     const extraRootIds: string[] = [];
     this.getRootIdSet().forEach((id) => {
@@ -426,12 +430,16 @@ export abstract class EntityStore implements NormalizedCache {
     return obj;
   }
 
+  private hasScalarConfig() {
+    return !!this.policies.cache["config"].scalars;
+  }
+
   private coerceStoreObject(
     obj: StoreObject,
     coerce: (scalar: Scalar<any, any>, value: unknown) => unknown,
     typename = obj.__typename
   ): StoreObject {
-    if (!typename || !this.policies.cache["config"].scalars) {
+    if (!typename || !this.hasScalarConfig()) {
       return obj;
     }
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -362,10 +362,6 @@ export class StoreReader {
           // do nothing
         } else if (fieldValue != null) {
           if (__DEV__) {
-            const typename = context.store.getFieldValue<string>(
-              objectOrReference,
-              "__typename"
-            );
             const fieldName = selection.name.value;
 
             if (typename) {


### PR DESCRIPTION
Small improvements mentioned in https://github.com/apollographql/apollo-client/pull/13270#pullrequestreview-4602823218.

- Keeps `cache.extract()` cheap when no scalars are configured
- Reuses an existing variable to remove unneeded duplicate code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache extraction so scalar values are only normalized when scalar handling is enabled.
  * Preserved stored values unchanged when scalar handling is disabled.
  * Refined store field checks to avoid redundant lookups during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->