### PR TITLE
fix(RetryLink): skip retry after unsubscribe during async retryIf

### DIFF
--- a/.changeset/retry-link-cancel-await.md
+++ b/.changeset/retry-link-cancel-await.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix `RetryLink` scheduling a retry after the consumer has unsubscribed while an async `retryIf` was still pending.

--- a/src/link/retry/__tests__/retryLink.ts
+++ b/src/link/retry/__tests__/retryLink.ts
@@ -215,6 +215,39 @@ describe("RetryLink", () => {
     ]);
   });
 
+  it("does not schedule a retry after unsubscribe while awaiting retryIf", async () => {
+    let resolveRetryIf!: (value: boolean) => void;
+    const retryIfPromise = new Promise<boolean>((resolve) => {
+      resolveRetryIf = resolve;
+    });
+    const attemptStub = jest.fn(() => retryIfPromise);
+
+    const retry = new RetryLink({
+      delay: { initial: 1 },
+      attempts: attemptStub,
+    });
+    const linkStub = jest.fn(() => throwError(() => standardError)) as any;
+    const link = ApolloLink.from([retry, new ApolloLink(linkStub)]);
+
+    const subscription = execute(link, { query }).subscribe({
+      next: () => {},
+      error: () => {},
+    });
+
+    // Wait until onError has suspended on the async retryIf promise.
+    await Promise.resolve();
+    expect(attemptStub).toHaveBeenCalledTimes(1);
+    expect(linkStub).toHaveBeenCalledTimes(1);
+
+    subscription.unsubscribe();
+    resolveRetryIf(true);
+
+    // Allow the resumed onError (and any scheduled setTimeout) to run.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(linkStub).toHaveBeenCalledTimes(1);
+  });
+
   it("handles protocol errors from multipart subscriptions", async () => {
     const subscription = gql`
       subscription MySubscription {

--- a/src/link/retry/retryLink.ts
+++ b/src/link/retry/retryLink.ts
@@ -146,6 +146,9 @@ class RetryableOperation {
   private retryCount: number = 0;
   private currentSubscription: Subscription | null = null;
   private timerId: ReturnType<typeof setTimeout> | undefined;
+  // Set by cancel() so an onError suspended at await retryIf() does not
+  // schedule another attempt after the consumer has unsubscribed.
+  private cancelled = false;
 
   constructor(
     private observer: Observer<ApolloLink.Result>,
@@ -161,6 +164,7 @@ class RetryableOperation {
    * Stop retrying for the operation, and cancel any in-progress requests.
    */
   public cancel() {
+    this.cancelled = true;
     if (this.currentSubscription) {
       this.currentSubscription.unsubscribe();
     }
@@ -200,6 +204,11 @@ class RetryableOperation {
       this.operation,
       errorLike
     );
+    // cancel() may have run while we awaited retryIf; do not schedule another
+    // attempt or notify a torn-down observer.
+    if (this.cancelled) {
+      return;
+    }
     if (shouldRetry) {
       this.scheduleRetry(
         this.delayFor(this.retryCount, this.operation, errorLike)


### PR DESCRIPTION
### Checklist:
- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

## Summary

Closes #13346.

`RetryLink`'s `onError` awaits an async `retryIf` before calling `scheduleRetry`. If the consumer unsubscribes while that promise is pending, `cancel()` clears `timerId`. That leaves the same sentinel value `scheduleRetry` treats as "no retry pending", so when `onError` resumes it can schedule another network request against a torn-down observer.

This change tracks cancellation with an explicit flag and returns from `onError` after the await when the subscription has already been cancelled.

## Test plan

- [x] Added a regression test that suspends `retryIf` on a deferred promise, unsubscribes, then resolves `retryIf` to `true` and asserts no additional forward call is made
- [x] `npm test -- --testPathPatterns='link/retry/__tests__/retryLink' --no-coverage` — 36/36 passing across the Core / GraphQL 16 / RxJS min projects



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retry behavior so no additional retries are scheduled after a subscription is canceled while awaiting an asynchronous retry decision.
  * Prevented canceled operations from triggering further downstream requests or timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->