### PR TITLE
Add tests for incremental payloads with custom scalars

### DIFF
--- a/.changeset/nasty-cheetahs-confess.md
+++ b/.changeset/nasty-cheetahs-confess.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where custom scalars returned in intermediate incremental `@defer` payloads did not return the parsed scalar value.

--- a/.changeset/nasty-cheetahs-confess.md
+++ b/.changeset/nasty-cheetahs-confess.md
@@ -1,5 +1,0 @@
----
-"@apollo/client": patch
----
-
-Fix an issue where custom scalars returned in intermediate incremental `@defer` payloads did not return the parsed scalar value.

--- a/config/jest.config.ts
+++ b/config/jest.config.ts
@@ -42,6 +42,7 @@ const reactSharedTestFileIgnoreList = [
   ignoreDTSFiles,
   ignoreTSFiles,
   "src/react/hooks/__tests__/useBackgroundQuery/testUtils.tsx",
+  "src/react/hooks/__tests__/useLoadableQuery/testUtils.tsx",
   "src/react/hooks/__tests__/useSuspenseQuery/testUtils.tsx",
   "src/react/query-preloader/__tests__/createQueryPreloader/testUtils.tsx",
 ];

--- a/src/core/__tests__/client.mutate/customScalars.test.ts
+++ b/src/core/__tests__/client.mutate/customScalars.test.ts
@@ -1,7 +1,13 @@
 import { delay, of } from "rxjs";
 
 import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
 import { MockLink } from "@apollo/client/testing";
 import { dateScalar, ObservableStream } from "@apollo/client/testing/internal";
@@ -655,6 +661,199 @@ test("parses custom scalar fields in queries triggered by refetchQueries", async
       __typename: "Event",
       id: "1",
       startDate: new Date(2026, 2, 3),
+    },
+  });
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["createEvent", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.mutate({ mutation, errorPolicy: "none" })
+  ).rejects.toEqual(
+    new CombinedGraphQLErrors({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["createEvent", "endDate"],
+        },
+      ],
+    })
+  );
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["createEvent", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.mutate({ mutation, errorPolicy: "all" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    error: new CombinedGraphQLErrors({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          // TODO: Determine if this is correct
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["createEvent", "endDate"],
+        },
+      ],
+    }),
+  });
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["createEvent", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.mutate({ mutation, errorPolicy: "ignore" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
     },
   });
 });

--- a/src/core/__tests__/client.query/customScalars.test.ts
+++ b/src/core/__tests__/client.query/customScalars.test.ts
@@ -1,7 +1,12 @@
 import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
 import { dateScalar } from "@apollo/client/testing/internal";
 
@@ -443,3 +448,248 @@ test.failing(
     });
   }
 );
+
+test("preserves referential identity when fetching identical serialized scalar values", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  const { data: first } = await client.query({
+    query,
+    fetchPolicy: "network-only",
+  });
+
+  expect(first).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+
+  const { data: second } = await client.query({
+    query,
+    fetchPolicy: "network-only",
+  });
+
+  expect(second).toBe(first);
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(client.query({ query, errorPolicy: "none" })).rejects.toEqual(
+    new CombinedGraphQLErrors({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["event", "endDate"],
+        },
+      ],
+    })
+  );
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.query({ query, errorPolicy: "all" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    error: new CombinedGraphQLErrors({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          // TODO: Determine if this is correct
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["event", "endDate"],
+        },
+      ],
+    }),
+  });
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.query({ query, errorPolicy: "ignore" })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+  });
+});

--- a/src/core/__tests__/client.readQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.readQuery/customScalars.test.ts
@@ -162,3 +162,61 @@ test("returns parsed custom scalar fields", () => {
     },
   });
 });
+
+test("preserves referential identity when writing identical serialized scalar values", () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: ApolloLink.empty(),
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  const previousResult = client.readQuery({ query });
+
+  expect(previousResult).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+
+  client.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+  });
+
+  expect(client.readQuery({ query })).toBe(previousResult);
+});

--- a/src/core/__tests__/client.subscribe/customScalars.test.ts
+++ b/src/core/__tests__/client.subscribe/customScalars.test.ts
@@ -1,7 +1,12 @@
 import { delay, of } from "rxjs";
 
-import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql } from "@apollo/client";
+import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
 import { dateScalar, ObservableStream } from "@apollo/client/testing/internal";
 
@@ -401,3 +406,278 @@ test.failing(
     await expect(stream).toComplete();
   }
 );
+
+test("preserves referential identity when a subscription emits identical serialized scalar values", async () => {
+  const subscription: TypedDocumentNode<{
+    eventCreated: { __typename: "Event"; id: string; startDate: Date };
+  }> = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of(
+        {
+          data: {
+            eventCreated: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        },
+        {
+          data: {
+            eventCreated: {
+              __typename: "Event",
+              id: "1",
+              startDate: "2026-01-01",
+            },
+          },
+        }
+      ).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.subscribe({ query: subscription })
+  );
+
+  const first = await stream.takeNext();
+
+  expect(first).toStrictEqualTyped({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  const second = await stream.takeNext();
+
+  expect(second.data!.eventCreated).toBe(first.data!.eventCreated);
+
+  await expect(stream).toComplete();
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["eventCreated", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.subscribe({ query: subscription, errorPolicy: "none" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    error: new CombinedGraphQLErrors({
+      data: {
+        eventCreated: {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["eventCreated", "endDate"],
+        },
+      ],
+    }),
+  });
+
+  await expect(stream).toComplete();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["eventCreated", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.subscribe({ query: subscription, errorPolicy: "all" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    error: new CombinedGraphQLErrors({
+      data: {
+        eventCreated: {
+          __typename: "Event",
+          id: "1",
+          // TODO: Determine if this is correct
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["eventCreated", "endDate"],
+        },
+      ],
+    }),
+  });
+
+  await expect(stream).toComplete();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const subscription = gql`
+    subscription EventCreated {
+      eventCreated {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          eventCreated: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["eventCreated", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.subscribe({ query: subscription, errorPolicy: "ignore" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      eventCreated: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+  });
+
+  await expect(stream).toComplete();
+});

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -1553,18 +1553,18 @@ test("parses custom scalar fields across `@defer` payloads when refetching (defe
   });
 
   await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
+    data: {
       event: {
         __typename: "Event",
         id: "1",
         startDate: new Date(2027, 0, 1),
         endDate: new Date(2026, 1, 2),
       },
-    }),
-    dataState: "streaming",
+    },
+    dataState: "complete",
     loading: true,
     networkStatus: NetworkStatus.streaming,
-    partial: true,
+    partial: false,
   });
 
   link.enqueueSubsequentChunk({
@@ -1718,18 +1718,18 @@ test("parses custom scalar fields across `@defer` payloads when refetching (grap
   });
 
   await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
+    data: {
       event: {
         __typename: "Event",
         id: "1",
         startDate: new Date(2027, 0, 1),
         endDate: new Date(2026, 1, 2),
       },
-    }),
-    dataState: "streaming",
+    },
+    dataState: "complete",
     loading: true,
     networkStatus: NetworkStatus.streaming,
-    partial: true,
+    partial: false,
   });
 
   link.enqueueSubsequentChunk({
@@ -1816,7 +1816,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
   });
 
   await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
+    data: {
       events: [
         {
           __typename: "Event",
@@ -1824,11 +1824,11 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
           startDate: new Date(2026, 0, 1),
         },
       ],
-    }),
-    dataState: "streaming",
+    },
+    dataState: "complete",
     loading: true,
     networkStatus: NetworkStatus.streaming,
-    partial: true,
+    partial: false,
   });
 
   link.enqueueSubsequentChunk({
@@ -1921,7 +1921,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
   });
 
   await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
+    data: {
       events: [
         {
           __typename: "Event",
@@ -1929,11 +1929,11 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
           startDate: new Date(2026, 0, 1),
         },
       ],
-    }),
-    dataState: "streaming",
+    },
+    dataState: "complete",
     loading: true,
     networkStatus: NetworkStatus.streaming,
-    partial: true,
+    partial: false,
   });
 
   link.enqueueSubsequentChunk({

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -1439,6 +1439,334 @@ test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", a
   await expect(stream).not.toEmitAnything();
 });
 
+test("parses custom scalar fields across `@defer` payloads when refetching (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  const observable = client.watchQuery({ query });
+  using stream = new ObservableStream(observable);
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, path: ["event"] }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  const refetchPromise = observable.refetch();
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2027-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2027, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2027-02-02" }, path: ["event"] }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2027, 0, 1),
+        endDate: new Date(2027, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(refetchPromise).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2027, 0, 1),
+        endDate: new Date(2027, 1, 2),
+      },
+    },
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses custom scalar fields across `@defer` payloads when refetching (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  const observable = client.watchQuery({ query });
+  using stream = new ObservableStream(observable);
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["event"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  const refetchPromise = observable.refetch();
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    partial: false,
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2027-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["event"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2027, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2027-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2027, 0, 1),
+        endDate: new Date(2027, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(refetchPromise).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2027, 0, 1),
+        endDate: new Date(2027, 1, 2),
+      },
+    },
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test("parses custom scalar fields across `@stream` payloads (defer20220824)", async () => {
   const link = mockDefer20220824();
   const client = new ApolloClient({

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -1,9 +1,25 @@
 import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
-import { dateScalar, ObservableStream } from "@apollo/client/testing/internal";
+import {
+  Defer20220824Handler,
+  GraphQL17Alpha9Handler,
+} from "@apollo/client/incremental";
+import {
+  dateScalar,
+  markAsStreaming,
+  mockDefer20220824,
+  mockDeferStreamGraphQL17Alpha9,
+  ObservableStream,
+} from "@apollo/client/testing/internal";
 
 test("serializes scalar variables used in field arguments", async () => {
   let requestVariables!: OperationVariables;
@@ -920,3 +936,715 @@ test.failing(
     });
   }
 );
+
+test("preserves referential identity when refetching identical serialized scalar values", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  const observable = client.watchQuery({
+    query,
+    notifyOnNetworkStatusChange: false,
+  });
+  using stream = new ObservableStream(observable);
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  const { data: previousData } = observable.getCurrentResult();
+
+  await expect(observable.refetch()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(observable.getCurrentResult().data).toBe(previousData);
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({ query, errorPolicy: "none" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    error: new CombinedGraphQLErrors({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["event", "endDate"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    partial: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({ query, errorPolicy: "all" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    error: new CombinedGraphQLErrors({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          // TODO: Determine if this is correct
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["event", "endDate"],
+        },
+      ],
+    }),
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({ query, errorPolicy: "ignore" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses custom scalar fields across `@defer` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using stream = new ObservableStream(client.watchQuery({ query }));
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, path: ["event"] }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using stream = new ObservableStream(client.watchQuery({ query }));
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["event"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses custom scalar fields across `@stream` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using stream = new ObservableStream(client.watchQuery({ query }));
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      ],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        path: ["events", 1],
+      },
+    ],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+        {
+          __typename: "Event",
+          id: "2",
+          startDate: new Date(2026, 1, 2),
+        },
+      ],
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using stream = new ObservableStream(client.watchQuery({ query }));
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    pending: [{ id: "0", path: ["events"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      ],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+        {
+          __typename: "Event",
+          id: "2",
+          startDate: new Date(2026, 1, 2),
+        },
+      ],
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});

--- a/src/react/hooks/__tests__/useBackgroundQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery/customScalars.test.tsx
@@ -255,15 +255,9 @@ test("preserves referential identity when refetching identical serialized scalar
     ),
   });
 
-  let refetch!: useBackgroundQuery.Result["refetch"];
-
   using _disabledAct = disableActEnvironment();
-  const { takeRender } = await renderUseBackgroundQuery(
-    () => {
-      const result = useBackgroundQuery(query);
-      refetch = result[1].refetch;
-      return result;
-    },
+  const { takeRender, refetch } = await renderUseBackgroundQuery(
+    () => useBackgroundQuery(query),
     { wrapper: createClientWrapper(client) }
   );
 
@@ -300,15 +294,7 @@ test("preserves referential identity when refetching identical serialized scalar
     previousData = snapshot.data;
   }
 
-  await expect(refetch()).resolves.toStrictEqual({
-    data: {
-      event: {
-        __typename: "Event",
-        id: "1",
-        startDate: new Date(2026, 0, 1),
-      },
-    },
-  });
+  void refetch();
 
   {
     const { renderedComponents } = await takeRender();

--- a/src/react/hooks/__tests__/useBackgroundQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery/customScalars.test.tsx
@@ -294,7 +294,15 @@ test("preserves referential identity when refetching identical serialized scalar
     previousData = snapshot.data;
   }
 
-  void refetch();
+  await expect(refetch()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
 
   {
     const { renderedComponents } = await takeRender();

--- a/src/react/hooks/__tests__/useBackgroundQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery/customScalars.test.tsx
@@ -1,13 +1,29 @@
+import assert from "node:assert";
+
 import { disableActEnvironment } from "@testing-library/react-render-stream";
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
+import {
+  Defer20220824Handler,
+  GraphQL17Alpha9Handler,
+} from "@apollo/client/incremental";
 import { useBackgroundQuery } from "@apollo/client/react";
 import {
   createClientWrapper,
   dateScalar,
+  markAsStreaming,
+  mockDefer20220824,
+  mockDeferStreamGraphQL17Alpha9,
+  spyOnConsole,
 } from "@apollo/client/testing/internal";
 
 import { renderUseBackgroundQuery } from "./testUtils.js";
@@ -43,9 +59,14 @@ test("serializes scalar variables used in field arguments", async () => {
     { wrapper: createClientWrapper(client) }
   );
 
-  await expect(takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useBackgroundQuery", "<Suspense />"],
-  });
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
 
   {
     const { snapshot, renderedComponents } = await takeRender();
@@ -99,9 +120,14 @@ test("serializes scalar variables used in directive arguments", async () => {
     { wrapper: createClientWrapper(client) }
   );
 
-  await expect(takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useBackgroundQuery", "<Suspense />"],
-  });
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
 
   {
     const { snapshot, renderedComponents } = await takeRender();
@@ -164,9 +190,14 @@ test("serializes scalar fields in input object variables", async () => {
     { wrapper: createClientWrapper(client) }
   );
 
-  await expect(takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useBackgroundQuery", "<Suspense />"],
-  });
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
 
   {
     const { snapshot, renderedComponents } = await takeRender();
@@ -189,4 +220,823 @@ test("serializes scalar fields in input object variables", async () => {
   expect(requestVariables).toStrictEqualTyped({
     filter: { date: "2026-01-01" },
   });
+});
+
+test("preserves referential identity when refetching identical serialized scalar values", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  let refetch!: useBackgroundQuery.Result["refetch"];
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseBackgroundQuery(
+    () => {
+      const result = useBackgroundQuery(query);
+      refetch = result[1].refetch;
+      return result;
+    },
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  let previousData: unknown;
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+
+    assert("data" in snapshot);
+
+    previousData = snapshot.data;
+  }
+
+  await expect(refetch()).resolves.toStrictEqual({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+
+    assert("data" in snapshot);
+
+    expect(snapshot.data).toBe(previousData);
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  using _consoleSpy = spyOnConsole("error");
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseBackgroundQuery(
+    () => useBackgroundQuery(query, { errorPolicy: "none" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<ErrorBoundary />"]);
+    expect(snapshot).toStrictEqualTyped({
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseBackgroundQuery(
+    () => useBackgroundQuery(query, { errorPolicy: "all" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.error,
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            // TODO: Determine if this is correct
+            startDate: new Date(2026, 0, 1),
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseBackgroundQuery(
+    () => useBackgroundQuery(query, { errorPolicy: "ignore" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseBackgroundQuery(
+    () => useBackgroundQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: markAsStreaming({
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, path: ["event"] }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseBackgroundQuery(
+    () => useBackgroundQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["event"] }],
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: markAsStreaming({
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseBackgroundQuery(
+    () => useBackgroundQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: markAsStreaming({
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        ],
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        path: ["events", 1],
+      },
+    ],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: new Date(2026, 1, 2),
+          },
+        ],
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseBackgroundQuery(
+    () => useBackgroundQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useBackgroundQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    pending: [{ id: "0", path: ["events"] }],
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: markAsStreaming({
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        ],
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: new Date(2026, 1, 2),
+          },
+        ],
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
 });

--- a/src/react/hooks/__tests__/useBackgroundQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery/customScalars.test.tsx
@@ -857,7 +857,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
 
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot).toStrictEqualTyped({
-      data: markAsStreaming({
+      data: {
         events: [
           {
             __typename: "Event",
@@ -865,8 +865,8 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
             startDate: new Date(2026, 0, 1),
           },
         ],
-      }),
-      dataState: "streaming",
+      },
+      dataState: "complete",
       networkStatus: NetworkStatus.streaming,
       error: undefined,
     });
@@ -975,7 +975,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
 
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot).toStrictEqualTyped({
-      data: markAsStreaming({
+      data: {
         events: [
           {
             __typename: "Event",
@@ -983,8 +983,8 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
             startDate: new Date(2026, 0, 1),
           },
         ],
-      }),
-      dataState: "streaming",
+      },
+      dataState: "complete",
       networkStatus: NetworkStatus.streaming,
       error: undefined,
     });

--- a/src/react/hooks/__tests__/useBackgroundQuery/testUtils.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery/testUtils.tsx
@@ -1,8 +1,10 @@
 import type { RenderOptions } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import {
   createRenderStream,
   useTrackRenders,
 } from "@testing-library/react-render-stream";
+import { userEvent } from "@testing-library/user-event";
 import React, { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -47,7 +49,7 @@ export async function renderUseBackgroundQuery<
 
   function App({ props }: { props: Props | undefined }) {
     useTrackRenders({ name: "useBackgroundQuery" });
-    const [queryRef] = renderHook(props as any);
+    const [queryRef, { refetch }] = renderHook(props as any);
 
     return (
       <Suspense fallback={<SuspenseFallback />}>
@@ -56,11 +58,13 @@ export async function renderUseBackgroundQuery<
           onError={(error) => replaceSnapshot({ error })}
         >
           {queryRef && <UseReadQuery queryRef={queryRef} />}
+          <button onClick={() => refetch()}>refetch</button>
         </ErrorBoundary>
       </Suspense>
     );
   }
 
+  const user = userEvent.setup();
   const { render, takeRender, replaceSnapshot } = createRenderStream<
     useReadQuery.Result<TData, TStates> | { error: ErrorLike }
   >();
@@ -71,5 +75,11 @@ export async function renderUseBackgroundQuery<
     return utils.rerender(<App props={props} />);
   }
 
-  return { takeRender, rerender };
+  // refetch needs to be run in an event handler in order for React 18 to commit
+  // the suspense fallback
+  async function refetch() {
+    await user.click(screen.getByText("refetch"));
+  }
+
+  return { takeRender, rerender, refetch };
 }

--- a/src/react/hooks/__tests__/useBackgroundQuery/testUtils.tsx
+++ b/src/react/hooks/__tests__/useBackgroundQuery/testUtils.tsx
@@ -1,11 +1,10 @@
 import type { RenderOptions } from "@testing-library/react";
-import { screen } from "@testing-library/react";
 import {
   createRenderStream,
   useTrackRenders,
 } from "@testing-library/react-render-stream";
-import { userEvent } from "@testing-library/user-event";
 import React, { Suspense } from "react";
+import { flushSync } from "react-dom";
 import { ErrorBoundary } from "react-error-boundary";
 
 import type { DataState, ErrorLike, OperationVariables } from "@apollo/client";
@@ -47,9 +46,13 @@ export async function renderUseBackgroundQuery<
     return null;
   }
 
+  let currentRefetch!: useBackgroundQuery.Result<TData, TVariables>["refetch"];
+
   function App({ props }: { props: Props | undefined }) {
     useTrackRenders({ name: "useBackgroundQuery" });
     const [queryRef, { refetch }] = renderHook(props as any);
+
+    currentRefetch = refetch;
 
     return (
       <Suspense fallback={<SuspenseFallback />}>
@@ -58,13 +61,11 @@ export async function renderUseBackgroundQuery<
           onError={(error) => replaceSnapshot({ error })}
         >
           {queryRef && <UseReadQuery queryRef={queryRef} />}
-          <button onClick={() => refetch()}>refetch</button>
         </ErrorBoundary>
       </Suspense>
     );
   }
 
-  const user = userEvent.setup();
   const { render, takeRender, replaceSnapshot } = createRenderStream<
     useReadQuery.Result<TData, TStates> | { error: ErrorLike }
   >();
@@ -75,11 +76,13 @@ export async function renderUseBackgroundQuery<
     return utils.rerender(<App props={props} />);
   }
 
-  // refetch needs to be run in an event handler in order for React 18 to commit
-  // the suspense fallback
-  async function refetch() {
-    await user.click(screen.getByText("refetch"));
-  }
+  // React 18 skips committing the suspense fallback when refetch is triggered
+  // as a default-priority update, so the fallback render is missed and tests
+  // may fail. flushSync forces a synchronous commit so the fallback renders in
+  // both React 18 and 19, while returning the refetch promise.
+  const refetch: typeof currentRefetch = (...args) => {
+    return flushSync(() => currentRefetch(...args));
+  };
 
   return { takeRender, rerender, refetch };
 }

--- a/src/react/hooks/__tests__/useLazyQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useLazyQuery/customScalars.test.tsx
@@ -5,7 +5,13 @@ import {
 import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
 import { useLazyQuery } from "@apollo/client/react";
 import {
@@ -1056,3 +1062,550 @@ test.failing(
     }
   }
 );
+
+test("preserves referential identity when re-executing with identical serialized scalar values", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { fetchPolicy: "network-only" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  let previousData: unknown;
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+
+    previousData = result.data;
+  }
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+
+    expect(result.data).toBe(previousData);
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { errorPolicy: "none" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).rejects.toEqual(
+    new CombinedGraphQLErrors({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["event", "endDate"],
+        },
+      ],
+    })
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.error,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { errorPolicy: "all" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    error: new CombinedGraphQLErrors({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          // TODO: Determine if this is correct
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["event", "endDate"],
+        },
+      ],
+    }),
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            // TODO: Determine if this is correct
+            startDate: new Date(2026, 0, 1),
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.error,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useLazyQuery(query, { errorPolicy: "ignore" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: false,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  const [execute] = getCurrentSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      dataState: "empty",
+      called: true,
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      called: true,
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      previousData: undefined,
+      variables: {},
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});

--- a/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
@@ -1,3 +1,4 @@
+import type { RenderOptions } from "@testing-library/react";
 import { screen } from "@testing-library/react";
 import {
   createRenderStream,
@@ -6,17 +7,118 @@ import {
 } from "@testing-library/react-render-stream";
 import { userEvent } from "@testing-library/user-event";
 import React, { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { delay, of } from "rxjs";
 
-import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import type { DataState, ErrorLike, OperationVariables } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
+import {
+  Defer20220824Handler,
+  GraphQL17Alpha9Handler,
+} from "@apollo/client/incremental";
 import type { QueryRef } from "@apollo/client/react";
 import { useLoadableQuery, useReadQuery } from "@apollo/client/react";
 import {
   createClientWrapper,
   dateScalar,
+  markAsStreaming,
+  mockDefer20220824,
+  mockDeferStreamGraphQL17Alpha9,
+  spyOnConsole,
 } from "@apollo/client/testing/internal";
+import { invariant } from "@apollo/client/utilities/invariant";
+
+async function renderHook<
+  TData,
+  TVariables extends OperationVariables,
+  TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"],
+  Props = never,
+>(
+  renderHookImpl: (
+    props: Props extends never ? undefined : Props
+  ) => useLoadableQuery.Result<TData, TVariables, TStates>,
+  options: Pick<RenderOptions, "wrapper"> & { initialProps?: Props }
+) {
+  function UseReadQuery({
+    queryRef,
+  }: {
+    queryRef: QueryRef<TData, TVariables, TStates>;
+  }) {
+    useTrackRenders({ name: "useReadQuery" });
+    mergeSnapshot({ result: useReadQuery(queryRef) });
+
+    return null;
+  }
+
+  function SuspenseFallback() {
+    useTrackRenders({ name: "<Suspense />" });
+
+    return null;
+  }
+
+  function ErrorFallback() {
+    useTrackRenders({ name: "<ErrorBoundary />" });
+
+    return null;
+  }
+
+  function App({ props }: { props: Props | undefined }) {
+    useTrackRenders({ name: "useLoadableQuery" });
+    const [loadQuery, queryRef] = renderHookImpl(props as any);
+
+    mergeSnapshot({ loadQuery });
+
+    return (
+      <Suspense fallback={<SuspenseFallback />}>
+        <ErrorBoundary
+          FallbackComponent={ErrorFallback}
+          onError={(error) => replaceSnapshot({ error })}
+        >
+          {queryRef && <UseReadQuery queryRef={queryRef} />}
+        </ErrorBoundary>
+      </Suspense>
+    );
+  }
+
+  const {
+    render,
+    getCurrentRender,
+    takeRender,
+    mergeSnapshot,
+    replaceSnapshot,
+  } = createRenderStream<
+    | {
+        loadQuery: useLoadableQuery.LoadQueryFunction<TVariables>;
+        result?: useReadQuery.Result<TData, TStates>;
+      }
+    | { error: ErrorLike }
+  >({ initialSnapshot: { loadQuery: null as any } });
+
+  const utils = await render(<App props={options.initialProps} />, options);
+
+  function rerender(props: Props) {
+    return utils.rerender(<App props={props} />);
+  }
+
+  function getCurrentSnapshot() {
+    const { snapshot } = getCurrentRender();
+    invariant(
+      "loadQuery" in snapshot,
+      "Expected rendered hook instead of error boundary"
+    );
+
+    return snapshot;
+  }
+
+  return { takeRender, rerender, getCurrentSnapshot };
+}
 
 test("serializes scalar variables used in field arguments", async () => {
   let requestVariables!: OperationVariables;
@@ -315,4 +417,894 @@ test("serializes scalar fields in input object variables", async () => {
   expect(requestVariables).toStrictEqualTyped({
     filter: { date: "2026-01-01" },
   });
+});
+
+test("preserves referential identity when refetching identical serialized scalar values", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  let refetch!: useLoadableQuery.Result["2"]["refetch"];
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderHook(
+    () => {
+      const result = useLoadableQuery(query);
+      refetch = result[2].refetch;
+      return result;
+    },
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  getCurrentSnapshot().loadQuery();
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  let previousData: unknown;
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+
+    previousData = snapshot.result!.data;
+  }
+
+  await expect(refetch()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+
+    expect(snapshot.result!.data).toBe(previousData);
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  using _consoleSpy = spyOnConsole("error");
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderHook(
+    () => useLoadableQuery(query, { errorPolicy: "none" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  getCurrentSnapshot().loadQuery();
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<ErrorBoundary />"]);
+    expect(snapshot).toStrictEqualTyped({
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderHook(
+    () => useLoadableQuery(query, { errorPolicy: "all" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  getCurrentSnapshot().loadQuery();
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.error,
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            // TODO: Determine if this is correct
+            startDate: new Date(2026, 0, 1),
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderHook(
+    () => useLoadableQuery(query, { errorPolicy: "ignore" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  getCurrentSnapshot().loadQuery();
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderHook(
+    () => useLoadableQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  getCurrentSnapshot().loadQuery();
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: markAsStreaming({
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, path: ["event"] }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderHook(
+    () => useLoadableQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  getCurrentSnapshot().loadQuery();
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["event"] }],
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: markAsStreaming({
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderHook(
+    () => useLoadableQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  getCurrentSnapshot().loadQuery();
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: markAsStreaming({
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        ],
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        path: ["events", 1],
+      },
+    ],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: new Date(2026, 1, 2),
+          },
+        ],
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderHook(
+    () => useLoadableQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  getCurrentSnapshot().loadQuery();
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    pending: [{ id: "0", path: ["events"] }],
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: markAsStreaming({
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        ],
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: new Date(2026, 1, 2),
+          },
+        ],
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
 });

--- a/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react-render-stream";
 import { userEvent } from "@testing-library/user-event";
 import React, { Suspense } from "react";
+import { flushSync } from "react-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import { delay, of } from "rxjs";
 
@@ -69,11 +70,16 @@ async function renderHook<
     return null;
   }
 
+  type RefetchFunction = useLoadableQuery.Handlers<
+    TData,
+    TVariables
+  >["refetch"];
+
   function App({ props }: { props: Props | undefined }) {
     useTrackRenders({ name: "useLoadableQuery" });
-    const [loadQuery, queryRef] = renderHookImpl(props as any);
+    const [loadQuery, queryRef, { refetch }] = renderHookImpl(props as any);
 
-    mergeSnapshot({ loadQuery });
+    mergeSnapshot({ loadQuery, refetch });
 
     return (
       <Suspense fallback={<SuspenseFallback />}>
@@ -96,10 +102,15 @@ async function renderHook<
   } = createRenderStream<
     | {
         loadQuery: useLoadableQuery.LoadQueryFunction<TVariables>;
+        refetch: RefetchFunction;
         result?: useReadQuery.Result<TData, TStates>;
       }
     | { error: ErrorLike }
-  >({ initialSnapshot: { loadQuery: null as any } });
+  >({
+    // These values should always be available, but createRenderStream needs an
+    // initial snapshot when using mergeSnapshot so we provide it with something
+    initialSnapshot: { loadQuery: null as any, refetch: null as any },
+  });
 
   const utils = await render(<App props={options.initialProps} />, options);
 
@@ -117,7 +128,21 @@ async function renderHook<
     return snapshot;
   }
 
-  return { takeRender, rerender, getCurrentSnapshot };
+  // React 18 skips committing the suspense fallback when loadQuery/refetch is
+  // triggered as a default-priority update, so the fallback render is missed
+  // and tests may fail. flushSync forces a synchronous commit so the fallback
+  // renders in both React 18 and 19, while returning the underlying result.
+  const loadQuery: useLoadableQuery.LoadQueryFunction<TVariables> = (
+    ...args
+  ) => {
+    return flushSync(() => getCurrentSnapshot().loadQuery(...args));
+  };
+
+  const refetch: RefetchFunction = (...args) => {
+    return flushSync(() => getCurrentSnapshot().refetch(...args));
+  };
+
+  return { takeRender, rerender, getCurrentSnapshot, refetch, loadQuery };
 }
 
 test("serializes scalar variables used in field arguments", async () => {
@@ -452,15 +477,9 @@ test("preserves referential identity when refetching identical serialized scalar
     ),
   });
 
-  let refetch!: useLoadableQuery.Result["2"]["refetch"];
-
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderHook(
-    () => {
-      const result = useLoadableQuery(query);
-      refetch = result[2].refetch;
-      return result;
-    },
+  const { takeRender, refetch, loadQuery } = await renderHook(
+    () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
 
@@ -470,7 +489,7 @@ test("preserves referential identity when refetching identical serialized scalar
     expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
   }
 
-  getCurrentSnapshot().loadQuery();
+  loadQuery();
 
   {
     const { renderedComponents } = await takeRender();
@@ -590,7 +609,7 @@ test("serializes scalar fields in the error with a `none` error policy", async (
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderHook(
+  const { takeRender, loadQuery } = await renderHook(
     () => useLoadableQuery(query, { errorPolicy: "none" }),
     { wrapper: createClientWrapper(client) }
   );
@@ -601,7 +620,7 @@ test("serializes scalar fields in the error with a `none` error policy", async (
     expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
   }
 
-  getCurrentSnapshot().loadQuery();
+  loadQuery();
 
   {
     const { renderedComponents } = await takeRender();
@@ -682,7 +701,7 @@ test("parses scalar fields in the result and serializes them in the error with a
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderHook(
+  const { takeRender, loadQuery } = await renderHook(
     () => useLoadableQuery(query, { errorPolicy: "all" }),
     { wrapper: createClientWrapper(client) }
   );
@@ -693,7 +712,7 @@ test("parses scalar fields in the result and serializes them in the error with a
     expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
   }
 
-  getCurrentSnapshot().loadQuery();
+  loadQuery();
 
   {
     const { renderedComponents } = await takeRender();
@@ -786,7 +805,7 @@ test("parses custom scalar fields with an `ignore` error policy", async () => {
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderHook(
+  const { takeRender, loadQuery } = await renderHook(
     () => useLoadableQuery(query, { errorPolicy: "ignore" }),
     { wrapper: createClientWrapper(client) }
   );
@@ -797,7 +816,7 @@ test("parses custom scalar fields with an `ignore` error policy", async () => {
     expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
   }
 
-  getCurrentSnapshot().loadQuery();
+  loadQuery();
 
   {
     const { renderedComponents } = await takeRender();

--- a/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
@@ -880,7 +880,7 @@ test("parses custom scalar fields across `@defer` payloads (defer20220824)", asy
   `;
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderHook(
+  const { takeRender, loadQuery } = await renderHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
@@ -891,7 +891,7 @@ test("parses custom scalar fields across `@defer` payloads (defer20220824)", asy
     expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
   }
 
-  getCurrentSnapshot().loadQuery();
+  loadQuery();
 
   {
     const { renderedComponents } = await takeRender();
@@ -990,7 +990,7 @@ test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", a
   `;
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderHook(
+  const { takeRender, loadQuery } = await renderHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
@@ -1001,7 +1001,7 @@ test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", a
     expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
   }
 
-  getCurrentSnapshot().loadQuery();
+  loadQuery();
 
   {
     const { renderedComponents } = await takeRender();
@@ -1098,7 +1098,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
   `;
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderHook(
+  const { takeRender, loadQuery } = await renderHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
@@ -1109,7 +1109,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
     expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
   }
 
-  getCurrentSnapshot().loadQuery();
+  loadQuery();
 
   {
     const { renderedComponents } = await takeRender();
@@ -1225,7 +1225,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
   `;
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderHook(
+  const { takeRender, loadQuery } = await renderHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
@@ -1236,7 +1236,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
     expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
   }
 
-  getCurrentSnapshot().loadQuery();
+  loadQuery();
 
   {
     const { renderedComponents } = await takeRender();

--- a/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderOptions } from "@testing-library/react";
 import { screen } from "@testing-library/react";
 import {
   createRenderStream,
@@ -7,11 +6,9 @@ import {
 } from "@testing-library/react-render-stream";
 import { userEvent } from "@testing-library/user-event";
 import React, { Suspense } from "react";
-import { flushSync } from "react-dom";
-import { ErrorBoundary } from "react-error-boundary";
 import { delay, of } from "rxjs";
 
-import type { DataState, ErrorLike, OperationVariables } from "@apollo/client";
+import type { OperationVariables } from "@apollo/client";
 import {
   ApolloClient,
   ApolloLink,
@@ -36,114 +33,7 @@ import {
 } from "@apollo/client/testing/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
-async function renderHook<
-  TData,
-  TVariables extends OperationVariables,
-  TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"],
-  Props = never,
->(
-  renderHookImpl: (
-    props: Props extends never ? undefined : Props
-  ) => useLoadableQuery.Result<TData, TVariables, TStates>,
-  options: Pick<RenderOptions, "wrapper"> & { initialProps?: Props }
-) {
-  function UseReadQuery({
-    queryRef,
-  }: {
-    queryRef: QueryRef<TData, TVariables, TStates>;
-  }) {
-    useTrackRenders({ name: "useReadQuery" });
-    mergeSnapshot({ result: useReadQuery(queryRef) });
-
-    return null;
-  }
-
-  function SuspenseFallback() {
-    useTrackRenders({ name: "<Suspense />" });
-
-    return null;
-  }
-
-  function ErrorFallback() {
-    useTrackRenders({ name: "<ErrorBoundary />" });
-
-    return null;
-  }
-
-  type RefetchFunction = useLoadableQuery.Handlers<
-    TData,
-    TVariables
-  >["refetch"];
-
-  function App({ props }: { props: Props | undefined }) {
-    useTrackRenders({ name: "useLoadableQuery" });
-    const [loadQuery, queryRef, { refetch }] = renderHookImpl(props as any);
-
-    mergeSnapshot({ loadQuery, refetch });
-
-    return (
-      <Suspense fallback={<SuspenseFallback />}>
-        <ErrorBoundary
-          FallbackComponent={ErrorFallback}
-          onError={(error) => replaceSnapshot({ error })}
-        >
-          {queryRef && <UseReadQuery queryRef={queryRef} />}
-        </ErrorBoundary>
-      </Suspense>
-    );
-  }
-
-  const {
-    render,
-    getCurrentRender,
-    takeRender,
-    mergeSnapshot,
-    replaceSnapshot,
-  } = createRenderStream<
-    | {
-        loadQuery: useLoadableQuery.LoadQueryFunction<TVariables>;
-        refetch: RefetchFunction;
-        result?: useReadQuery.Result<TData, TStates>;
-      }
-    | { error: ErrorLike }
-  >({
-    // These values should always be available, but createRenderStream needs an
-    // initial snapshot when using mergeSnapshot so we provide it with something
-    initialSnapshot: { loadQuery: null as any, refetch: null as any },
-  });
-
-  const utils = await render(<App props={options.initialProps} />, options);
-
-  function rerender(props: Props) {
-    return utils.rerender(<App props={props} />);
-  }
-
-  function getCurrentSnapshot() {
-    const { snapshot } = getCurrentRender();
-    invariant(
-      "loadQuery" in snapshot,
-      "Expected rendered hook instead of error boundary"
-    );
-
-    return snapshot;
-  }
-
-  // React 18 skips committing the suspense fallback when loadQuery/refetch is
-  // triggered as a default-priority update, so the fallback render is missed
-  // and tests may fail. flushSync forces a synchronous commit so the fallback
-  // renders in both React 18 and 19, while returning the underlying result.
-  const loadQuery: useLoadableQuery.LoadQueryFunction<TVariables> = (
-    ...args
-  ) => {
-    return flushSync(() => getCurrentSnapshot().loadQuery(...args));
-  };
-
-  const refetch: RefetchFunction = (...args) => {
-    return flushSync(() => getCurrentSnapshot().refetch(...args));
-  };
-
-  return { takeRender, rerender, getCurrentSnapshot, refetch, loadQuery };
-}
+import { renderUseLoadableQueryHook } from "./testUtils.js";
 
 test("serializes scalar variables used in field arguments", async () => {
   let requestVariables!: OperationVariables;
@@ -478,7 +368,7 @@ test("preserves referential identity when refetching identical serialized scalar
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, refetch, loadQuery } = await renderHook(
+  const { takeRender, refetch, loadQuery } = await renderUseLoadableQueryHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
@@ -609,7 +499,7 @@ test("serializes scalar fields in the error with a `none` error policy", async (
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, loadQuery } = await renderHook(
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
     () => useLoadableQuery(query, { errorPolicy: "none" }),
     { wrapper: createClientWrapper(client) }
   );
@@ -701,7 +591,7 @@ test("parses scalar fields in the result and serializes them in the error with a
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, loadQuery } = await renderHook(
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
     () => useLoadableQuery(query, { errorPolicy: "all" }),
     { wrapper: createClientWrapper(client) }
   );
@@ -805,7 +695,7 @@ test("parses custom scalar fields with an `ignore` error policy", async () => {
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, loadQuery } = await renderHook(
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
     () => useLoadableQuery(query, { errorPolicy: "ignore" }),
     { wrapper: createClientWrapper(client) }
   );
@@ -880,7 +770,7 @@ test("parses custom scalar fields across `@defer` payloads (defer20220824)", asy
   `;
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, loadQuery } = await renderHook(
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
@@ -990,7 +880,7 @@ test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", a
   `;
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, loadQuery } = await renderHook(
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
@@ -1098,7 +988,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
   `;
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, loadQuery } = await renderHook(
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );
@@ -1225,7 +1115,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
   `;
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, loadQuery } = await renderHook(
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
     () => useLoadableQuery(query),
     { wrapper: createClientWrapper(client) }
   );

--- a/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
@@ -1,11 +1,4 @@
-import { screen } from "@testing-library/react";
-import {
-  createRenderStream,
-  disableActEnvironment,
-  useTrackRenders,
-} from "@testing-library/react-render-stream";
-import { userEvent } from "@testing-library/user-event";
-import React, { Suspense } from "react";
+import { disableActEnvironment } from "@testing-library/react-render-stream";
 import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
@@ -21,8 +14,7 @@ import {
   Defer20220824Handler,
   GraphQL17Alpha9Handler,
 } from "@apollo/client/incremental";
-import type { QueryRef } from "@apollo/client/react";
-import { useLoadableQuery, useReadQuery } from "@apollo/client/react";
+import { useLoadableQuery } from "@apollo/client/react";
 import {
   createClientWrapper,
   dateScalar,
@@ -51,13 +43,6 @@ test("serializes scalar variables used in field arguments", async () => {
     }),
   });
 
-  const renderStream = createRenderStream({
-    initialSnapshot: {
-      result: null as useReadQuery.Result<any> | null,
-    },
-    skipNonTrackingRenders: true,
-  });
-
   const query = gql`
     query Event($date: Date!) {
       event(date: $date) {
@@ -66,53 +51,33 @@ test("serializes scalar variables used in field arguments", async () => {
     }
   `;
 
-  function ReadQuery({ queryRef }: { queryRef: QueryRef }) {
-    useTrackRenders({ name: "useReadQuery" });
-    renderStream.mergeSnapshot({ result: useReadQuery(queryRef) });
-
-    return null;
-  }
-
-  function Fallback() {
-    useTrackRenders({ name: "<Suspense />" });
-    return null;
-  }
-
-  function App() {
-    useTrackRenders({ name: "useLoadableQuery" });
-    const [loadQuery, queryRef] = useLoadableQuery(query);
-
-    return (
-      <>
-        <button onClick={() => loadQuery({ date: new Date(2026, 0, 1) })}>
-          Load query
-        </button>
-        <Suspense fallback={<Fallback />}>
-          {queryRef && <ReadQuery queryRef={queryRef} />}
-        </Suspense>
-      </>
-    );
-  }
-
   using _disabledAct = disableActEnvironment();
-  const user = userEvent.setup();
-  await renderStream.render(<App />, {
-    wrapper: createClientWrapper(client),
-  });
-
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useLoadableQuery"],
-  });
-
-  await user.click(screen.getByText("Load query"));
-
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useLoadableQuery", "<Suspense />"],
-  });
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
+    () => useLoadableQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
 
   {
-    const { snapshot, renderedComponents } = await renderStream.takeRender();
+    const { renderedComponents } = await takeRender();
 
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  loadQuery({ date: new Date(2026, 0, 1) });
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot.result).toStrictEqualTyped({
       data: {
@@ -127,7 +92,7 @@ test("serializes scalar variables used in field arguments", async () => {
     });
   }
 
-  await expect(renderStream).not.toRerender();
+  await expect(takeRender).not.toRerender();
   expect(requestVariables).toStrictEqualTyped({ date: "2026-01-01" });
 });
 
@@ -147,13 +112,6 @@ test("serializes scalar variables used in directive arguments", async () => {
     }),
   });
 
-  const renderStream = createRenderStream({
-    initialSnapshot: {
-      result: null as useReadQuery.Result<any> | null,
-    },
-    skipNonTrackingRenders: true,
-  });
-
   const query = gql`
     query Event($date: Date!) {
       event @on(date: $date) {
@@ -162,53 +120,33 @@ test("serializes scalar variables used in directive arguments", async () => {
     }
   `;
 
-  function ReadQuery({ queryRef }: { queryRef: QueryRef }) {
-    useTrackRenders({ name: "useReadQuery" });
-    renderStream.mergeSnapshot({ result: useReadQuery(queryRef) });
-
-    return null;
-  }
-
-  function Fallback() {
-    useTrackRenders({ name: "<Suspense />" });
-    return null;
-  }
-
-  function App() {
-    useTrackRenders({ name: "useLoadableQuery" });
-    const [loadQuery, queryRef] = useLoadableQuery(query);
-
-    return (
-      <>
-        <button onClick={() => loadQuery({ date: new Date(2026, 0, 1) })}>
-          Load query
-        </button>
-        <Suspense fallback={<Fallback />}>
-          {queryRef && <ReadQuery queryRef={queryRef} />}
-        </Suspense>
-      </>
-    );
-  }
-
   using _disabledAct = disableActEnvironment();
-  const user = userEvent.setup();
-  await renderStream.render(<App />, {
-    wrapper: createClientWrapper(client),
-  });
-
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useLoadableQuery"],
-  });
-
-  await user.click(screen.getByText("Load query"));
-
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useLoadableQuery", "<Suspense />"],
-  });
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
+    () => useLoadableQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
 
   {
-    const { snapshot, renderedComponents } = await renderStream.takeRender();
+    const { renderedComponents } = await takeRender();
 
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  loadQuery({ date: new Date(2026, 0, 1) });
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot.result).toStrictEqualTyped({
       data: {
@@ -223,7 +161,7 @@ test("serializes scalar variables used in directive arguments", async () => {
     });
   }
 
-  await expect(renderStream).not.toRerender();
+  await expect(takeRender).not.toRerender();
   expect(requestVariables).toStrictEqualTyped({ date: "2026-01-01" });
 });
 
@@ -250,13 +188,6 @@ test("serializes scalar fields in input object variables", async () => {
     }),
   });
 
-  const renderStream = createRenderStream({
-    initialSnapshot: {
-      result: null as useReadQuery.Result<any> | null,
-    },
-    skipNonTrackingRenders: true,
-  });
-
   const query = gql`
     query Event($filter: EventFilter!) {
       event(filter: $filter) {
@@ -265,55 +196,33 @@ test("serializes scalar fields in input object variables", async () => {
     }
   `;
 
-  function ReadQuery({ queryRef }: { queryRef: QueryRef }) {
-    useTrackRenders({ name: "useReadQuery" });
-    renderStream.mergeSnapshot({ result: useReadQuery(queryRef) });
-
-    return null;
-  }
-
-  function Fallback() {
-    useTrackRenders({ name: "<Suspense />" });
-    return null;
-  }
-
-  function App() {
-    useTrackRenders({ name: "useLoadableQuery" });
-    const [loadQuery, queryRef] = useLoadableQuery(query);
-
-    return (
-      <>
-        <button
-          onClick={() => loadQuery({ filter: { date: new Date(2026, 0, 1) } })}
-        >
-          Load query
-        </button>
-        <Suspense fallback={<Fallback />}>
-          {queryRef && <ReadQuery queryRef={queryRef} />}
-        </Suspense>
-      </>
-    );
-  }
-
   using _disabledAct = disableActEnvironment();
-  const user = userEvent.setup();
-  await renderStream.render(<App />, {
-    wrapper: createClientWrapper(client),
-  });
-
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useLoadableQuery"],
-  });
-
-  await user.click(screen.getByText("Load query"));
-
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useLoadableQuery", "<Suspense />"],
-  });
+  const { takeRender, loadQuery } = await renderUseLoadableQueryHook(
+    () => useLoadableQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
 
   {
-    const { snapshot, renderedComponents } = await renderStream.takeRender();
+    const { renderedComponents } = await takeRender();
 
+    expect(renderedComponents).toStrictEqual(["useLoadableQuery"]);
+  }
+
+  loadQuery({ filter: { date: new Date(2026, 0, 1) } });
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useLoadableQuery",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    invariant("result" in snapshot);
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot.result).toStrictEqualTyped({
       data: {
@@ -328,7 +237,7 @@ test("serializes scalar fields in input object variables", async () => {
     });
   }
 
-  await expect(renderStream).not.toRerender();
+  await expect(takeRender).not.toRerender();
   expect(requestVariables).toStrictEqualTyped({
     filter: { date: "2026-01-01" },
   });

--- a/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery/customScalars.test.tsx
@@ -938,7 +938,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
     invariant("result" in snapshot);
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot.result).toStrictEqualTyped({
-      data: markAsStreaming({
+      data: {
         events: [
           {
             __typename: "Event",
@@ -946,8 +946,8 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
             startDate: new Date(2026, 0, 1),
           },
         ],
-      }),
-      dataState: "streaming",
+      },
+      dataState: "complete",
       networkStatus: NetworkStatus.streaming,
       error: undefined,
     });
@@ -1066,7 +1066,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
     invariant("result" in snapshot);
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot.result).toStrictEqualTyped({
-      data: markAsStreaming({
+      data: {
         events: [
           {
             __typename: "Event",
@@ -1074,8 +1074,8 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
             startDate: new Date(2026, 0, 1),
           },
         ],
-      }),
-      dataState: "streaming",
+      },
+      dataState: "complete",
       networkStatus: NetworkStatus.streaming,
       error: undefined,
     });

--- a/src/react/hooks/__tests__/useLoadableQuery/testUtils.tsx
+++ b/src/react/hooks/__tests__/useLoadableQuery/testUtils.tsx
@@ -1,0 +1,125 @@
+import type { RenderOptions } from "@testing-library/react";
+import {
+  createRenderStream,
+  useTrackRenders,
+} from "@testing-library/react-render-stream";
+import React, { Suspense } from "react";
+import { flushSync } from "react-dom";
+import { ErrorBoundary } from "react-error-boundary";
+
+import type { DataState, ErrorLike, OperationVariables } from "@apollo/client";
+import {
+  type QueryRef,
+  type useLoadableQuery,
+  useReadQuery,
+} from "@apollo/client/react";
+import { invariant } from "@apollo/client/utilities/invariant";
+
+export async function renderUseLoadableQueryHook<
+  TData,
+  TVariables extends OperationVariables,
+  TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"],
+  Props = never,
+>(
+  renderHook: (
+    props: Props extends never ? undefined : Props
+  ) => useLoadableQuery.Result<TData, TVariables, TStates>,
+  options: Pick<RenderOptions, "wrapper"> & { initialProps?: Props }
+) {
+  function UseReadQuery({
+    queryRef,
+  }: {
+    queryRef: QueryRef<TData, TVariables, TStates>;
+  }) {
+    useTrackRenders({ name: "useReadQuery" });
+    mergeSnapshot({ result: useReadQuery(queryRef) });
+
+    return null;
+  }
+
+  function SuspenseFallback() {
+    useTrackRenders({ name: "<Suspense />" });
+
+    return null;
+  }
+
+  function ErrorFallback() {
+    useTrackRenders({ name: "<ErrorBoundary />" });
+
+    return null;
+  }
+
+  type RefetchFunction = useLoadableQuery.Handlers<
+    TData,
+    TVariables
+  >["refetch"];
+
+  function App({ props }: { props: Props | undefined }) {
+    useTrackRenders({ name: "useLoadableQuery" });
+    const [loadQuery, queryRef, { refetch }] = renderHook(props as any);
+
+    mergeSnapshot({ loadQuery, refetch });
+
+    return (
+      <Suspense fallback={<SuspenseFallback />}>
+        <ErrorBoundary
+          FallbackComponent={ErrorFallback}
+          onError={(error) => replaceSnapshot({ error })}
+        >
+          {queryRef && <UseReadQuery queryRef={queryRef} />}
+        </ErrorBoundary>
+      </Suspense>
+    );
+  }
+
+  const {
+    render,
+    getCurrentRender,
+    takeRender,
+    mergeSnapshot,
+    replaceSnapshot,
+  } = createRenderStream<
+    | {
+        loadQuery: useLoadableQuery.LoadQueryFunction<TVariables>;
+        refetch: RefetchFunction;
+        result?: useReadQuery.Result<TData, TStates>;
+      }
+    | { error: ErrorLike }
+  >({
+    // These values should always be available, but createRenderStream needs an
+    // initial snapshot when using mergeSnapshot so we provide it with something
+    initialSnapshot: { loadQuery: null as any, refetch: null as any },
+  });
+
+  const utils = await render(<App props={options.initialProps} />, options);
+
+  function rerender(props: Props) {
+    return utils.rerender(<App props={props} />);
+  }
+
+  function getCurrentSnapshot() {
+    const { snapshot } = getCurrentRender();
+    invariant(
+      "loadQuery" in snapshot,
+      "Expected rendered hook instead of error boundary"
+    );
+
+    return snapshot;
+  }
+
+  // React 18 skips committing the suspense fallback when loadQuery/refetch is
+  // triggered as a default-priority update, so the fallback render is missed
+  // and tests may fail. flushSync forces a synchronous commit so the fallback
+  // renders in both React 18 and 19, while returning the underlying result.
+  const loadQuery: useLoadableQuery.LoadQueryFunction<TVariables> = (
+    ...args
+  ) => {
+    return flushSync(() => getCurrentSnapshot().loadQuery(...args));
+  };
+
+  const refetch: RefetchFunction = (...args) => {
+    return flushSync(() => getCurrentSnapshot().refetch(...args));
+  };
+
+  return { takeRender, rerender, getCurrentSnapshot, refetch, loadQuery };
+}

--- a/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useMutation/customScalars.test.tsx
@@ -5,13 +5,25 @@ import {
 import { delay, of } from "rxjs";
 
 import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
+import {
+  Defer20220824Handler,
+  GraphQL17Alpha9Handler,
+} from "@apollo/client/incremental";
 import { useMutation, useQuery } from "@apollo/client/react";
 import { MockLink } from "@apollo/client/testing";
 import {
   createClientWrapper,
   dateScalar,
+  mockDefer20220824,
+  mockDeferStreamGraphQL17Alpha9,
 } from "@apollo/client/testing/internal";
 
 test("serializes scalar variables used in field arguments", async () => {
@@ -1106,4 +1118,589 @@ test("parses custom scalar fields in queries triggered by refetchQueries", async
       startDate: new Date(2026, 2, 3),
     },
   });
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["createEvent", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation, { errorPolicy: "none" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+
+  await expect(mutate()).rejects.toEqual(
+    new CombinedGraphQLErrors({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["createEvent", "endDate"],
+        },
+      ],
+    })
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: new CombinedGraphQLErrors({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["createEvent", "endDate"],
+          },
+        ],
+      }),
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["createEvent", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation, { errorPolicy: "all" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+
+  await expect(mutate()).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    error: new CombinedGraphQLErrors({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          // TODO: Determine if this is correct
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["createEvent", "endDate"],
+        },
+      ],
+    }),
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      error: new CombinedGraphQLErrors({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            // TODO: Determine if this is correct
+            startDate: new Date(2026, 0, 1),
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["createEvent", "endDate"],
+          },
+        ],
+      }),
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          createEvent: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["createEvent", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation, { errorPolicy: "ignore" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+
+  await expect(mutate()).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      error: undefined,
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+
+  const promise = mutate();
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, path: ["createEvent"] }],
+    hasNext: false,
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      error: undefined,
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(promise).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const mutation = gql`
+    mutation CreateEvent {
+      createEvent {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: false,
+      loading: false,
+    });
+  }
+
+  const [mutate] = getCurrentSnapshot();
+
+  const promise = mutate();
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      called: true,
+      loading: true,
+    });
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["createEvent"] }],
+    hasNext: true,
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const [, result] = await takeSnapshot();
+
+    expect(result).toStrictEqualTyped({
+      data: {
+        createEvent: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      error: undefined,
+      called: true,
+      loading: false,
+    });
+  }
+
+  await expect(promise).resolves.toStrictEqualTyped({
+    data: {
+      createEvent: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+  });
+
+  await expect(takeSnapshot).not.toRerender();
 });

--- a/src/react/hooks/__tests__/useQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useQuery/customScalars.test.tsx
@@ -1332,7 +1332,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
   });
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: markAsStreaming({
+    data: {
       events: [
         {
           __typename: "Event",
@@ -1340,8 +1340,8 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
           startDate: new Date(2026, 0, 1),
         },
       ],
-    }),
-    dataState: "streaming",
+    },
+    dataState: "complete",
     loading: true,
     networkStatus: NetworkStatus.streaming,
     previousData: undefined,
@@ -1452,7 +1452,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
   });
 
   await expect(takeSnapshot()).resolves.toStrictEqualTyped({
-    data: markAsStreaming({
+    data: {
       events: [
         {
           __typename: "Event",
@@ -1460,8 +1460,8 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
           startDate: new Date(2026, 0, 1),
         },
       ],
-    }),
-    dataState: "streaming",
+    },
+    dataState: "complete",
     loading: true,
     networkStatus: NetworkStatus.streaming,
     previousData: undefined,

--- a/src/react/hooks/__tests__/useQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useQuery/customScalars.test.tsx
@@ -5,12 +5,25 @@ import {
 import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
+import {
+  Defer20220824Handler,
+  GraphQL17Alpha9Handler,
+} from "@apollo/client/incremental";
 import { useQuery } from "@apollo/client/react";
 import {
   createClientWrapper,
   dateScalar,
+  markAsStreaming,
+  mockDefer20220824,
+  mockDeferStreamGraphQL17Alpha9,
 } from "@apollo/client/testing/internal";
 
 test("serializes scalar variables used in field arguments", async () => {
@@ -696,3 +709,811 @@ test.failing(
     });
   }
 );
+
+test("preserves referential identity when refetching identical serialized scalar values", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot, getCurrentSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+
+  const { data: previousData, refetch } = getCurrentSnapshot();
+
+  await expect(refetch()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.refetch,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+
+  const { data } = getCurrentSnapshot();
+
+  expect(data).toBe(previousData);
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { errorPolicy: "none" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    error: new CombinedGraphQLErrors({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["event", "endDate"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { errorPolicy: "all" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    dataState: "complete",
+    error: new CombinedGraphQLErrors({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          // TODO: Determine if this is correct
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      errors: [
+        {
+          message: "Could not resolve endDate",
+          path: ["event", "endDate"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query, { errorPolicy: "ignore" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: null,
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: markAsStreaming({
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    previousData: undefined,
+    variables: {},
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, path: ["event"] }],
+    hasNext: false,
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["event"] }],
+    hasNext: true,
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: markAsStreaming({
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    previousData: undefined,
+    variables: {},
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    hasNext: true,
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: markAsStreaming({
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      ],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    previousData: undefined,
+    variables: {},
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        path: ["events", 1],
+      },
+    ],
+    hasNext: false,
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+        {
+          __typename: "Event",
+          id: "2",
+          startDate: new Date(2026, 1, 2),
+        },
+      ],
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      ],
+    },
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    pending: [{ id: "0", path: ["events"] }],
+    hasNext: true,
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: markAsStreaming({
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      ],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    previousData: undefined,
+    variables: {},
+  });
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+        {
+          __typename: "Event",
+          id: "2",
+          startDate: new Date(2026, 1, 2),
+        },
+      ],
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      ],
+    },
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+});

--- a/src/react/hooks/__tests__/useQueryRefHandlers/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useQueryRefHandlers/customScalars.test.tsx
@@ -103,9 +103,14 @@ test("serializes scalar variables passed to refetch", async () => {
     wrapper: createClientWrapper(client),
   });
 
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useQueryRefHandlers", "<Suspense />"],
-  });
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useQueryRefHandlers",
+      "<Suspense />",
+    ]);
+  }
 
   {
     const { snapshot, renderedComponents } = await renderStream.takeRender();
@@ -135,9 +140,14 @@ test("serializes scalar variables passed to refetch", async () => {
     },
   });
 
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useQueryRefHandlers", "<Suspense />"],
-  });
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useQueryRefHandlers",
+      "<Suspense />",
+    ]);
+  }
 
   {
     const { snapshot, renderedComponents } = await renderStream.takeRender();
@@ -242,9 +252,14 @@ test("serializes scalar variables passed to fetchMore", async () => {
     wrapper: createClientWrapper(client),
   });
 
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useQueryRefHandlers", "<Suspense />"],
-  });
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useQueryRefHandlers",
+      "<Suspense />",
+    ]);
+  }
 
   {
     const { snapshot, renderedComponents } = await renderStream.takeRender();
@@ -274,9 +289,14 @@ test("serializes scalar variables passed to fetchMore", async () => {
     },
   });
 
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useQueryRefHandlers", "<Suspense />"],
-  });
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useQueryRefHandlers",
+      "<Suspense />",
+    ]);
+  }
 
   {
     const { snapshot, renderedComponents } = await renderStream.takeRender();
@@ -388,9 +408,14 @@ test("serializes scalar variables passed to subscribeToMore", async () => {
     wrapper: createClientWrapper(client),
   });
 
-  await expect(renderStream.takeRender()).resolves.toMatchObject({
-    renderedComponents: ["useQueryRefHandlers", "<Suspense />"],
-  });
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useQueryRefHandlers",
+      "<Suspense />",
+    ]);
+  }
 
   {
     const { snapshot, renderedComponents } = await renderStream.takeRender();
@@ -444,4 +469,161 @@ test("serializes scalar variables passed to subscribeToMore", async () => {
   expect(subscriptionLink.operation?.variables).toStrictEqualTyped({
     date: "2026-01-01",
   });
+});
+
+test("preserves referential identity when refetching identical serialized scalar values", async () => {
+  let refetchPromise!: ReturnType<
+    ReturnType<typeof useQueryRefHandlers>["refetch"]
+  >;
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query);
+  const renderStream = createRenderStream({
+    initialSnapshot: {
+      result: null as useReadQuery.Result<any> | null,
+    },
+  });
+
+  function ReadQuery() {
+    useTrackRenders({ name: "useReadQuery" });
+    renderStream.mergeSnapshot({ result: useReadQuery(queryRef) });
+
+    return null;
+  }
+
+  function Fallback() {
+    useTrackRenders({ name: "<Suspense />" });
+    return null;
+  }
+
+  function App() {
+    useTrackRenders({ name: "useQueryRefHandlers" });
+    const { refetch } = useQueryRefHandlers(queryRef);
+
+    return (
+      <>
+        <button
+          onClick={() => {
+            refetchPromise = refetch();
+          }}
+        >
+          Refetch
+        </button>
+        <Suspense fallback={<Fallback />}>
+          <ReadQuery />
+        </Suspense>
+      </>
+    );
+  }
+
+  const user = userEvent.setup();
+  using _disabledAct = disableActEnvironment();
+  await renderStream.render(<App />, {
+    wrapper: createClientWrapper(client),
+  });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useQueryRefHandlers",
+      "<Suspense />",
+    ]);
+  }
+
+  let previousData: unknown;
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+
+    previousData = snapshot.result!.data;
+  }
+
+  await user.click(screen.getByText("Refetch"));
+
+  await expect(refetchPromise).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual([
+      "useQueryRefHandlers",
+      "<Suspense />",
+    ]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+
+    expect(snapshot.result!.data).toBe(previousData);
+  }
+
+  await expect(renderStream).not.toRerender();
 });

--- a/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
@@ -2,12 +2,26 @@ import { disableActEnvironment } from "@testing-library/react-render-stream";
 import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
+import {
+  Defer20220824Handler,
+  GraphQL17Alpha9Handler,
+} from "@apollo/client/incremental";
 import { useSuspenseQuery } from "@apollo/client/react";
 import {
   createClientWrapper,
   dateScalar,
+  markAsStreaming,
+  mockDefer20220824,
+  mockDeferStreamGraphQL17Alpha9,
+  spyOnConsole,
 } from "@apollo/client/testing/internal";
 
 import { renderUseSuspenseQuery } from "./testUtils.js";
@@ -629,3 +643,783 @@ test.failing(
     }
   }
 );
+
+test("preserves referential identity when refetching identical serialized scalar values", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender, getCurrentSnapshot } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  const { data: previousData, refetch } = getCurrentSnapshot();
+
+  await expect(refetch()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  expect(getCurrentSnapshot().data).toBe(previousData);
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  using _consoleSpy = spyOnConsole("error");
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query, { errorPolicy: "none" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<ErrorBoundary />"]);
+    expect(snapshot).toStrictEqualTyped({
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query, { errorPolicy: "all" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.error,
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            // TODO: Determine if this is correct
+            startDate: new Date(2026, 0, 1),
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query, { errorPolicy: "ignore" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: markAsStreaming({
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, path: ["event"] }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["event"] }],
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: markAsStreaming({
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: markAsStreaming({
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        ],
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        path: ["events", 1],
+      },
+    ],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: new Date(2026, 1, 2),
+          },
+        ],
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  using _disabledAct = disableActEnvironment();
+  const { takeRender } = await renderUseSuspenseQuery(
+    () => useSuspenseQuery(query),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  {
+    const { renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["<Suspense />"]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    pending: [{ id: "0", path: ["events"] }],
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: markAsStreaming({
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        ],
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
+    expect(snapshot).toStrictEqualTyped({
+      data: {
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: new Date(2026, 1, 2),
+          },
+        ],
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(takeRender).not.toRerender();
+});

--- a/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
@@ -1249,7 +1249,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
 
     expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
     expect(snapshot).toStrictEqualTyped({
-      data: markAsStreaming({
+      data: {
         events: [
           {
             __typename: "Event",
@@ -1257,8 +1257,8 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
             startDate: new Date(2026, 0, 1),
           },
         ],
-      }),
-      dataState: "streaming",
+      },
+      dataState: "complete",
       networkStatus: NetworkStatus.streaming,
       error: undefined,
     });
@@ -1364,7 +1364,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
 
     expect(renderedComponents).toStrictEqual(["useSuspenseQuery"]);
     expect(snapshot).toStrictEqualTyped({
-      data: markAsStreaming({
+      data: {
         events: [
           {
             __typename: "Event",
@@ -1372,8 +1372,8 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
             startDate: new Date(2026, 0, 1),
           },
         ],
-      }),
-      dataState: "streaming",
+      },
+      dataState: "complete",
       networkStatus: NetworkStatus.streaming,
       error: undefined,
     });

--- a/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
@@ -678,10 +678,10 @@ test("preserves referential identity when refetching identical serialized scalar
   });
 
   using _disabledAct = disableActEnvironment();
-  const { takeRender, getCurrentSnapshot } = await renderUseSuspenseQuery(
-    () => useSuspenseQuery(query),
-    { wrapper: createClientWrapper(client) }
-  );
+  const { takeRender, getCurrentSnapshot, refetch } =
+    await renderUseSuspenseQuery(() => useSuspenseQuery(query), {
+      wrapper: createClientWrapper(client),
+    });
 
   {
     const { renderedComponents } = await takeRender();
@@ -707,17 +707,9 @@ test("preserves referential identity when refetching identical serialized scalar
     });
   }
 
-  const { data: previousData, refetch } = getCurrentSnapshot();
+  const { data: previousData } = getCurrentSnapshot();
 
-  await expect(refetch()).resolves.toStrictEqualTyped({
-    data: {
-      event: {
-        __typename: "Event",
-        id: "1",
-        startDate: new Date(2026, 0, 1),
-      },
-    },
-  });
+  void refetch();
 
   {
     const { renderedComponents } = await takeRender();

--- a/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery/customScalars.test.tsx
@@ -709,7 +709,15 @@ test("preserves referential identity when refetching identical serialized scalar
 
   const { data: previousData } = getCurrentSnapshot();
 
-  void refetch();
+  await expect(refetch()).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
 
   {
     const { renderedComponents } = await takeRender();

--- a/src/react/hooks/__tests__/useSuspenseQuery/testUtils.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery/testUtils.tsx
@@ -1,11 +1,10 @@
 import type { RenderOptions } from "@testing-library/react";
-import { screen } from "@testing-library/react";
 import {
   createRenderStream,
   useTrackRenders,
 } from "@testing-library/react-render-stream";
-import { userEvent } from "@testing-library/user-event";
 import React, { Suspense } from "react";
+import { flushSync } from "react-dom";
 import { ErrorBoundary } from "react-error-boundary";
 
 import type { ErrorLike, OperationVariables } from "@apollo/client";
@@ -22,14 +21,9 @@ export async function renderUseSuspenseQuery<
 ) {
   function UseSuspenseQuery({ props }: { props: Props | undefined }) {
     useTrackRenders({ name: "useSuspenseQuery" });
-    // eslint-disable-next-line testing-library/render-result-naming-convention
-    const result = renderHook(props as any);
-    replaceSnapshot(result);
+    replaceSnapshot(renderHook(props as any));
 
-    // We need to trigger refetch in an event handler in order for React 18 to
-    // commit the suspense fallback, otherwise the suspense fallback render is
-    // skipped and tests may fail.
-    return <button onClick={() => result.refetch()}>refetch</button>;
+    return null;
   }
 
   function SuspenseFallback() {
@@ -57,7 +51,6 @@ export async function renderUseSuspenseQuery<
     );
   }
 
-  const user = userEvent.setup();
   const { render, takeRender, replaceSnapshot, getCurrentRender } =
     createRenderStream<
       useSuspenseQuery.Result<TData, TVariables> | { error: ErrorLike }
@@ -77,9 +70,15 @@ export async function renderUseSuspenseQuery<
     return snapshot;
   }
 
-  async function refetch() {
-    await user.click(screen.getByText("refetch"));
-  }
+  // React 18 skips committing the suspense fallback when refetch is triggered
+  // as a default-priority update, so the fallback render is missed and tests
+  // may fail. flushSync forces a synchronous commit so the fallback renders in
+  // both React 18 and 19, while returning the refetch promise.
+  const refetch: useSuspenseQuery.Result<TData, TVariables>["refetch"] = (
+    ...args
+  ) => {
+    return flushSync(() => getCurrentSnapshot().refetch(...args));
+  };
 
   return { getCurrentSnapshot, rerender, takeRender, refetch };
 }

--- a/src/react/hooks/__tests__/useSuspenseQuery/testUtils.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery/testUtils.tsx
@@ -1,8 +1,10 @@
 import type { RenderOptions } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import {
   createRenderStream,
   useTrackRenders,
 } from "@testing-library/react-render-stream";
+import { userEvent } from "@testing-library/user-event";
 import React, { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -20,9 +22,14 @@ export async function renderUseSuspenseQuery<
 ) {
   function UseSuspenseQuery({ props }: { props: Props | undefined }) {
     useTrackRenders({ name: "useSuspenseQuery" });
-    replaceSnapshot(renderHook(props as any));
+    // eslint-disable-next-line testing-library/render-result-naming-convention
+    const result = renderHook(props as any);
+    replaceSnapshot(result);
 
-    return null;
+    // We need to trigger refetch in an event handler in order for React 18 to
+    // commit the suspense fallback, otherwise the suspense fallback render is
+    // skipped and tests may fail.
+    return <button onClick={() => result.refetch()}>refetch</button>;
   }
 
   function SuspenseFallback() {
@@ -50,6 +57,7 @@ export async function renderUseSuspenseQuery<
     );
   }
 
+  const user = userEvent.setup();
   const { render, takeRender, replaceSnapshot, getCurrentRender } =
     createRenderStream<
       useSuspenseQuery.Result<TData, TVariables> | { error: ErrorLike }
@@ -69,5 +77,9 @@ export async function renderUseSuspenseQuery<
     return snapshot;
   }
 
-  return { getCurrentSnapshot, rerender, takeRender };
+  async function refetch() {
+    await user.click(screen.getByText("refetch"));
+  }
+
+  return { getCurrentSnapshot, rerender, takeRender, refetch };
 }

--- a/src/react/query-preloader/__tests__/createQueryPreloader/customScalars.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader/customScalars.test.tsx
@@ -1,11 +1,27 @@
 import { disableActEnvironment } from "@testing-library/react-render-stream";
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import type { OperationVariables } from "@apollo/client";
-import { ApolloClient, ApolloLink, gql, NetworkStatus } from "@apollo/client";
+import {
+  ApolloClient,
+  ApolloLink,
+  CombinedGraphQLErrors,
+  gql,
+  NetworkStatus,
+} from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
+import {
+  Defer20220824Handler,
+  GraphQL17Alpha9Handler,
+} from "@apollo/client/incremental";
 import { createQueryPreloader } from "@apollo/client/react";
-import { dateScalar } from "@apollo/client/testing/internal";
+import {
+  dateScalar,
+  markAsStreaming,
+  mockDefer20220824,
+  mockDeferStreamGraphQL17Alpha9,
+  spyOnConsole,
+} from "@apollo/client/testing/internal";
 
 import { renderDefaultTestApp } from "./testUtils.js";
 
@@ -157,4 +173,680 @@ test("serializes scalar fields in input object variables", async () => {
   expect(requestVariables).toStrictEqualTyped({
     filter: { date: "2026-01-01" },
   });
+});
+
+test("serializes scalar fields in the error with a `none` error policy", async () => {
+  using _consoleSpy = spyOnConsole("error");
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query, { errorPolicy: "none" });
+
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp({ client, queryRef });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["App", "<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["Error"]);
+    expect(snapshot.error).toEqual(
+      new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      })
+    );
+  }
+
+  await expect(renderStream).not.toRerender();
+});
+
+test("parses scalar fields in the result and serializes them in the error with an `all` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query, { errorPolicy: "all" });
+
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp({ client, queryRef });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["App", "<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.error,
+      error: new CombinedGraphQLErrors({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            // TODO: Determine if this is correct
+            startDate: new Date(2026, 0, 1),
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }),
+    });
+  }
+
+  await expect(renderStream).not.toRerender();
+});
+
+test("parses custom scalar fields with an `ignore` error policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        endDate
+      }
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+            endDate: null,
+          },
+        },
+        errors: [
+          {
+            message: "Could not resolve endDate",
+            path: ["event", "endDate"],
+          },
+        ],
+      }).pipe(delay(20))
+    ),
+  });
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query, { errorPolicy: "ignore" });
+
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp({ client, queryRef });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["App", "<Suspense />"]);
+  }
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: null,
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(renderStream).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query);
+
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp({ client, queryRef });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["App", "<Suspense />"]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: markAsStreaming({
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, path: ["event"] }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(renderStream).not.toRerender();
+});
+
+test("parses custom scalar fields across `@defer` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+            endDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... @defer {
+          endDate
+        }
+      }
+    }
+  `;
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query);
+
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp({ client, queryRef });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["App", "<Suspense />"]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+      },
+    },
+    pending: [{ id: "0", path: ["event"] }],
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: markAsStreaming({
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+        },
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [{ data: { endDate: "2026-02-02" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        event: {
+          __typename: "Event",
+          id: "1",
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 2),
+        },
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(renderStream).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (defer20220824)", async () => {
+  const link = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query);
+
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp({ client, queryRef });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["App", "<Suspense />"]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: markAsStreaming({
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        ],
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        path: ["events", 1],
+      },
+    ],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: new Date(2026, 1, 2),
+          },
+        ],
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(renderStream).not.toRerender();
+});
+
+test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", async () => {
+  const link = mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: link.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const query = gql`
+    query Events {
+      events @stream(initialCount: 1) {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const preloadQuery = createQueryPreloader(client);
+  const queryRef = preloadQuery(query);
+
+  using _disabledAct = disableActEnvironment();
+  const { renderStream } = await renderDefaultTestApp({ client, queryRef });
+
+  {
+    const { renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["App", "<Suspense />"]);
+  }
+
+  link.enqueueInitialChunk({
+    data: {
+      events: [
+        {
+          __typename: "Event",
+          id: "1",
+          startDate: "2026-01-01",
+        },
+      ],
+    },
+    pending: [{ id: "0", path: ["events"] }],
+    hasNext: true,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: markAsStreaming({
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+        ],
+      }),
+      dataState: "streaming",
+      networkStatus: NetworkStatus.streaming,
+      error: undefined,
+    });
+  }
+
+  link.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: "2026-02-02",
+          },
+        ] as any,
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  {
+    const { snapshot, renderedComponents } = await renderStream.takeRender();
+
+    expect(renderedComponents).toStrictEqual(["useReadQuery"]);
+    expect(snapshot.result).toStrictEqualTyped({
+      data: {
+        events: [
+          {
+            __typename: "Event",
+            id: "1",
+            startDate: new Date(2026, 0, 1),
+          },
+          {
+            __typename: "Event",
+            id: "2",
+            startDate: new Date(2026, 1, 2),
+          },
+        ],
+      },
+      dataState: "complete",
+      networkStatus: NetworkStatus.ready,
+      error: undefined,
+    });
+  }
+
+  await expect(renderStream).not.toRerender();
 });

--- a/src/react/query-preloader/__tests__/createQueryPreloader/customScalars.test.tsx
+++ b/src/react/query-preloader/__tests__/createQueryPreloader/customScalars.test.tsx
@@ -676,7 +676,7 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
 
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot.result).toStrictEqualTyped({
-      data: markAsStreaming({
+      data: {
         events: [
           {
             __typename: "Event",
@@ -684,8 +684,8 @@ test("parses custom scalar fields across `@stream` payloads (defer20220824)", as
             startDate: new Date(2026, 0, 1),
           },
         ],
-      }),
-      dataState: "streaming",
+      },
+      dataState: "complete",
       networkStatus: NetworkStatus.streaming,
       error: undefined,
     });
@@ -791,7 +791,7 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
 
     expect(renderedComponents).toStrictEqual(["useReadQuery"]);
     expect(snapshot.result).toStrictEqualTyped({
-      data: markAsStreaming({
+      data: {
         events: [
           {
             __typename: "Event",
@@ -799,8 +799,8 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
             startDate: new Date(2026, 0, 1),
           },
         ],
-      }),
-      dataState: "streaming",
+      },
+      dataState: "complete",
       networkStatus: NetworkStatus.streaming,
       error: undefined,
     });


### PR DESCRIPTION
Adds tests to ensure scalar values are applied to incremental payloads (both `@defer` and `@stream`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when handling custom scalar values, including dates, in queries, mutations, subscriptions, and React hooks.
  - Custom scalar data is now correctly parsed and preserved across GraphQL errors and different error policies.
  - Improved handling of custom scalars during deferred and streamed responses.
  - Preserved result identity when refreshed data is unchanged, helping avoid unnecessary updates.

- **Tests**
  - Expanded coverage across loading, refetching, partial-data, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->