### PR TITLE
Fix issue where changes to `@export` fields did not trigger updates

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1116,10 +1116,12 @@ interface QueryManagerOptions {
 namespace QueryNotification {
     // (undocumented)
     type FromCache<TData> = NextNotification<ObservableQuery.Result<TData>> & {
+        resolvedVariables?: OperationVariables;
         source: "cache";
     };
     // (undocumented)
     type FromNetwork<TData> = ObservableNotification<ObservableQuery.Result<TData>> & {
+        resolvedVariables?: OperationVariables;
         source: "network";
     };
     // (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2530,10 +2530,12 @@ interface QueryManagerOptions {
 namespace QueryNotification {
     // (undocumented)
     type FromCache<TData> = NextNotification<ObservableQuery.Result<TData>> & {
+        resolvedVariables?: OperationVariables;
         source: "cache";
     };
     // (undocumented)
     type FromNetwork<TData> = ObservableNotification<ObservableQuery.Result<TData>> & {
+        resolvedVariables?: OperationVariables;
         source: "network";
     };
     // (undocumented)

--- a/.changeset/stale-moles-tap.md
+++ b/.changeset/stale-moles-tap.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where some `@export` queries would not react to cache updates when the fields keyed by exported variables were updated.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 47972,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 42227,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35919,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29427
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 48044,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 42315,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35982,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29489
 }

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -1,6 +1,7 @@
+import { waitFor } from "@testing-library/react";
 import { print } from "graphql";
 import { gql } from "graphql-tag";
-import { of } from "rxjs";
+import { delay, of } from "rxjs";
 
 import { ApolloClient, LocalStateError, NetworkStatus } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
@@ -981,7 +982,7 @@ describe("@client @export tests", () => {
     let fetchCount = 0;
     const link = new ApolloLink((operation) => {
       fetchCount += 1;
-      const id = operation.variables.userId as string;
+      const id = operation.variables.userId;
       return of({
         data: {
           user: {
@@ -1168,7 +1169,7 @@ describe("@client @export tests", () => {
     let fetchCount = 0;
     const link = new ApolloLink((operation) => {
       fetchCount += 1;
-      const id = operation.variables.userId as string;
+      const id = operation.variables.userId;
       return of({
         data: {
           user: {
@@ -1462,6 +1463,630 @@ describe("@client @export tests", () => {
       data: {
         userId: "2",
         friendList: [{ __typename: "Friend", id: "10", name: "Amidala" }],
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  test("delivers both cache and network results for cache-and-network when variables come from @export", async () => {
+    const query = gql`
+      query UserWithExport($userId: ID!) {
+        userId @client @export(as: "userId")
+        user(id: $userId) {
+          id
+          name
+        }
+      }
+    `;
+
+    let fetchCount = 0;
+    const link = new ApolloLink((operation) => {
+      fetchCount += 1;
+      const id = operation.variables.userId;
+      return of({
+        data: {
+          user: {
+            __typename: "User",
+            id,
+            name: `server-${id}`,
+          },
+        },
+      });
+    });
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link,
+      localState: new LocalState(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "1" },
+    });
+    client.writeQuery({
+      query,
+      variables: { userId: "1" },
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          name: "cached-1",
+        },
+      },
+    });
+
+    const stream = new ObservableStream(
+      client.watchQuery({ query, fetchPolicy: "cache-and-network" })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          name: "cached-1",
+        },
+      },
+      dataState: "complete",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          name: "server-1",
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(1);
+
+    client.cache.evict({
+      id: client.cache.identify({ __typename: "User", id: "1" }),
+      fieldName: "name",
+    });
+    client.cache.gc();
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          name: "server-1",
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(2);
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  test("delivers partial cache then network results when returnPartialData is true and variables come from @export", async () => {
+    const query = gql`
+      query UserWithExport($userId: ID!) {
+        userId @client @export(as: "userId")
+        user(id: $userId) {
+          id
+          address {
+            id
+            street
+          }
+        }
+      }
+    `;
+
+    let fetchCount = 0;
+    const link = new ApolloLink((operation) => {
+      fetchCount += 1;
+      const id = operation.variables.userId;
+      return of({
+        data: {
+          user: {
+            __typename: "User",
+            id,
+            address: {
+              __typename: "Address",
+              id: `addr-${id}`,
+              street: `Street ${fetchCount}`,
+            },
+          },
+        },
+      });
+    });
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link,
+      localState: new LocalState(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "1" },
+    });
+
+    client.writeQuery({
+      query: gql`
+        query ($userId: ID!) {
+          userId @client
+          user(id: $userId) {
+            id
+          }
+        }
+      `,
+      variables: { userId: "1" },
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+        },
+      },
+    });
+
+    const stream = new ObservableStream(
+      client.watchQuery({ query, returnPartialData: true })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+        },
+      },
+      dataState: "partial",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            street: "Street 1",
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(1);
+
+    client.cache.evict({
+      id: client.cache.identify({ __typename: "User", id: "1" }),
+      fieldName: "address",
+    });
+    client.cache.gc();
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+        },
+      },
+      dataState: "partial",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            street: "Street 2",
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(2);
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  test("ignores a slow in-flight response after @export variables change via reobserve", async () => {
+    const query = gql`
+      query UserWithExport($userId: ID!) {
+        userId @client @export(as: "userId")
+        user(id: $userId) {
+          id
+          name
+        }
+      }
+    `;
+
+    let fetchCount = 0;
+    const link = new ApolloLink((operation) => {
+      fetchCount += 1;
+      const id = operation.variables.userId;
+      return of({
+        data: {
+          user: {
+            __typename: "User",
+            id,
+            name: `user-${id}-fetch-${fetchCount}`,
+          },
+        },
+      }).pipe(delay(id === "1" ? 100 : 10));
+    });
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link,
+      localState: new LocalState(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "1" },
+    });
+
+    const observable = client.watchQuery({ query });
+    const stream = new ObservableStream(observable);
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await waitFor(() => expect(fetchCount).toBe(1));
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "2" },
+    });
+    // Cache broadcasts do not reobserve while a network request is active, so
+    // trigger it manually to cancel the in-flight request and start the new
+    // one.
+    void observable.reobserve();
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "2",
+        user: {
+          __typename: "User",
+          id: "2",
+          name: "user-2-fetch-2",
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    // Wait longer than the initial request would take to finish to validate it
+    // doesn't overwrite the new request.
+    await expect(stream).not.toEmitAnything({ timeout: 200 });
+    expect(fetchCount).toBe(2);
+
+    client.cache.evict({
+      id: client.cache.identify({ __typename: "User", id: "2" }),
+      fieldName: "name",
+    });
+    client.cache.gc();
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "2",
+        user: {
+          __typename: "User",
+          id: "2",
+          name: "user-2-fetch-3",
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(3);
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  test("should refetch after network-only when a remote field is missing and variables come from @export", async () => {
+    const query = gql`
+      query UserWithExport($userId: ID!) {
+        userId @client @export(as: "userId")
+        user(id: $userId) {
+          id
+          address {
+            id
+            random
+          }
+        }
+      }
+    `;
+
+    let fetchCount = 0;
+    const link = new ApolloLink((operation) => {
+      fetchCount += 1;
+      const id = operation.variables.userId;
+      return of({
+        data: {
+          user: {
+            __typename: "User",
+            id,
+            address: {
+              __typename: "Address",
+              id: `addr-${id}`,
+              random: fetchCount,
+            },
+          },
+        },
+      });
+    });
+
+    const cache = new InMemoryCache();
+    const client = new ApolloClient({
+      cache,
+      link,
+      localState: new LocalState(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "1" },
+    });
+
+    const stream = new ObservableStream(
+      client.watchQuery({ query, fetchPolicy: "network-only" })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            random: 1,
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(1);
+
+    cache.evict({
+      id: cache.identify({ __typename: "User", id: "1" }),
+      fieldName: "address",
+    });
+    cache.gc();
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            random: 2,
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(2);
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  test("starts a new request when @export variables change mid-stream via reobserve", async () => {
+    const multipart = mockDeferStreamGraphQL17Alpha9();
+
+    const query = gql`
+      query FriendListWithExport($userId: ID!) {
+        userId @client @export(as: "userId")
+        friendList(userId: $userId) @stream(initialCount: 1) {
+          id
+          name
+        }
+      }
+    `;
+
+    const client = new ApolloClient({
+      link: multipart.httpLink,
+      cache: new InMemoryCache(),
+      localState: new LocalState(),
+      incrementalHandler: new GraphQL17Alpha9Handler(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "1" },
+    });
+
+    const observable = client.watchQuery({ query });
+    const stream = new ObservableStream(observable);
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    multipart.enqueueInitialChunk({
+      data: {
+        friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
+      },
+      pending: [{ id: "0", path: ["friendList"] }],
+      hasNext: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: markAsStreaming({
+        userId: "1",
+        friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
+      }),
+      dataState: "streaming",
+      loading: true,
+      networkStatus: NetworkStatus.streaming,
+      partial: true,
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "2" },
+    });
+    // Cache writes alone do not reobserve while a network operation is active
+    // so trigger reobserve manually to start the new request.
+    void observable.reobserve();
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    multipart.enqueueInitialChunk({
+      data: {
+        friendList: [{ __typename: "Friend", id: "10", name: "Padme" }],
+      },
+      pending: [],
+      hasNext: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "2",
+        friendList: [{ __typename: "Friend", id: "10", name: "Padme" }],
       },
       dataState: "complete",
       loading: false,

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -4,10 +4,13 @@ import { of } from "rxjs";
 
 import { ApolloClient, LocalStateError, NetworkStatus } from "@apollo/client";
 import { InMemoryCache } from "@apollo/client/cache";
+import { GraphQL17Alpha9Handler } from "@apollo/client/incremental";
 import { ApolloLink } from "@apollo/client/link";
 import { LocalState } from "@apollo/client/local-state";
 import { MockSubscriptionLink } from "@apollo/client/testing";
 import {
+  markAsStreaming,
+  mockDeferStreamGraphQL17Alpha9,
   ObservableStream,
   spyOnConsole,
   wait,
@@ -1076,6 +1079,111 @@ describe("@client @export tests", () => {
       partial: false,
     });
     expect(fetchCount).toBe(2);
+  });
+
+  test("merges concurrent cache updates during a streamed response when variables come from @export", async () => {
+    const multipart = mockDeferStreamGraphQL17Alpha9();
+    const userId = "1";
+
+    const query = gql`
+      query FriendListWithExport($userId: ID!) {
+        userId @client @export(as: "userId")
+        friendList(userId: $userId) @stream(initialCount: 1) {
+          id
+          name
+        }
+      }
+    `;
+
+    const client = new ApolloClient({
+      link: multipart.httpLink,
+      cache: new InMemoryCache(),
+      localState: new LocalState(),
+      incrementalHandler: new GraphQL17Alpha9Handler(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId },
+    });
+
+    const stream = new ObservableStream(client.watchQuery({ query }));
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    multipart.enqueueInitialChunk({
+      data: {
+        friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
+      },
+      pending: [{ id: "0", path: ["friendList"] }],
+      hasNext: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: markAsStreaming({
+        userId,
+        friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
+      }),
+      dataState: "streaming",
+      loading: true,
+      networkStatus: NetworkStatus.streaming,
+      partial: true,
+    });
+
+    client.writeFragment({
+      id: "Friend:1",
+      fragment: gql`
+        fragment FriendName on Friend {
+          name
+        }
+      `,
+      data: {
+        name: "Jedi",
+      },
+    });
+
+    multipart.enqueueSubsequentChunk({
+      incremental: [
+        {
+          items: [
+            { __typename: "Friend", id: "2", name: "Han" },
+            { __typename: "Friend", id: "3", name: "Leia" },
+          ] as any,
+          id: "0",
+        },
+      ],
+      completed: [{ id: "0" }],
+      hasNext: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId,
+        friendList: [
+          {
+            __typename: "Friend",
+            id: "1",
+            name: "Jedi", // updated from cache mid-stream
+          },
+          { __typename: "Friend", id: "2", name: "Han" },
+          { __typename: "Friend", id: "3", name: "Leia" },
+        ],
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
   });
 
   test("should update @client @export variables on each broadcast if they've changed", async () => {

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -1149,6 +1149,149 @@ describe("@client @export tests", () => {
     expect(fetchCount).toBe(4);
   });
 
+  test("should refetch after a complete cache hit when a remote field is missing and variables come from @export", async () => {
+    const query = gql`
+      query UserWithExport($userId: ID!) {
+        userId @client @export(as: "userId")
+        user(id: $userId) {
+          id
+          address {
+            id
+            random
+          }
+        }
+      }
+    `;
+
+    let fetchCount = 0;
+    const link = new ApolloLink((operation) => {
+      fetchCount += 1;
+      const id = operation.variables.userId as string;
+      return of({
+        data: {
+          user: {
+            __typename: "User",
+            id,
+            address: {
+              __typename: "Address",
+              id: `addr-${id}`,
+              random: fetchCount,
+            },
+          },
+        },
+      });
+    });
+
+    const cache = new InMemoryCache();
+    const client = new ApolloClient({
+      cache,
+      link,
+      localState: new LocalState(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "1" },
+    });
+    client.writeQuery({
+      query,
+      variables: { userId: "1" },
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            random: 0,
+          },
+        },
+      },
+    });
+
+    const stream = new ObservableStream(client.watchQuery({ query }));
+
+    // Export resolution is async, so we still get a loading emission
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            random: 0,
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(0);
+
+    // Make sure writing the same variables don't refetch unnecessarily
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "1" },
+    });
+    await expect(stream).not.toEmitAnything({ timeout: 200 });
+    expect(fetchCount).toBe(0);
+
+    cache.evict({
+      id: cache.identify({ __typename: "User", id: "1" }),
+      fieldName: "address",
+    });
+    cache.gc();
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "1",
+        user: {
+          __typename: "User",
+          id: "1",
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            random: 1,
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(1);
+  });
+
   test("merges concurrent cache updates during a streamed response when variables come from @export", async () => {
     const multipart = mockDeferStreamGraphQL17Alpha9();
 

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -982,17 +982,15 @@ describe("@client @export tests", () => {
     let fetchCount = 0;
     const link = new ApolloLink((operation) => {
       fetchCount += 1;
-      expect(operation.variables).toEqual({ userId });
+      const id = operation.variables.userId as string;
       return of({
         data: {
           user: {
             __typename: "User",
-            id: userId,
+            id,
             address: {
               __typename: "Address",
-              id: "addr-1",
-              // Change the field value per request so we can assert a refetch
-              // actually happened after the cache eviction.
+              id: `addr-${id}`,
               random: fetchCount,
             },
           },
@@ -1013,7 +1011,7 @@ describe("@client @export tests", () => {
           userId
         }
       `,
-      data: { userId },
+      data: { userId: "1" },
     });
 
     const stream = new ObservableStream(client.watchQuery({ query }));
@@ -1028,10 +1026,10 @@ describe("@client @export tests", () => {
 
     await expect(stream).toEmitTypedValue({
       data: {
-        userId,
+        userId: "1",
         user: {
           __typename: "User",
-          id: userId,
+          id: "1",
           address: {
             __typename: "Address",
             id: "addr-1",
@@ -1047,7 +1045,7 @@ describe("@client @export tests", () => {
     expect(fetchCount).toBe(1);
 
     cache.evict({
-      id: cache.identify({ __typename: "User", id: userId }),
+      id: cache.identify({ __typename: "User", id: "1" }),
       fieldName: "address",
     });
     cache.gc();
@@ -1062,10 +1060,10 @@ describe("@client @export tests", () => {
 
     await expect(stream).toEmitTypedValue({
       data: {
-        userId,
+        userId: "1",
         user: {
           __typename: "User",
-          id: userId,
+          id: "1",
           address: {
             __typename: "Address",
             id: "addr-1",
@@ -1079,6 +1077,77 @@ describe("@client @export tests", () => {
       partial: false,
     });
     expect(fetchCount).toBe(2);
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "2" },
+    });
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "2",
+        user: {
+          __typename: "User",
+          id: "2",
+          address: {
+            __typename: "Address",
+            id: "addr-2",
+            random: 3,
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(3);
+
+    cache.evict({
+      id: cache.identify({ __typename: "User", id: "2" }),
+      fieldName: "address",
+    });
+    cache.gc();
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "2",
+        user: {
+          __typename: "User",
+          id: "2",
+          address: {
+            __typename: "Address",
+            id: "addr-2",
+            random: 4,
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(4);
   });
 
   test("merges concurrent cache updates during a streamed response when variables come from @export", async () => {

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -1146,6 +1146,8 @@ describe("@client @export tests", () => {
       networkStatus: NetworkStatus.ready,
       partial: false,
     });
+
+    await expect(stream).not.toEmitAnything();
     expect(fetchCount).toBe(4);
   });
 
@@ -1289,6 +1291,8 @@ describe("@client @export tests", () => {
       networkStatus: NetworkStatus.ready,
       partial: false,
     });
+
+    await expect(stream).not.toEmitAnything();
     expect(fetchCount).toBe(1);
   });
 
@@ -1464,6 +1468,8 @@ describe("@client @export tests", () => {
       networkStatus: NetworkStatus.ready,
       partial: false,
     });
+
+    await expect(stream).not.toEmitAnything();
   });
 
   test("should update @client @export variables on each broadcast if they've changed", async () => {

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -978,7 +978,6 @@ describe("@client @export tests", () => {
       }
     `;
 
-    const userId = "1";
     let fetchCount = 0;
     const link = new ApolloLink((operation) => {
       fetchCount += 1;
@@ -1152,7 +1151,6 @@ describe("@client @export tests", () => {
 
   test("merges concurrent cache updates during a streamed response when variables come from @export", async () => {
     const multipart = mockDeferStreamGraphQL17Alpha9();
-    const userId = "1";
 
     const query = gql`
       query FriendListWithExport($userId: ID!) {
@@ -1177,7 +1175,7 @@ describe("@client @export tests", () => {
           userId
         }
       `,
-      data: { userId },
+      data: { userId: "1" },
     });
 
     const stream = new ObservableStream(client.watchQuery({ query }));
@@ -1200,7 +1198,7 @@ describe("@client @export tests", () => {
 
     await expect(stream).toEmitTypedValue({
       data: markAsStreaming({
-        userId,
+        userId: "1",
         friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
       }),
       dataState: "streaming",
@@ -1237,7 +1235,7 @@ describe("@client @export tests", () => {
 
     await expect(stream).toEmitTypedValue({
       data: {
-        userId,
+        userId: "1",
         friendList: [
           {
             __typename: "Friend",
@@ -1247,6 +1245,76 @@ describe("@client @export tests", () => {
           { __typename: "Friend", id: "2", name: "Han" },
           { __typename: "Friend", id: "3", name: "Leia" },
         ],
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId: "2" },
+    });
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    multipart.enqueueInitialChunk({
+      data: {
+        friendList: [{ __typename: "Friend", id: "10", name: "Padme" }],
+      },
+      pending: [],
+      hasNext: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "2",
+        friendList: [{ __typename: "Friend", id: "10", name: "Padme" }],
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    client.cache.evict({
+      id: "ROOT_QUERY",
+      fieldName: "friendList",
+      args: { userId: "2" },
+    });
+    client.cache.gc();
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    multipart.enqueueInitialChunk({
+      data: {
+        friendList: [{ __typename: "Friend", id: "10", name: "Amidala" }],
+      },
+      pending: [],
+      hasNext: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId: "2",
+        friendList: [{ __typename: "Friend", id: "10", name: "Amidala" }],
       },
       dataState: "complete",
       loading: false,

--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -960,6 +960,124 @@ describe("@client @export tests", () => {
     expect(fetchCount).toBe(1);
   });
 
+  // https://github.com/apollographql/apollo-client/issues/13335
+  test("should refetch when a remote field is missing from the cache and variables come from @export", async () => {
+    const query = gql`
+      query UserWithExport($userId: ID!) {
+        userId @client @export(as: "userId")
+        user(id: $userId) {
+          id
+          address {
+            id
+            random
+          }
+        }
+      }
+    `;
+
+    const userId = "1";
+    let fetchCount = 0;
+    const link = new ApolloLink((operation) => {
+      fetchCount += 1;
+      expect(operation.variables).toEqual({ userId });
+      return of({
+        data: {
+          user: {
+            __typename: "User",
+            id: userId,
+            address: {
+              __typename: "Address",
+              id: "addr-1",
+              // Change the field value per request so we can assert a refetch
+              // actually happened after the cache eviction.
+              random: fetchCount,
+            },
+          },
+        },
+      });
+    });
+
+    const cache = new InMemoryCache();
+    const client = new ApolloClient({
+      cache,
+      link,
+      localState: new LocalState(),
+    });
+
+    client.writeQuery({
+      query: gql`
+        {
+          userId
+        }
+      `,
+      data: { userId },
+    });
+
+    const stream = new ObservableStream(client.watchQuery({ query }));
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId,
+        user: {
+          __typename: "User",
+          id: userId,
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            random: 1,
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(1);
+
+    cache.evict({
+      id: cache.identify({ __typename: "User", id: userId }),
+      fieldName: "address",
+    });
+    cache.gc();
+
+    await expect(stream).toEmitSimilarValue({
+      expected: (previous) => ({
+        ...previous,
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+      }),
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        userId,
+        user: {
+          __typename: "User",
+          id: userId,
+          address: {
+            __typename: "Address",
+            id: "addr-1",
+            random: 2,
+          },
+        },
+      },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(fetchCount).toBe(2);
+  });
+
   test("should update @client @export variables on each broadcast if they've changed", async () => {
     const cache = new InMemoryCache();
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1932,15 +1932,53 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     },
     SubjectValue<TData, TVariables>
   > = filterMap((notification) => {
-    const { query, variables, meta } = notification;
+    const { query, meta } = notification;
 
     if (notification.source === "setResult") {
-      return { query, variables, result: notification.value, meta };
+      return {
+        query,
+        variables: this.variables,
+        result: notification.value,
+        meta,
+      };
     }
 
-    if (notification.kind === "C" || !isEqualQuery(notification, this)) {
+    if (notification.kind === "C") {
       return;
     }
+
+    const resolvedVariables =
+      "resolvedVariables" in notification ?
+        notification.resolvedVariables
+      : undefined;
+
+    // Usually we prefer to drop notifications that don't match this query
+    // but this breaks when used with `@export` queries that resolve variables
+    // after the request is initiated. `notification.resolvedVariables` gives us
+    // the variables the query actually resolved with during evaluation in
+    // QueryManager (which is the variables value after `@export` variables have
+    // been applied), but we need to update this query with those resolved
+    // variables maybe in the middle of a request (updating is handled below).
+    // When we update this.variables to the resolved variables, this causes
+    // isEqualQuery(notification, this) to fail for future notifications since
+    // the notification.variables holds the stale variables value. In this case,
+    // we want to allow the notification through only if the current variables
+    // value matches the resolved variables.
+    //
+    // Note: the check for matching resolved variables typically kicks in for
+    // multi-emission fetches (such as defer, or cache-and-network, etc).
+    if (!equal(resolvedVariables, this.variables)) {
+      if (!isEqualQuery(notification, this)) {
+        return;
+      }
+
+      if (resolvedVariables) {
+        this.options.variables = resolvedVariables as TVariables;
+        this.resubscribeCache();
+      }
+    }
+
+    const variables = this.variables;
 
     let result: ObservableQuery.Result<TData>;
     const previous = this.subject.getValue();
@@ -1964,7 +2002,11 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       result =
         notification.kind === "E" ?
           ({
-            ...(isEqualQuery(previous, notification) ?
+            ...((
+              isEqualQuery(previous, notification) ||
+              (resolvedVariables &&
+                equal(resolvedVariables, previous.variables))
+            ) ?
               previous.result
             : { data: undefined, dataState: "empty", partial: true }),
             error: notification.error,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1967,8 +1967,12 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     //
     // Note: the check for matching resolved variables typically kicks in for
     // multi-emission fetches (such as defer, or cache-and-network, etc).
+    if (notification.query !== this.query) {
+      return;
+    }
+
     if (!equal(resolvedVariables, this.variables)) {
-      if (!isEqualQuery(notification, this)) {
+      if (!equal(notification.variables, this.variables)) {
         return;
       }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1612,6 +1612,10 @@ export class QueryManager {
         return of({
           kind: "N",
           value: toResult(data),
+          // Always attach the variables used for this fetch so @export
+          // resolution can update ObservableQuery.options.variables and
+          // resubscribe the cache watch under the correct variable set.
+          resolvedVariables: variables,
           source: "cache",
         });
       };
@@ -1646,6 +1650,10 @@ export class QueryManager {
             (resolved): QueryNotification.FromCache<TData> => ({
               kind: "N",
               value: toResult(resolved.data || void 0),
+              // Always attach the variables used for this fetch so @export
+              // resolution can update ObservableQuery.options.variables and
+              // resubscribe the cache watch under the correct variable set.
+              resolvedVariables: variables,
               source: "cache",
             })
           )
@@ -1688,6 +1696,10 @@ export class QueryManager {
         map(
           (result): QueryNotification.FromNetwork<TData> => ({
             ...result,
+            // Always attach the variables used for this fetch so @export
+            // resolution can update ObservableQuery.options.variables and
+            // resubscribe the cache watch under the correct variable set.
+            resolvedVariables: variables,
             source: "network",
           })
         )

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -1399,6 +1399,82 @@ describe("ObservableQuery", () => {
       await promise;
       expect(client.getObservableQueries().size).toBe(0);
     });
+
+    it("ignores an in-flight result from the previous query after the query changes", async () => {
+      const initialQuery = gql`
+        query InitialQuery {
+          author {
+            firstName
+          }
+        }
+      `;
+
+      const updatedQuery = gql`
+        query UpdatedQuery {
+          product {
+            name
+          }
+        }
+      `;
+
+      const productData = {
+        product: { __typename: "Product", name: "Widget" },
+      };
+
+      const link = new MockSubscriptionLink();
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link,
+      });
+
+      client.writeQuery({ query: updatedQuery, data: productData });
+
+      const observable = client.watchQuery({ query: initialQuery });
+      const stream = new ObservableStream(observable);
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
+
+      void observable.reobserve({
+        query: updatedQuery,
+        // NOTE: `cache-only` is needed to reproduce because we don't
+        // unsubscribe from the old observable when the request doesn't hit the
+        // link chain.
+        fetchPolicy: "cache-only",
+      });
+
+      await expect(stream).toEmitTypedValue({
+        data: productData,
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+
+      link.simulateResult(
+        {
+          result: {
+            data: { author: { __typename: "Author", firstName: "John" } },
+          },
+        },
+        true
+      );
+
+      await expect(stream).not.toEmitAnything();
+
+      expect(observable.getCurrentResult()).toStrictEqualTyped({
+        data: productData,
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+    });
   });
 
   describe("setVariables", () => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -385,10 +385,12 @@ export declare namespace QueryNotification {
   type FromNetwork<TData> = ObservableNotification<
     ObservableQuery.Result<TData>
   > & {
+    resolvedVariables?: OperationVariables;
     source: "network";
   };
 
   type FromCache<TData> = NextNotification<ObservableQuery.Result<TData>> & {
+    resolvedVariables?: OperationVariables;
     source: "cache";
   };
 


### PR DESCRIPTION
Fixes #13335

We had a regression in 4.x with regards to `@export` fields where queries would sometimes not respond to cache updates. This happened when a field changed an object that depended on the variables keyed by the `@export` values.

```gql
query ($userId: ID!) {
  userId @client @export(as: "userId")
  user(id: $userId) {
    id
    name
  }
}
```

In this case, `ObservableQuery` subscribed to the cache using the initial empty variables value, but never resubscribed after export variables were known. This meant changes to data inside that `user` object never notified the query of the change.

This fix now emits a `resolvedVariables` value along with the notification to `ObservableQuery` so that `ObservableQuery` can update its `variables` and resubscribe to the cache using the export variables. I added a whole bunch of other tests to catch other potential edge cases to make sure we didn't miss this for other situations. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reactivity issues affecting queries that use `@export` variables.
  * Cache updates now correctly trigger refreshed results when exported-variable fields change or are evicted.
  * Improved behavior for refetching, partial data, cache-and-network requests, and network-only requests.
  * Improved handling of streamed responses and variable changes during in-flight requests.

* **Tests**
  * Added coverage for cache, network, refetch, partial-result, and streaming scenarios involving `@export` variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->