### PR TITLE
Remove `lastRequestId` on `QueryInfo`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1029,8 +1029,6 @@ class QueryManager {
     }): ObservableAndInfo<TData>;
     // (undocumented)
     fetchQuery<TData, TVariables extends OperationVariables>(options: ApolloClient.WatchQueryOptions<TData, TVariables>, networkStatus?: NetworkStatus): Promise<ApolloClient.QueryResult<TData>>;
-    // (undocumented)
-    generateRequestId(): number;
     // Warning: (ae-forgotten-export) The symbol "TransformCacheEntry" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2443,8 +2443,6 @@ class QueryManager {
     }): ObservableAndInfo<TData>;
     // (undocumented)
     fetchQuery<TData, TVariables extends OperationVariables>(options: ApolloClient.WatchQueryOptions<TData, TVariables>, networkStatus?: NetworkStatus): Promise<ApolloClient.QueryResult<TData>>;
-    // (undocumented)
-    generateRequestId(): number;
     // Warning: (ae-forgotten-export) The symbol "TransformCacheEntry" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/.changeset/hip-clocks-exercise.md
+++ b/.changeset/hip-clocks-exercise.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Cleanup some unused internals. Please file an issue if you notice anything change.

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -98,9 +98,6 @@ export class QueryInfo<
   TVariables extends OperationVariables = OperationVariables,
   TCache extends ApolloCache = ApolloCache,
 > {
-  // TODO remove soon - this should be able to be handled by cancelling old operations before starting new ones
-  lastRequestId = 1;
-
   private cache: TCache;
   private queryManager: Pick<
     QueryManager,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1053,7 +1053,6 @@ export class QueryManager {
       exposeExtensions?: boolean;
     }
   ): Observable<ObservableQuery.Result<TData>> {
-    const requestId = (queryInfo.lastRequestId = this.generateRequestId());
     const { errorPolicy } = options;
 
     // Performing transformForLink here gives this.cache a chance to fill in
@@ -1107,10 +1106,6 @@ export class QueryManager {
           aqr[extensionsSymbol] = result.extensions;
         }
 
-        // In the case we start multiple network requests simultaneously, we
-        // want to ensure we properly set `data` if we're reporting on an old
-        // result which will not be caught by the conditional above that ends up
-        // throwing the markError result.
         if (hasErrors) {
           if (errorPolicy === "none") {
             aqr.data = void 0 as TData;
@@ -1129,8 +1124,7 @@ export class QueryManager {
         return aqr;
       }),
       catchError((error) => {
-        // Avoid storing errors from older interrupted queries.
-        if (requestId >= queryInfo.lastRequestId && errorPolicy === "none") {
+        if (errorPolicy === "none") {
           queryInfo.resetLastWrite();
           observableQuery?.["resetNotifications"]();
           throw error;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -618,11 +618,6 @@ export class QueryManager {
     }));
   }
 
-  private requestIdCounter = 1;
-  public generateRequestId() {
-    return this.requestIdCounter++;
-  }
-
   public clearStore(
     options: Cache.ResetOptions = {
       discardWatches: true,


### PR DESCRIPTION
Remove the `lastRequestId` property on `QueryInfo`. This stuck around from the v3 days where a `QueryInfo` instance was long-lived between requests. Now that a new `QueryInfo` instance is created for a single request, race conditions are no longer an issue. The condition checked in the error case `requestId >= queryInfo.lastRequestId` was always true since `requestId` is always equal to `queryInfo.lastRequestId`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling for network/query errors, reducing the chance of stale results affecting error recovery.
* **Chores**
  * Updated the release to a patch version.
  * Removed unused internal cleanup code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->