### PR TITLE
Fix widening of default options types when variables contain constant types

### DIFF
--- a/integration-tests/type-tests/signatures/modern/useQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useQuery.ts
@@ -367,6 +367,168 @@ test("requires variables with mixed TVariables", () => {
   );
 });
 
+// https://github.com/apollographql/apollo-client/issues/13342
+test("constant variable types do not widen returnPartialData", () => {
+  {
+    const query: TypedDocumentNode<{ character: string }, { type: "main" }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { type: "main" },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { type: "main" }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { type: "main" }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | DataValue.Partial<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<
+      "empty" | "partial" | "streaming" | "complete"
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { episode: 10 }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { episode: 10 },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { episode: 10 }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { episode: 10 },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { episode: 10 }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { episode: 10 },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | DataValue.Partial<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<
+      "empty" | "partial" | "streaming" | "complete"
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { main: true }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { main: true },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { main: true }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { main: true },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { main: true }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { main: true },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | DataValue.Partial<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<
+      "empty" | "partial" | "streaming" | "complete"
+    >();
+  }
+});
+
 test("always returns empty data/dataState with unconditional skipToken", () => {
   const query: TypedDocumentNode<
     { character: string },

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -201,10 +201,6 @@ export declare namespace useQuery {
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
-    TOptions extends
-      | Record<string, never> // no options
-      | Options<TData, TVariables>
-      | SkipToken,
     TReturnPartialData extends boolean | undefined = undefined,
   > = LazyType<
     Result<
@@ -213,16 +209,13 @@ export declare namespace useQuery {
       | "complete"
       | "streaming"
       | "empty"
-      | (TOptions extends any ?
-          TOptions extends SkipToken ? never
-          : OptionWithFallback<
-            { returnPartialData: TReturnPartialData },
-            DefaultOptions,
-            "returnPartialData"
-          > extends false ?
-            never
-          : "partial"
-        : never)
+      | (OptionWithFallback<
+          { returnPartialData: TReturnPartialData },
+          DefaultOptions,
+          "returnPartialData"
+        > extends false ?
+          never
+        : "partial")
     >
   >;
 
@@ -532,22 +525,16 @@ export declare namespace useQuery {
           DocumentNode | TypedDocumentNode<TData, TVariables>
         : // this overload should only be accessible if all `TVariables` are optional
           never
-      ): useQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
+      ): useQuery.ResultForOptions<TData, TVariables>;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
       <
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends useQuery.Options<TData, NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TProvidedVariables extends TVariables & {
+          [K in Exclude<keyof TProvidedVariables, keyof TVariables>]?: never;
+        } = TVariables,
         TReturnPartialData extends boolean | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
@@ -556,15 +543,20 @@ export declare namespace useQuery {
         [TVariables] extends [never] ? [options: never]
         : // variables optional
         {} extends TVariables ?
-          [options?: TOptions & { returnPartialData?: TReturnPartialData }]
+          [
+            options?: useQuery.Base.Options<TData, NoInfer<TVariables>> & {
+              variables?: TProvidedVariables;
+              returnPartialData?: TReturnPartialData;
+            },
+          ]
         : // variables required
-          [options: TOptions & { returnPartialData?: TReturnPartialData }]
-      ): useQuery.ResultForOptions<
-        TData,
-        TVariables,
-        TOptions,
-        TReturnPartialData
-      >;
+          [
+            options: useQuery.Base.Options<TData, NoInfer<TVariables>> & {
+              variables: TProvidedVariables;
+              returnPartialData?: TReturnPartialData;
+            },
+          ]
+      ): useQuery.ResultForOptions<TData, TVariables, TReturnPartialData>;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
       <
@@ -582,15 +574,9 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends useQuery.Options<TData, NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TProvidedVariables extends TVariables & {
+          [K in Exclude<keyof TProvidedVariables, keyof TVariables>]?: never;
+        } = TVariables,
         TReturnPartialData extends boolean | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
@@ -601,21 +587,22 @@ export declare namespace useQuery {
         {} extends TVariables ?
           [
             options?:
-              | (TOptions & { returnPartialData?: TReturnPartialData })
+              | (useQuery.Base.Options<TData, NoInfer<TVariables>> & {
+                  variables?: TProvidedVariables;
+                  returnPartialData?: TReturnPartialData;
+                })
               | SkipToken,
           ]
         : // variables required
           [
             options:
-              | (TOptions & { returnPartialData?: TReturnPartialData })
+              | (useQuery.Base.Options<TData, NoInfer<TVariables>> & {
+                  variables: TProvidedVariables;
+                  returnPartialData?: TReturnPartialData;
+                })
               | SkipToken,
           ]
-      ): useQuery.ResultForOptions<
-        TData,
-        TVariables,
-        TOptions | SkipToken,
-        TReturnPartialData
-      >;
+      ): useQuery.ResultForOptions<TData, TVariables, TReturnPartialData>;
 
       ssrDisabledResult: ObservableQuery.Result<any>;
     }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -205,6 +205,7 @@ export declare namespace useQuery {
       | Record<string, never> // no options
       | Options<TData, TVariables>
       | SkipToken,
+    TReturnPartialData extends boolean | undefined = undefined,
   > = LazyType<
     Result<
       TData,
@@ -215,7 +216,7 @@ export declare namespace useQuery {
       | (TOptions extends any ?
           TOptions extends SkipToken ? never
           : OptionWithFallback<
-            TOptions,
+            { returnPartialData: TReturnPartialData },
             DefaultOptions,
             "returnPartialData"
           > extends false ?
@@ -547,16 +548,23 @@ export declare namespace useQuery {
               >]?: never;
             }
           >,
+        TReturnPartialData extends boolean | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: // we generally do not allow for a `TVariables` of `never`
         // TODO: check if we need a similar check in other hooks
         [TVariables] extends [never] ? [options: never]
         : // variables optional
-        {} extends TVariables ? [options?: TOptions]
+        {} extends TVariables ?
+          [options?: TOptions & { returnPartialData?: TReturnPartialData }]
         : // variables required
-          [options: TOptions]
-      ): useQuery.ResultForOptions<TData, TVariables, TOptions>;
+          [options: TOptions & { returnPartialData?: TReturnPartialData }]
+      ): useQuery.ResultForOptions<
+        TData,
+        TVariables,
+        TOptions,
+        TReturnPartialData
+      >;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
       <
@@ -583,16 +591,31 @@ export declare namespace useQuery {
               >]?: never;
             }
           >,
+        TReturnPartialData extends boolean | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: // we generally do not allow for a `TVariables` of `never`
         // TODO: check if we need a similar check in other hooks
         [TVariables] extends [never] ? [options: never]
         : // variables optional
-        {} extends TVariables ? [options?: TOptions | SkipToken]
+        {} extends TVariables ?
+          [
+            options?:
+              | (TOptions & { returnPartialData?: TReturnPartialData })
+              | SkipToken,
+          ]
         : // variables required
-          [options: TOptions | SkipToken]
-      ): useQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
+          [
+            options:
+              | (TOptions & { returnPartialData?: TReturnPartialData })
+              | SkipToken,
+          ]
+      ): useQuery.ResultForOptions<
+        TData,
+        TVariables,
+        TOptions | SkipToken,
+        TReturnPartialData
+      >;
 
       ssrDisabledResult: ObservableQuery.Result<any>;
     }


### PR DESCRIPTION
Fixes #13342

TypeScript playground of the reproduction: https://tsplay.dev/mAbMQW