### PR TITLE
Expose KeyArgsFunction, RelayFieldPolicy types to consumers

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -636,7 +636,7 @@ const _invalidateModifier: unique symbol;
 export { isReference }
 
 // @public (undocumented)
-type KeyArgsFunction = (args: Record<string, any> | null, context: {
+export type KeyArgsFunction = (args: Record<string, any> | null, context: {
     typename: string;
     fieldName: string;
     field: FieldNode | null;
@@ -1009,7 +1009,6 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-utilities.api.md
+++ b/.api-reports/api-report-utilities.api.md
@@ -177,10 +177,8 @@ export interface Reference {
 // Warning: (ae-forgotten-export) The symbol "TIncomingRelay" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type RelayFieldPolicy<TNode> = FieldPolicy<TExistingRelay<TNode> | null, TIncomingRelay<TNode> | null, TIncomingRelay<TNode> | null>;
+export type RelayFieldPolicy<TNode> = FieldPolicy<TExistingRelay<TNode> | null, TIncomingRelay<TNode> | null, TIncomingRelay<TNode> | null>;
 
-// Warning: (ae-forgotten-export) The symbol "RelayFieldPolicy" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function relayStylePagination<TNode extends Reference_2 = Reference_2>(keyArgs?: KeyArgs): RelayFieldPolicy<TNode>;
 

--- a/.changeset/mighty-rats-accept.md
+++ b/.changeset/mighty-rats-accept.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Export `KeyArgsFunction` and `RelayFieldPolicy` types from public entrypoints.

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -36,6 +36,7 @@ export type {
   FieldPolicy,
   FieldReadFunction,
   FieldReadFunctionOptions,
+  KeyArgsFunction,
   PossibleTypesMap,
   TypePolicies,
   TypePolicy,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -28,6 +28,7 @@ export {
   getMainDefinition,
 } from "@apollo/client/utilities/internal";
 
+export type { RelayFieldPolicy } from "./policies/pagination.js";
 export {
   concatPagination,
   offsetLimitPagination,

--- a/src/utilities/policies/pagination.ts
+++ b/src/utilities/policies/pagination.ts
@@ -92,7 +92,7 @@ type TIncomingRelay<TNode> = {
   pageInfo?: TRelayPageInfo;
 };
 
-type RelayFieldPolicy<TNode> = FieldPolicy<
+export type RelayFieldPolicy<TNode> = FieldPolicy<
   TExistingRelay<TNode> | null,
   TIncomingRelay<TNode> | null,
   TIncomingRelay<TNode> | null


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-client/issues/13296

These types were previously available to import in version 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public API with additional type exports for cache and pagination utilities.
  * This makes it easier to build type-safe custom caching and field policy integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->