### PR TITLE
Guard relay multipart fetch after stringify failure

### DIFF
--- a/.changeset/khaki-rivers-beg.md
+++ b/.changeset/khaki-rivers-beg.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Prevent relay multipart subscriptions from issuing a fetch request after serializing the request body fails.

--- a/src/utilities/subscriptions/relay/__tests__/createFetchMultipartSubscription.test.ts
+++ b/src/utilities/subscriptions/relay/__tests__/createFetchMultipartSubscription.test.ts
@@ -126,5 +126,28 @@ describe("createFetchMultipartSubscription", () => {
 
       expect(errorSpy).toHaveBeenCalledWith(networkError);
     });
+
+    it("should not call fetch if JSON serialization fails", () => {
+      const errorSpy = jest.fn();
+      const mockFetch = jest.fn();
+      const variables: Record<string, unknown> = {};
+
+      variables.self = variables;
+
+      const subscribe = createFetchMultipartSubscription("/graphql", {
+        fetch: mockFetch as typeof fetch,
+      });
+
+      const observable = subscribe(mockRequestParameters, variables);
+
+      observable.subscribe({
+        next: () => {},
+        error: errorSpy,
+        complete: () => {},
+      });
+
+      expect(errorSpy).toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/utilities/subscriptions/relay/index.ts
+++ b/src/utilities/subscriptions/relay/index.ts
@@ -39,6 +39,7 @@ export function createFetchMultipartSubscription(
         options.body = JSON.stringify(body);
       } catch (parseError) {
         sink.error(parseError as Error);
+        return;
       }
 
       const currentFetch = preferredFetch || maybe(() => fetch) || backupFetch;


### PR DESCRIPTION
## Summary
- return early when serializing the relay multipart subscription body fails
- add a regression test that verifies `fetch` is not called after the stringify error

## Why
If `JSON.stringify(body)` throws, the observable reports the error but still falls through to `fetch`, which can trigger an unnecessary network request after the subscription has already failed.

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription error handling when request data cannot be serialized, ensuring the error is reported and the request stops immediately.
  * Prevented network calls from being attempted after serialization fails.

* **Tests**
  * Added coverage for a serialization failure scenario to verify the error callback is triggered and no request is sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->