### PR TITLE
Add unique-names anchor to fragments docs

### DIFF
--- a/.changeset/quiet-pans-doubt.md
+++ b/.changeset/quiet-pans-doubt.md
@@ -1,5 +1,0 @@
----
-"@apollo/client": patch
----
-
-Add `{#unique-names}` anchor to the fragments docs page so the `graphql-tag` warning about duplicate fragment names links to a valid page.

--- a/.changeset/quiet-pans-doubt.md
+++ b/.changeset/quiet-pans-doubt.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add `{#unique-names}` anchor to the fragments docs page so the `graphql-tag` warning about duplicate fragment names links to a valid page.

--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -43,7 +43,7 @@ Changes to the `NameParts` fragment automatically update the fields included in 
 
 ## Unique fragment names {#unique-names}
 
-Fragment names must be unique across your entire application. If you accidentally define two fragments with the same name but different field selections, `graphql-tag` warns you about the conflict at runtime to prevent subtle bugs:
+Fragment names must be unique across your entire application. If you accidentally reuse a fragment name, `graphql-tag` warns you about the conflict at runtime to prevent subtle bugs:
 
 ```text
 Warning: fragment with name SomeFragment already exists.

--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -43,7 +43,7 @@ Changes to the `NameParts` fragment automatically update the fields included in 
 
 ## Unique fragment names {#unique-names}
 
-Fragment names must be unique across your entire application. If you reuse a fragment name, the `graphql-tag` component will warn about the conflict at runtime to prevent subtle bugs:
+Fragment names must be unique across your entire application. If you reuse a fragment name, the `graphql-tag` library warns about the conflict at runtime to help prevent bugs:
 
 ```text
 Warning: fragment with name SomeFragment already exists.
@@ -51,7 +51,7 @@ graphql-tag enforces all fragment names across your application to be unique; re
 this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
 ```
 
-Always use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid name collisions.
+As a best practice, use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid name collisions.
 
 ## Example usage
 

--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -41,6 +41,18 @@ query GetPerson {
 
 Changes to the `NameParts` fragment automatically update the fields included in any operations that use it. This reduces the effort required to keep fields consistent across a set of operations.
 
+## Unique fragment names {#unique-names}
+
+Fragment names must be unique across your entire application. If you accidentally define two fragments with the same name but different field selections, `graphql-tag` warns you about the conflict at runtime to prevent subtle bugs:
+
+```text
+Warning: fragment with name SomeFragment already exists.
+graphql-tag enforces all fragment names across your application to be unique; read more about
+this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
+```
+
+Always use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid accidental name collisions.
+
 ## Example usage
 
 Let's say we have a blog application that executes several GraphQL operations related to comments (submitting a comment, fetching a post's comments, etc.). Our application likely has a `Comment` component that is responsible for rendering comment data.

--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -43,7 +43,7 @@ Changes to the `NameParts` fragment automatically update the fields included in 
 
 ## Unique fragment names {#unique-names}
 
-Fragment names must be unique across your entire application. If you accidentally reuse a fragment name, `graphql-tag` warns you about the conflict at runtime to prevent subtle bugs:
+Fragment names must be unique across your entire application. If you reuse a fragment name, the `graphql-tag` component will warn about the conflict at runtime to prevent subtle bugs:
 
 ```text
 Warning: fragment with name SomeFragment already exists.
@@ -51,7 +51,7 @@ graphql-tag enforces all fragment names across your application to be unique; re
 this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
 ```
 
-Always use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid accidental name collisions.
+Always use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid name collisions.
 
 ## Example usage
 


### PR DESCRIPTION
The `graphql-tag` library warns when duplicate fragment names are found and links to `http://dev.apollodata.com/core/fragments.html#unique-names`. This URL no longer resolves.

This PR adds a dedicated section with the `{#unique-names}` custom anchor ID to the Apollo Client fragments docs page so that the old link serves useful content instead of a 404.

Fixes #13292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on using unique fragment names across the application.
  * Documented the warning shown when duplicate fragment names are detected.
  * Recommended descriptive, component-scoped naming to prevent conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->