### PR TITLE
Add back prepack script

### DIFF
--- a/.changeset/empty-peas-buy.md
+++ b/.changeset/empty-peas-buy.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client-graphql-codegen": patch
+---
+
+Fix accidentally omitted runtime files in latest minor.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - run: npm run ci:precheck
       - run: npm version
       - run: npm ci
-      - run: npm run build -w @apollo/client-graphql-codegen && cd codegen/dist && mv "$(npm pack --json | jq --raw-output '.[0].filename')" apollo-client-graphql-codegen.tgz
+      - run: npm run build -w @apollo/client-graphql-codegen && cd codegen && mv "dist/$(npm pack --ignore-scripts --pack-destination dist --json | jq --raw-output '.[0].filename')" dist/apollo-client-graphql-codegen.tgz
       - persist_to_workspace:
           root: codegen/dist
           paths:

--- a/codegen/package.json
+++ b/codegen/package.json
@@ -31,6 +31,7 @@
     "prebuild": "npm run clean",
     "clean": "rimraf dist",
     "build": "tsc",
+    "prepack": "npm run build",
     "publint": "publint run --strict ."
   },
   "devDependencies": {


### PR DESCRIPTION
#13300 removed the `prepack` script in `codegen/package.json` because this interfered with the `npm pack` command when run locally. This change however meant the package wasn't built, so `dist` wasn't published and all runtime files were gone. This should fix the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a packaging issue that caused runtime files to be missing from the latest minor release.
  * Ensured the package is built before it is published, helping avoid incomplete releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->