### PR TITLE
Add unique-names anchor to fragments docs

### DIFF
--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -41,6 +41,18 @@ query GetPerson {
 
 Changes to the `NameParts` fragment automatically update the fields included in any operations that use it. This reduces the effort required to keep fields consistent across a set of operations.
 
+## Unique fragment names {#unique-names}
+
+Fragment names must be unique across your entire application. If you reuse a fragment name, the `graphql-tag` library warns about the conflict at runtime to help prevent bugs:
+
+```text
+Warning: fragment with name SomeFragment already exists.
+graphql-tag enforces all fragment names across your application to be unique; read more about
+this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
+```
+
+As a best practice, use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid name collisions.
+
 ## Example usage
 
 Let's say we have a blog application that executes several GraphQL operations related to comments (submitting a comment, fetching a post's comments, etc.). Our application likely has a `Comment` component that is responsible for rendering comment data.

--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -41,18 +41,6 @@ query GetPerson {
 
 Changes to the `NameParts` fragment automatically update the fields included in any operations that use it. This reduces the effort required to keep fields consistent across a set of operations.
 
-## Unique fragment names {#unique-names}
-
-Fragment names must be unique across your entire application. If you reuse a fragment name, the `graphql-tag` library warns about the conflict at runtime to help prevent bugs:
-
-```text
-Warning: fragment with name SomeFragment already exists.
-graphql-tag enforces all fragment names across your application to be unique; read more about
-this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
-```
-
-As a best practice, use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid name collisions.
-
 ## Example usage
 
 Let's say we have a blog application that executes several GraphQL operations related to comments (submitting a comment, fetching a post's comments, etc.). Our application likely has a `Comment` component that is responsible for rendering comment data.
@@ -1802,3 +1790,17 @@ The following masking utility types are available to override:
 - `Unmasked<TData>` - Unwraps `TData` into the full result type
 
 For more information about other overridable types in Apollo Client, see the [TypeScript guide](../development-testing/static-typing).
+
+## Troubleshooting
+
+### Unique names
+
+Fragment names must be unique across your entire application. If you reuse a fragment name, the `graphql-tag` library warns about the conflict at runtime to help prevent bugs:
+
+```text
+Warning: fragment with name SomeFragment already exists.
+graphql-tag enforces all fragment names across your application to be unique; read more about
+this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
+```
+
+As a best practice, use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid name collisions.

--- a/docs/source/data/fragments.mdx
+++ b/docs/source/data/fragments.mdx
@@ -1795,7 +1795,7 @@ For more information about other overridable types in Apollo Client, see the [Ty
 
 ### Unique names
 
-Fragment names must be unique across your entire application. If you reuse a fragment name, the `graphql-tag` library warns about the conflict at runtime to help prevent bugs:
+Fragment names must be unique across your entire application. If you reuse a fragment name, `graphql-tag` provides a warning about the conflict at runtime to help you identify the issue:
 
 ```text
 Warning: fragment with name SomeFragment already exists.
@@ -1803,4 +1803,4 @@ graphql-tag enforces all fragment names across your application to be unique; re
 this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
 ```
 
-As a best practice, use descriptive, component-scoped fragment names (like `ItemFragment` or `UserProfileFragment`) to avoid name collisions.
+As a best practice, use descriptive, component-scoped fragment names (like `CartItemFragment` or `UserProfileCardFragment`) to avoid name collisions.


### PR DESCRIPTION
Closes #13292

Adds a dedicated section for the unique-names anchor so graphql-tag warning links resolve properly. This is a docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on using unique GraphQL fragment names.
  * Included an example warning for fragment name collisions.
  * Recommended descriptive, component-scoped names to prevent conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->