### PR TITLE
fix: apply query variable defaults when undefined is passed explicitly

### DIFF
--- a/.changeset/pink-shoes-cheer.md
+++ b/.changeset/pink-shoes-cheer.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Fix a bug where GraphQL variable default values were not applied when `undefined` was passed explicitly in `variables`. This caused `@include`/`@skip` directives to throw "Invalid variable referenced" errors when the variable was passed as `undefined` instead of being omitted entirely.
+Fix a bug where GraphQL variable default values were not applied during cache reads when variables with defaults were explicitly set to `undefined`. This caused `@include`/`@skip` directives to throw "Invalid variable referenced" errors when the variable was passed as `undefined` instead of being omitted entirely.

--- a/.changeset/pink-shoes-cheer.md
+++ b/.changeset/pink-shoes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix a bug where GraphQL variable default values were not applied when `undefined` was passed explicitly in `variables`. This caused `@include`/`@skip` directives to throw "Invalid variable referenced" errors when the variable was passed as `undefined` instead of being omitted entirely.

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -287,7 +287,31 @@ describe("reading from the store", () => {
       variables,
     });
 
-    // $show defaults to false, so @include(if: false) excludes the field
+    expect(result).toEqual({
+      id: "abcd",
+    });
+  });
+
+  it("applies defaults when variables are omitted entirely", () => {
+    const query = gql`
+      query someQuery($show: Boolean = false) {
+        id
+        field @include(if: $show)
+      }
+    `;
+
+    const store = defaultNormalizedCacheFactory({
+      ROOT_QUERY: {
+        __typename: "Query",
+        id: "abcd",
+      } as StoreObject,
+    });
+
+    const result = readQueryFromStore(reader, {
+      store,
+      query,
+    });
+
     expect(result).toEqual({
       id: "abcd",
     });

--- a/src/cache/inmemory/__tests__/readFromStore.ts
+++ b/src/cache/inmemory/__tests__/readFromStore.ts
@@ -262,6 +262,37 @@ describe("reading from the store", () => {
     });
   });
 
+  it("applies defaults when variable is explicitly undefined", () => {
+    const query = gql`
+      query someQuery($show: Boolean = false) {
+        id
+        field @include(if: $show)
+      }
+    `;
+
+    const variables = {
+      show: undefined,
+    };
+
+    const store = defaultNormalizedCacheFactory({
+      ROOT_QUERY: {
+        __typename: "Query",
+        id: "abcd",
+      } as StoreObject,
+    });
+
+    const result = readQueryFromStore(reader, {
+      store,
+      query,
+      variables,
+    });
+
+    // $show defaults to false, so @include(if: false) excludes the field
+    expect(result).toEqual({
+      id: "abcd",
+    });
+  });
+
   it("runs a nested query", () => {
     const result: any = {
       id: "abcd",

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -16,6 +16,7 @@ import type {
   FragmentMapFunction,
 } from "@apollo/client/utilities/internal";
 import {
+  compact,
   DeepMerger,
   getDefaultValues,
   getFragmentFromSelection,
@@ -204,13 +205,10 @@ export class StoreReader {
   }: DiffQueryAgainstStoreOptions): Cache.DiffResult<T> {
     const policies = this.config.cache.policies;
 
-    const rawVariables = variables ?? {};
-    variables = {
-      ...getDefaultValues(getQueryDefinition(query)),
-      ...Object.fromEntries(
-        Object.entries(rawVariables).filter(([, v]) => v !== undefined)
-      ),
-    };
+    variables = compact(
+      getDefaultValues(getQueryDefinition(query)),
+      variables,
+    );
 
     const rootRef = makeReference(rootId);
     const execResult = this.executeSelectionSet({

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -205,10 +205,7 @@ export class StoreReader {
   }: DiffQueryAgainstStoreOptions): Cache.DiffResult<T> {
     const policies = this.config.cache.policies;
 
-    variables = compact(
-      getDefaultValues(getQueryDefinition(query)),
-      variables,
-    );
+    variables = compact(getDefaultValues(getQueryDefinition(query)), variables);
 
     const rootRef = makeReference(rootId);
     const execResult = this.executeSelectionSet({

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -204,9 +204,12 @@ export class StoreReader {
   }: DiffQueryAgainstStoreOptions): Cache.DiffResult<T> {
     const policies = this.config.cache.policies;
 
+    const rawVariables = variables ?? {};
     variables = {
       ...getDefaultValues(getQueryDefinition(query)),
-      ...variables!,
+      ...Object.fromEntries(
+        Object.entries(rawVariables).filter(([, v]) => v !== undefined)
+      ),
     };
 
     const rootRef = makeReference(rootId);


### PR DESCRIPTION
Fixes #13345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GraphQL variable handling when variables are explicitly set to `undefined`.
  * Query-defined default values are now applied correctly, ensuring conditional fields such as those controlled by `@include` return the expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->