### PR TITLE
fix: apply query variable defaults when undefined is passed explicitly

### DIFF
--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -262,6 +262,37 @@ describe("reading from the store", () => {
     });
   });
 
+  it("applies defaults when variable is explicitly undefined", () => {
+    const query = gql`
+      query someQuery($show: Boolean = false) {
+        id
+        field @include(if: $show)
+      }
+    `;
+
+    const variables = {
+      show: undefined,
+    };
+
+    const store = defaultNormalizedCacheFactory({
+      ROOT_QUERY: {
+        __typename: "Query",
+        id: "abcd",
+      } as StoreObject,
+    });
+
+    const result = readQueryFromStore(reader, {
+      store,
+      query,
+      variables,
+    });
+
+    // $show defaults to false, so @include(if: false) excludes the field
+    expect(result).toEqual({
+      id: "abcd",
+    });
+  });
+
   it("runs a nested query", () => {
     const result: any = {
       id: "abcd",

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -204,9 +204,12 @@ export class StoreReader {
   }: DiffQueryAgainstStoreOptions): Cache.DiffResult<T> {
     const policies = this.config.cache.policies;
 
+    const rawVariables = variables ?? {};
     variables = {
       ...getDefaultValues(getQueryDefinition(query)),
-      ...variables!,
+      ...Object.fromEntries(
+        Object.entries(rawVariables).filter(([, v]) => v !== undefined)
+      ),
     };
 
     const rootRef = makeReference(rootId);


### PR DESCRIPTION
Fixes #13345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query handling when variables are omitted or explicitly set to `undefined`.
  * GraphQL default variable values are now applied consistently, improving conditional field selection and related query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->