### PR TITLE
🤖🤖🤖 fix: disable MockedProvider devtools by default

### DIFF
--- a/.changeset/proud-cooks-sip.md
+++ b/.changeset/proud-cooks-sip.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Default `MockedProvider` to keep Apollo Client DevTools disabled unless explicitly configured.

--- a/src/testing/react/MockedProvider.tsx
+++ b/src/testing/react/MockedProvider.tsx
@@ -57,7 +57,7 @@ export class MockedProvider extends React.Component<
           defaultOptions: mockLinkDefaultOptions,
         }),
       localState,
-      devtools,
+      devtools: devtools ?? { enabled: false },
     });
 
     this.state = {

--- a/src/testing/react/__tests__/MockedProvider.test.tsx
+++ b/src/testing/react/__tests__/MockedProvider.test.tsx
@@ -90,6 +90,31 @@ describe("General use", () => {
     errorThrown = false;
   });
 
+  it("should not connect to Apollo Client DevTools by default", () => {
+    delete (window as any).__APOLLO_CLIENT__;
+
+    const provider = new MockedProvider({});
+
+    expect((provider as any).state.client.devtoolsConfig.enabled).toBe(false);
+    expect((window as any).__APOLLO_CLIENT__).toBeUndefined();
+
+    provider.componentWillUnmount();
+  });
+
+  it("should allow Apollo Client DevTools to be enabled", () => {
+    jest.useFakeTimers();
+    delete (window as any).__APOLLO_CLIENT__;
+
+    const provider = new MockedProvider({ devtools: { enabled: true } });
+
+    expect((provider as any).state.client.devtoolsConfig.enabled).toBe(true);
+    expect((window as any).__APOLLO_CLIENT__).toBeDefined();
+
+    delete (window as any).__APOLLO_CLIENT__;
+    provider.componentWillUnmount();
+    jest.useRealTimers();
+  });
+
   it("should mock the data", async () => {
     using _disabledAct = disableActEnvironment();
     const { takeSnapshot } = await renderHookToSnapshotStream(


### PR DESCRIPTION
Fixes #13344

## Summary
- Restore the `MockedProvider` behavior from #11289 by disabling Apollo Client DevTools unless `devtools` is explicitly provided.
- Add regression coverage that verifies the default does not register `window.__APOLLO_CLIENT__` while `devtools={{ enabled: true }}` still opts in.
- Add a patch changeset.

### Checklist:
- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

## Tests
- `npm run test -- --runInBand --testRegex src/testing/react/__tests__/MockedProvider.test.tsx`
- `npm exec -- prettier --check src/testing/react/MockedProvider.tsx src/testing/react/__tests__/MockedProvider.test.tsx .changeset/proud-cooks-sip.md`
- `git diff --check`

Note: a focused ESLint run was attempted, but the local clone lacked generated `docs/public/canonical-references.json`, causing ESLint config loading to fail before linting changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DevTools are now disabled by default when using `MockedProvider`, preventing unintended global DevTools registration.
  * DevTools can still be explicitly enabled through the provider configuration.

* **Documentation**
  * Added a patch release note describing the updated default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->