### PR TITLE
Parse scalars for `no-cache` queries

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -96,6 +96,7 @@ export abstract class ApolloCache {
     // (undocumented)
     readonly assumeImmutableResults: boolean;
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    configuresScalars(): boolean;
     abstract diff<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: Cache_2.DiffOptions<TData, TVariables> & {
         [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
     }): Cache_2.InternalDiffResultWithDataState<TData> | Cache_2.DiffResult<TData>;
@@ -110,11 +111,10 @@ export abstract class ApolloCache {
     gc(): string[];
     // @internal @deprecated
     getMemoryInternals?: typeof getApolloCacheMemoryInternals;
-    // (undocumented)
-    getRootTypename(operation: OperationTypeNode): string | undefined;
+    getRootTypename(operation: OperationTypeNode): string;
     // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> | undefined;
-    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
+    getScalarForField<TSerialized = unknown, TParsed = unknown>(typename: string, fieldName: string): Scalar<TSerialized, TParsed> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -650,6 +650,8 @@ export class InMemoryCache extends ApolloCache {
     // (undocumented)
     protected config: InMemoryCacheConfig;
     // (undocumented)
+    configuresScalars(): boolean;
+    // (undocumented)
     diff<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: Cache_2.DiffOptions<TData, TVariables> & {
         [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
     }): Cache_2.InternalDiffResultWithDataState<TData>;
@@ -671,7 +673,7 @@ export class InMemoryCache extends ApolloCache {
     getRootTypename(operation: OperationTypeNode): string;
     // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> extends (Scalar<infer TSerialized, infer TParsed>) ? IsLooselyEqual<TSerialized, TParsed> extends true ? ApolloCache.GetScalarType<TKey> | undefined : ApolloCache.GetScalarType<TKey> : never;
-    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
+    getScalarForField<TSerialized = unknown, TParsed = unknown>(typename: string, fieldName: string): Scalar<TSerialized, TParsed> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -1161,8 +1163,8 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/cache.ts:205:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
-// src/cache/inmemory/inMemoryCache.ts:469:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/core/cache.ts:206:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/inmemory/inMemoryCache.ts:473:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
 // src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:179:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:147:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -30,6 +30,7 @@ import type { IsLooselyEqual } from '@apollo/client/utilities/internal';
 import { isReference } from '@apollo/client/utilities';
 import type { NoInfer as NoInfer_2 } from '@apollo/client/utilities/internal';
 import { Observable } from 'rxjs';
+import type { OperationTypeNode } from 'graphql';
 import type { OperationVariables } from '@apollo/client';
 import type { Prettify } from '@apollo/client/utilities/internal';
 import { Reference } from '@apollo/client/utilities';
@@ -110,7 +111,10 @@ export abstract class ApolloCache {
     // @internal @deprecated
     getMemoryInternals?: typeof getApolloCacheMemoryInternals;
     // (undocumented)
+    getRootTypename(operation: OperationTypeNode): string | undefined;
+    // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> | undefined;
+    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -664,7 +668,10 @@ export class InMemoryCache extends ApolloCache {
     // @internal @deprecated
     getMemoryInternals?: typeof getInMemoryCacheMemoryInternals;
     // (undocumented)
+    getRootTypename(operation: OperationTypeNode): string;
+    // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> extends (Scalar<infer TSerialized, infer TParsed>) ? IsLooselyEqual<TSerialized, TParsed> extends true ? ApolloCache.GetScalarType<TKey> | undefined : ApolloCache.GetScalarType<TKey> : never;
+    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -1154,8 +1161,8 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/cache.ts:204:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
-// src/cache/inmemory/inMemoryCache.ts:456:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/core/cache.ts:205:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/inmemory/inMemoryCache.ts:469:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
 // src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:179:3 - (ae-forgotten-export) The symbol "ScalarNames" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:147:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1376,7 +1376,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 //
 // src/core/ApolloClient.ts:635:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1406,7 +1406,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 //
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:406:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:197:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -95,7 +95,7 @@ export type ClassicSignature = SignatureStyle extends "classic" ? unknown : neve
 // @internal @deprecated
 export function cloneDeep<T>(value: T): T;
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export function coerceScalarFieldsToParsed(result: Record<string, any>, query: DocumentNode, cache: ApolloCache): Record<string, any>;
 
 // @public

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -4,7 +4,8 @@
 
 ```ts
 
-import type { ApolloCache } from '@apollo/client';
+import type { ApolloCache } from '@apollo/client/cache';
+import type { ApolloCache as ApolloCache_2 } from '@apollo/client';
 import type { ApolloClient } from '@apollo/client';
 import type { ASTNode } from 'graphql';
 import type { Cache as Cache_2 } from '@apollo/client/cache';
@@ -90,6 +91,9 @@ export type ClassicSignature = SignatureStyle extends "classic" ? unknown : neve
 
 // @internal @deprecated
 export function cloneDeep<T>(value: T): T;
+
+// @public (undocumented)
+export function coerceScalarFieldsToParsed(result: Record<string, any>, query: DocumentNode, cache: ApolloCache): Record<string, any>;
 
 // @public
 export function combineLatestBatched<T>(observables: Array<Observable<T> & {
@@ -433,7 +437,7 @@ export function makeStreamInfoTrie(): StreamInfoTrie;
 export function makeUniqueId(prefix: string): string;
 
 // @public (undocumented)
-export const mapObservableFragmentMemoized: <From, To>(observable: ApolloCache.ObservableFragment<From>, _cacheKey: symbol, mapFn: (from: ApolloCache.WatchFragmentResult<From>) => ApolloCache.WatchFragmentResult<To>) => ApolloCache.ObservableFragment<To>;
+export const mapObservableFragmentMemoized: <From, To>(observable: ApolloCache_2.ObservableFragment<From>, _cacheKey: symbol, mapFn: (from: ApolloCache_2.WatchFragmentResult<From>) => ApolloCache_2.WatchFragmentResult<To>) => ApolloCache_2.ObservableFragment<To>;
 
 // @internal @deprecated (undocumented)
 export function maybeDeepFreeze<T>(obj: T): T;

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -83,6 +83,9 @@ export const canonicalStringify: ((value: any) => string) & {
 // @internal @deprecated (undocumented)
 export const canUseDOM: boolean;
 
+// @internal @deprecated (undocumented)
+export function capitalize(str: string): string;
+
 // @internal @deprecated
 export const checkDocument: (doc: DocumentNode, expectedType?: OperationTypeNode) => void;
 

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -4,7 +4,8 @@
 
 ```ts
 
-import type { ApolloCache } from '@apollo/client';
+import type { ApolloCache } from '@apollo/client/cache';
+import type { ApolloCache as ApolloCache_2 } from '@apollo/client';
 import type { ApolloClient } from '@apollo/client';
 import type { ASTNode } from 'graphql';
 import type { DataValue } from '@apollo/client';
@@ -85,6 +86,9 @@ export type ClassicSignature = SignatureStyle extends "classic" ? unknown : neve
 
 // @internal @deprecated
 export function cloneDeep<T>(value: T): T;
+
+// @public (undocumented)
+export function coerceScalarFieldsToParsed(result: Record<string, any>, query: DocumentNode, cache: ApolloCache): Record<string, any>;
 
 // @public
 export function combineLatestBatched<T>(observables: Array<Observable<T> & {
@@ -425,7 +429,7 @@ export function makeStreamInfoTrie(): StreamInfoTrie;
 export function makeUniqueId(prefix: string): string;
 
 // @public (undocumented)
-export const mapObservableFragmentMemoized: <From, To>(observable: ApolloCache.ObservableFragment<From>, _cacheKey: symbol, mapFn: (from: ApolloCache.WatchFragmentResult<From>) => ApolloCache.WatchFragmentResult<To>) => ApolloCache.ObservableFragment<To>;
+export const mapObservableFragmentMemoized: <From, To>(observable: ApolloCache_2.ObservableFragment<From>, _cacheKey: symbol, mapFn: (from: ApolloCache_2.WatchFragmentResult<From>) => ApolloCache_2.WatchFragmentResult<To>) => ApolloCache_2.ObservableFragment<To>;
 
 // @internal @deprecated (undocumented)
 export function maybeDeepFreeze<T>(obj: T): T;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -104,7 +104,10 @@ export abstract class ApolloCache {
     // @internal @deprecated
     getMemoryInternals?: typeof getApolloCacheMemoryInternals;
     // (undocumented)
+    getRootTypename(operation: OperationTypeNode): string | undefined;
+    // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> | undefined;
+    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -1696,7 +1699,10 @@ export class InMemoryCache extends ApolloCache {
     // @internal @deprecated
     getMemoryInternals?: typeof getInMemoryCacheMemoryInternals;
     // (undocumented)
+    getRootTypename(operation: OperationTypeNode): string;
+    // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> extends (Scalar<infer TSerialized, infer TParsed>) ? IsLooselyEqual<TSerialized, TParsed> extends true ? ApolloCache.GetScalarType<TKey> | undefined : ApolloCache.GetScalarType<TKey> : never;
+    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -3251,8 +3257,8 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/cache.ts:129:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
-// src/cache/core/cache.ts:204:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:130:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:205:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:104:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
@@ -3262,7 +3268,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ApolloClient.ts:201:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:635:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:202:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:245:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -104,7 +104,10 @@ export abstract class ApolloCache {
     // @internal @deprecated
     getMemoryInternals?: typeof getApolloCacheMemoryInternals;
     // (undocumented)
+    getRootTypename(operation: OperationTypeNode): string | undefined;
+    // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> | undefined;
+    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -1750,7 +1753,10 @@ export class InMemoryCache extends ApolloCache {
     // @internal @deprecated
     getMemoryInternals?: typeof getInMemoryCacheMemoryInternals;
     // (undocumented)
+    getRootTypename(operation: OperationTypeNode): string;
+    // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> extends (Scalar<infer TSerialized, infer TParsed>) ? IsLooselyEqual<TSerialized, TParsed> extends true ? ApolloCache.GetScalarType<TKey> | undefined : ApolloCache.GetScalarType<TKey> : never;
+    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -3307,8 +3313,8 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/cache.ts:129:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
-// src/cache/core/cache.ts:204:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:130:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:205:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:104:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
@@ -3318,7 +3324,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:406:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:197:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:202:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:245:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -87,6 +87,7 @@ export abstract class ApolloCache {
     // (undocumented)
     readonly assumeImmutableResults: boolean;
     batch<U>(options: Cache_2.BatchOptions<this, U>): U;
+    configuresScalars(): boolean;
     abstract diff<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: Cache_2.DiffOptions<TData, TVariables> & {
         [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
     }): Cache_2.InternalDiffResultWithDataState<TData> | Cache_2.DiffResult<TData>;
@@ -103,11 +104,10 @@ export abstract class ApolloCache {
     //
     // @internal @deprecated
     getMemoryInternals?: typeof getApolloCacheMemoryInternals;
-    // (undocumented)
-    getRootTypename(operation: OperationTypeNode): string | undefined;
+    getRootTypename(operation: OperationTypeNode): string;
     // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> | undefined;
-    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
+    getScalarForField<TSerialized = unknown, TParsed = unknown>(typename: string, fieldName: string): Scalar<TSerialized, TParsed> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -1733,6 +1733,8 @@ export class InMemoryCache extends ApolloCache {
     // (undocumented)
     protected config: InMemoryCacheConfig;
     // (undocumented)
+    configuresScalars(): boolean;
+    // (undocumented)
     diff<TData = unknown, TVariables extends OperationVariables = OperationVariables>(query: Cache_2.DiffOptions<TData, TVariables> & {
         [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
     }): Cache_2.InternalDiffResultWithDataState<TData>;
@@ -1756,7 +1758,7 @@ export class InMemoryCache extends ApolloCache {
     getRootTypename(operation: OperationTypeNode): string;
     // (undocumented)
     getScalar<TKey extends keyof ApolloCache.Scalars>(key: TKey): ApolloCache.GetScalarType<TKey> extends (Scalar<infer TSerialized, infer TParsed>) ? IsLooselyEqual<TSerialized, TParsed> extends true ? ApolloCache.GetScalarType<TKey> | undefined : ApolloCache.GetScalarType<TKey> : never;
-    getScalarForField(typename: string, fieldName: string): Scalar<unknown, unknown> | undefined;
+    getScalarForField<TSerialized = unknown, TParsed = unknown>(typename: string, fieldName: string): Scalar<TSerialized, TParsed> | undefined;
     // (undocumented)
     identify(object: StoreObject | Reference): string | undefined;
     // (undocumented)
@@ -3313,8 +3315,8 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/cache.ts:130:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
-// src/cache/core/cache.ts:205:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:131:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:206:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:104:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:176:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts

--- a/.changeset/nasty-keys-brush.md
+++ b/.changeset/nasty-keys-brush.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Parse scalar fields for `no-cache` queries.

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -446,6 +446,7 @@ Array [
   "canonicalStringify",
   "checkDocument",
   "cloneDeep",
+  "coerceScalarFieldsToParsed",
   "combineLatestBatched",
   "compact",
   "createFragmentMap",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -445,6 +445,7 @@ Array [
   "bindCacheKey",
   "canUseDOM",
   "canonicalStringify",
+  "capitalize",
   "checkDocument",
   "cloneDeep",
   "coerceScalarFieldsToParsed",

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -447,6 +447,7 @@ Array [
   "canonicalStringify",
   "checkDocument",
   "cloneDeep",
+  "coerceScalarFieldsToParsed",
   "combineLatestBatched",
   "compact",
   "createFragmentMap",

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -264,8 +264,8 @@ export abstract class ApolloCache {
     return null;
   }
 
-  public getRootTypename(operation: OperationTypeNode) {
-    return operation[0].toUpperCase() + operation.slice(1);
+  public getRootTypename(operation: OperationTypeNode): string | undefined {
+    return;
   }
 
   // Custom scalars API

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -277,10 +277,10 @@ export abstract class ApolloCache {
   }
 
   /** Get a scalar instance for a field in a type */
-  public getScalarForField(
+  public getScalarForField<TSerialized = unknown, TParsed = unknown>(
     typename: string,
     fieldName: string
-  ): Scalar<unknown, unknown> | undefined {
+  ): Scalar<TSerialized, TParsed> | undefined {
     return;
   }
 

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -291,6 +291,19 @@ export abstract class ApolloCache {
   }
 
   /**
+   * Determines whether the cache configures custom scalars or not. This allows
+   * Apollo Client to skip processing results unnecessarily when there is
+   * nothing to transform into a scalar value.
+   *
+   * @remarks
+   * 3rd party caches should override this method if they have the ability to
+   * configure scalar implementations.
+   */
+  public configuresScalars() {
+    return false;
+  }
+
+  /**
    * Serializes scalar values in the variables object
    */
   public serializeVariables<

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -271,6 +271,14 @@ export abstract class ApolloCache {
     return;
   }
 
+  /** Get a scalar instance for a field in a type */
+  public getScalarForField(
+    typename: string,
+    fieldName: string
+  ): Scalar<unknown, unknown> | undefined {
+    return;
+  }
+
   /**
    * Serializes scalar values in the variables object
    */

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -37,6 +37,7 @@ import type {
 } from "@apollo/client/utilities/internal";
 import {
   bindCacheKey,
+  capitalize,
   combineLatestBatched,
   equalByQuery,
   getApolloCacheMemoryInternals,
@@ -264,8 +265,13 @@ export abstract class ApolloCache {
     return null;
   }
 
+  /**
+   * Get the root \_\_typename string for an operation type.
+   *
+   * @defaultValue Query, Mutation, or Subscription
+   */
   public getRootTypename(operation: OperationTypeNode): string {
-    return operation.at(0)!.toUpperCase() + operation.slice(1);
+    return capitalize(operation);
   }
 
   // Custom scalars API

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -264,8 +264,8 @@ export abstract class ApolloCache {
     return null;
   }
 
-  public getRootTypename(operation: OperationTypeNode): string | undefined {
-    return;
+  public getRootTypename(operation: OperationTypeNode): string {
+    return operation.at(0)!.toUpperCase() + operation.slice(1);
   }
 
   // Custom scalars API

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -266,7 +266,7 @@ export abstract class ApolloCache {
   }
 
   /**
-   * Get the root \_\_typename string for an operation type.
+   * Get the root typename value for an operation type.
    *
    * @defaultValue Query, Mutation, or Subscription
    */

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -5,6 +5,7 @@ import type {
   DocumentNode,
   FragmentDefinitionNode,
   InlineFragmentNode,
+  OperationTypeNode,
 } from "graphql";
 import { wrap } from "optimism";
 import {
@@ -261,6 +262,10 @@ export abstract class ApolloCache {
   // that register fragments ahead of time so they can be referenced by name.
   public lookupFragment(fragmentName: string): FragmentDefinitionNode | null {
     return null;
+  }
+
+  public getRootTypename(operation: OperationTypeNode) {
+    return operation[0].toUpperCase() + operation.slice(1);
   }
 
   // Custom scalars API

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -226,10 +226,10 @@ export class InMemoryCache extends ApolloCache {
   }
 
   /** Get a scalar instance for a field in a type */
-  public getScalarForField(
+  public getScalarForField<TSerialized = unknown, TParsed = unknown>(
     typename: string,
     fieldName: string
-  ): Scalar<unknown, unknown> | undefined {
+  ): Scalar<TSerialized, TParsed> | undefined {
     return this.policies.getScalarForField(typename, fieldName);
   }
 

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -233,6 +233,10 @@ export class InMemoryCache extends ApolloCache {
     return this.policies.getScalarForField(typename, fieldName);
   }
 
+  public configuresScalars(): boolean {
+    return !!this.config.scalars;
+  }
+
   /**
    * {@inheritDoc @apollo/client/cache!ApolloCache#serializeVariables:member(1)}
    */

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -220,6 +220,14 @@ export class InMemoryCache extends ApolloCache {
     return this.config.scalars?.[key as string] as any;
   }
 
+  /** Get a scalar instance for a field in a type */
+  public getScalarForField(
+    typename: string,
+    fieldName: string
+  ): Scalar<unknown, unknown> | undefined {
+    return this.policies.getScalarForField(typename, fieldName);
+  }
+
   /**
    * {@inheritDoc @apollo/client/cache!ApolloCache#serializeVariables:member(1)}
    */

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -3,6 +3,7 @@ import type {
   DocumentNode,
   FragmentDefinitionNode,
   InlineFragmentNode,
+  OperationTypeNode,
 } from "graphql";
 import type { OptimisticWrapperFunction } from "optimism";
 import { wrap } from "optimism";
@@ -204,6 +205,10 @@ export class InMemoryCache extends ApolloCache {
     new Set([this.data.group, this.optimisticData.group]).forEach((group) =>
       group.resetCaching()
     );
+  }
+
+  public getRootTypename(operation: OperationTypeNode): string {
+    return this.policies.rootTypenamesById[`ROOT_${operation.toUpperCase()}`];
   }
 
   public getScalar<TKey extends keyof ApolloCache.Scalars>(

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1806,7 +1806,6 @@ export class QueryManager {
           observable: resultsFromLink().pipe(
             map((notification) => {
               if (
-                notification.source === "network" &&
                 notification.kind === "N" &&
                 notification.value.data != null
               ) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -4,6 +4,7 @@ import type {
   DocumentNode,
   FormattedExecutionResult,
 } from "graphql";
+import type { SelectionSetNode } from "graphql";
 import { BREAK, Kind, OperationTypeNode, visit } from "graphql";
 import { Observable, throwError } from "rxjs";
 import {
@@ -43,27 +44,36 @@ import type { DeepPartial } from "@apollo/client/utilities";
 import {
   cacheSizes,
   DocumentTransform,
+  getMainDefinition,
   isNetworkRequestInFlight,
   print,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import type { ExtensionsWithStreamInfo } from "@apollo/client/utilities/internal";
+import type {
+  ExtensionsWithStreamInfo,
+  FragmentMap,
+} from "@apollo/client/utilities/internal";
 import {
   AutoCleanedWeakCache,
   checkDocument,
+  createFragmentMap,
   extensionsSymbol,
   filterMap,
   getDefaultValues,
+  getFragmentDefinitions,
+  getFragmentFromSelection,
   getOperationDefinition,
   getOperationName,
   graphQLResultHasError,
   hasDirectives,
   hasForcedResolvers,
   isDocumentNode,
+  isField,
   isNonNullObject,
   makeUniqueId,
   mergeOptions,
   removeDirectivesFromDocument,
+  resultKeyNameFromField,
   streamInfoSymbol,
   toQueryResult,
 } from "@apollo/client/utilities/internal";
@@ -1790,11 +1800,110 @@ export class QueryManager {
         };
 
       case "no-cache":
-        return { fromLink: true, observable: resultsFromLink() };
+        return {
+          fromLink: true,
+          observable: resultsFromLink().pipe(
+            map((notification) => {
+              if (
+                notification.source !== "network" ||
+                notification.kind !== "N"
+              ) {
+                return notification;
+              }
+
+              return {
+                ...notification,
+                value: {
+                  ...notification.value,
+                  data: this.processScalars(query, notification.value.data),
+                },
+              };
+            })
+          ),
+        };
 
       case "standby":
         return { fromLink: false, observable: EMPTY };
     }
+  }
+
+  private processScalars(query: DocumentNode, data: unknown): any {
+    const process = (
+      selectionSet: SelectionSetNode,
+      data: any,
+      fragmentMap: FragmentMap
+    ): any => {
+      if (data == null) return data;
+
+      const result: Record<string, any> = {};
+      let changed = false;
+
+      for (const selection of selectionSet.selections) {
+        if (isField(selection)) {
+          const resultName = resultKeyNameFromField(selection);
+          const fieldValue = data[resultName];
+
+          if (Array.isArray(fieldValue)) {
+            const processed = fieldValue.map((item) => {
+              const processedItem = process(selectionSet, item, fragmentMap);
+              changed ||= item !== processedItem;
+
+              return processedItem;
+            });
+
+            result[resultName] = processed;
+
+            continue;
+          } else if (selection.selectionSet) {
+            const processed = process(
+              selection.selectionSet,
+              fieldValue,
+              fragmentMap
+            );
+
+            changed ||= processed !== fieldValue;
+            result[resultName] = processed;
+
+            continue;
+          }
+
+          const typename =
+            Object.hasOwn(data, "__typename") ? data.__typename : undefined;
+
+          if (!typename) {
+            return data;
+          }
+
+          const scalar = this.cache.getScalarForField(
+            typename,
+            selection.name.value
+          );
+
+          if (scalar) {
+            result[resultName] = scalar.coerceToParsed(fieldValue);
+            changed = true;
+          } else {
+            result[resultName] = fieldValue;
+          }
+        } else {
+          const fragment = getFragmentFromSelection(selection, fragmentMap);
+
+          const processed =
+            fragment ? process(fragment.selectionSet, data, fragmentMap) : data;
+          changed ||= processed !== data;
+
+          Object.assign(result, processed);
+        }
+      }
+
+      return changed ? result : data;
+    };
+
+    return process(
+      getMainDefinition(query).selectionSet,
+      data,
+      createFragmentMap(getFragmentDefinitions(query))
+    );
   }
 }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1772,7 +1772,6 @@ export class QueryManager {
           observable: resultsFromLink().pipe(
             map((notification) => {
               if (
-                notification.source === "network" &&
                 notification.kind === "N" &&
                 notification.value.data != null
               ) {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -56,6 +56,7 @@ import type {
 import {
   AutoCleanedWeakCache,
   checkDocument,
+  coerceScalarFieldsToParsed,
   createFragmentMap,
   extensionsSymbol,
   filterMap,
@@ -1805,19 +1806,18 @@ export class QueryManager {
           observable: resultsFromLink().pipe(
             map((notification) => {
               if (
-                notification.source !== "network" ||
-                notification.kind !== "N"
+                notification.source === "network" &&
+                notification.kind === "N" &&
+                notification.value.data != null
               ) {
-                return notification;
+                notification.value.data = coerceScalarFieldsToParsed(
+                  notification.value.data,
+                  query,
+                  this.cache
+                ) as TData;
               }
 
-              return {
-                ...notification,
-                value: {
-                  ...notification.value,
-                  data: this.processScalars(query, notification.value.data),
-                },
-              };
+              return notification;
             })
           ),
         };
@@ -1825,85 +1825,6 @@ export class QueryManager {
       case "standby":
         return { fromLink: false, observable: EMPTY };
     }
-  }
-
-  private processScalars(query: DocumentNode, data: unknown): any {
-    const process = (
-      selectionSet: SelectionSetNode,
-      data: any,
-      fragmentMap: FragmentMap
-    ): any => {
-      if (data == null) return data;
-
-      const result: Record<string, any> = {};
-      let changed = false;
-
-      for (const selection of selectionSet.selections) {
-        if (isField(selection)) {
-          const resultName = resultKeyNameFromField(selection);
-          const fieldValue = data[resultName];
-
-          if (Array.isArray(fieldValue)) {
-            const processed = fieldValue.map((item) => {
-              const processedItem = process(selectionSet, item, fragmentMap);
-              changed ||= item !== processedItem;
-
-              return processedItem;
-            });
-
-            result[resultName] = processed;
-
-            continue;
-          } else if (selection.selectionSet) {
-            const processed = process(
-              selection.selectionSet,
-              fieldValue,
-              fragmentMap
-            );
-
-            changed ||= processed !== fieldValue;
-            result[resultName] = processed;
-
-            continue;
-          }
-
-          const typename =
-            Object.hasOwn(data, "__typename") ? data.__typename : undefined;
-
-          if (!typename) {
-            return data;
-          }
-
-          const scalar = this.cache.getScalarForField(
-            typename,
-            selection.name.value
-          );
-
-          if (scalar) {
-            result[resultName] = scalar.coerceToParsed(fieldValue);
-            changed = true;
-          } else {
-            result[resultName] = fieldValue;
-          }
-        } else {
-          const fragment = getFragmentFromSelection(selection, fragmentMap);
-
-          const processed =
-            fragment ? process(fragment.selectionSet, data, fragmentMap) : data;
-          changed ||= processed !== data;
-
-          Object.assign(result, processed);
-        }
-      }
-
-      return changed ? result : data;
-    };
-
-    return process(
-      getMainDefinition(query).selectionSet,
-      data,
-      createFragmentMap(getFragmentDefinitions(query))
-    );
   }
 }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1797,7 +1797,8 @@ export class QueryManager {
             map((notification) => {
               if (
                 notification.kind === "N" &&
-                notification.value.data != null
+                notification.value.data != null &&
+                this.cache.configuresScalars()
               ) {
                 notification.value.data = coerceScalarFieldsToParsed(
                   notification.value.data,

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -4,7 +4,6 @@ import type {
   DocumentNode,
   FormattedExecutionResult,
 } from "graphql";
-import type { SelectionSetNode } from "graphql";
 import { BREAK, Kind, OperationTypeNode, visit } from "graphql";
 import { Observable, throwError } from "rxjs";
 import {
@@ -44,37 +43,28 @@ import type { DeepPartial } from "@apollo/client/utilities";
 import {
   cacheSizes,
   DocumentTransform,
-  getMainDefinition,
   isNetworkRequestInFlight,
   print,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import type {
-  ExtensionsWithStreamInfo,
-  FragmentMap,
-} from "@apollo/client/utilities/internal";
+import type { ExtensionsWithStreamInfo } from "@apollo/client/utilities/internal";
 import {
   AutoCleanedWeakCache,
   checkDocument,
   coerceScalarFieldsToParsed,
-  createFragmentMap,
   extensionsSymbol,
   filterMap,
   getDefaultValues,
-  getFragmentDefinitions,
-  getFragmentFromSelection,
   getOperationDefinition,
   getOperationName,
   graphQLResultHasError,
   hasDirectives,
   hasForcedResolvers,
   isDocumentNode,
-  isField,
   isNonNullObject,
   makeUniqueId,
   mergeOptions,
   removeDirectivesFromDocument,
-  resultKeyNameFromField,
   streamInfoSymbol,
   toQueryResult,
 } from "@apollo/client/utilities/internal";

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -4,6 +4,7 @@ import type {
   DocumentNode,
   FormattedExecutionResult,
 } from "graphql";
+import type { SelectionSetNode } from "graphql";
 import { BREAK, Kind, OperationTypeNode, visit } from "graphql";
 import { Observable, throwError } from "rxjs";
 import {
@@ -43,27 +44,36 @@ import type { DeepPartial } from "@apollo/client/utilities";
 import {
   cacheSizes,
   DocumentTransform,
+  getMainDefinition,
   isNetworkRequestInFlight,
   print,
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
-import type { ExtensionsWithStreamInfo } from "@apollo/client/utilities/internal";
+import type {
+  ExtensionsWithStreamInfo,
+  FragmentMap,
+} from "@apollo/client/utilities/internal";
 import {
   AutoCleanedWeakCache,
   checkDocument,
+  createFragmentMap,
   extensionsSymbol,
   filterMap,
   getDefaultValues,
+  getFragmentDefinitions,
+  getFragmentFromSelection,
   getOperationDefinition,
   getOperationName,
   graphQLResultHasError,
   hasDirectives,
   hasForcedResolvers,
   isDocumentNode,
+  isField,
   isNonNullObject,
   makeUniqueId,
   mergeOptions,
   removeDirectivesFromDocument,
+  resultKeyNameFromField,
   streamInfoSymbol,
   toQueryResult,
 } from "@apollo/client/utilities/internal";
@@ -1756,11 +1766,110 @@ export class QueryManager {
         return { fromLink: true, observable: resultsFromLink() };
 
       case "no-cache":
-        return { fromLink: true, observable: resultsFromLink() };
+        return {
+          fromLink: true,
+          observable: resultsFromLink().pipe(
+            map((notification) => {
+              if (
+                notification.source !== "network" ||
+                notification.kind !== "N"
+              ) {
+                return notification;
+              }
+
+              return {
+                ...notification,
+                value: {
+                  ...notification.value,
+                  data: this.processScalars(query, notification.value.data),
+                },
+              };
+            })
+          ),
+        };
 
       case "standby":
         return { fromLink: false, observable: EMPTY };
     }
+  }
+
+  private processScalars(query: DocumentNode, data: unknown): any {
+    const process = (
+      selectionSet: SelectionSetNode,
+      data: any,
+      fragmentMap: FragmentMap
+    ): any => {
+      if (data == null) return data;
+
+      const result: Record<string, any> = {};
+      let changed = false;
+
+      for (const selection of selectionSet.selections) {
+        if (isField(selection)) {
+          const resultName = resultKeyNameFromField(selection);
+          const fieldValue = data[resultName];
+
+          if (Array.isArray(fieldValue)) {
+            const processed = fieldValue.map((item) => {
+              const processedItem = process(selectionSet, item, fragmentMap);
+              changed ||= item !== processedItem;
+
+              return processedItem;
+            });
+
+            result[resultName] = processed;
+
+            continue;
+          } else if (selection.selectionSet) {
+            const processed = process(
+              selection.selectionSet,
+              fieldValue,
+              fragmentMap
+            );
+
+            changed ||= processed !== fieldValue;
+            result[resultName] = processed;
+
+            continue;
+          }
+
+          const typename =
+            Object.hasOwn(data, "__typename") ? data.__typename : undefined;
+
+          if (!typename) {
+            return data;
+          }
+
+          const scalar = this.cache.getScalarForField(
+            typename,
+            selection.name.value
+          );
+
+          if (scalar) {
+            result[resultName] = scalar.coerceToParsed(fieldValue);
+            changed = true;
+          } else {
+            result[resultName] = fieldValue;
+          }
+        } else {
+          const fragment = getFragmentFromSelection(selection, fragmentMap);
+
+          const processed =
+            fragment ? process(fragment.selectionSet, data, fragmentMap) : data;
+          changed ||= processed !== data;
+
+          Object.assign(result, processed);
+        }
+      }
+
+      return changed ? result : data;
+    };
+
+    return process(
+      getMainDefinition(query).selectionSet,
+      data,
+      createFragmentMap(getFragmentDefinitions(query))
+    );
   }
 }
 

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -56,6 +56,7 @@ import type {
 import {
   AutoCleanedWeakCache,
   checkDocument,
+  coerceScalarFieldsToParsed,
   createFragmentMap,
   extensionsSymbol,
   filterMap,
@@ -1771,19 +1772,18 @@ export class QueryManager {
           observable: resultsFromLink().pipe(
             map((notification) => {
               if (
-                notification.source !== "network" ||
-                notification.kind !== "N"
+                notification.source === "network" &&
+                notification.kind === "N" &&
+                notification.value.data != null
               ) {
-                return notification;
+                notification.value.data = coerceScalarFieldsToParsed(
+                  notification.value.data,
+                  query,
+                  this.cache
+                ) as TData;
               }
 
-              return {
-                ...notification,
-                value: {
-                  ...notification.value,
-                  data: this.processScalars(query, notification.value.data),
-                },
-              };
+              return notification;
             })
           ),
         };
@@ -1791,85 +1791,6 @@ export class QueryManager {
       case "standby":
         return { fromLink: false, observable: EMPTY };
     }
-  }
-
-  private processScalars(query: DocumentNode, data: unknown): any {
-    const process = (
-      selectionSet: SelectionSetNode,
-      data: any,
-      fragmentMap: FragmentMap
-    ): any => {
-      if (data == null) return data;
-
-      const result: Record<string, any> = {};
-      let changed = false;
-
-      for (const selection of selectionSet.selections) {
-        if (isField(selection)) {
-          const resultName = resultKeyNameFromField(selection);
-          const fieldValue = data[resultName];
-
-          if (Array.isArray(fieldValue)) {
-            const processed = fieldValue.map((item) => {
-              const processedItem = process(selectionSet, item, fragmentMap);
-              changed ||= item !== processedItem;
-
-              return processedItem;
-            });
-
-            result[resultName] = processed;
-
-            continue;
-          } else if (selection.selectionSet) {
-            const processed = process(
-              selection.selectionSet,
-              fieldValue,
-              fragmentMap
-            );
-
-            changed ||= processed !== fieldValue;
-            result[resultName] = processed;
-
-            continue;
-          }
-
-          const typename =
-            Object.hasOwn(data, "__typename") ? data.__typename : undefined;
-
-          if (!typename) {
-            return data;
-          }
-
-          const scalar = this.cache.getScalarForField(
-            typename,
-            selection.name.value
-          );
-
-          if (scalar) {
-            result[resultName] = scalar.coerceToParsed(fieldValue);
-            changed = true;
-          } else {
-            result[resultName] = fieldValue;
-          }
-        } else {
-          const fragment = getFragmentFromSelection(selection, fragmentMap);
-
-          const processed =
-            fragment ? process(fragment.selectionSet, data, fragmentMap) : data;
-          changed ||= processed !== data;
-
-          Object.assign(result, processed);
-        }
-      }
-
-      return changed ? result : data;
-    };
-
-    return process(
-      getMainDefinition(query).selectionSet,
-      data,
-      createFragmentMap(getFragmentDefinitions(query))
-    );
   }
 }
 

--- a/src/core/__tests__/client.query/customScalars.test.ts
+++ b/src/core/__tests__/client.query/customScalars.test.ts
@@ -397,57 +397,54 @@ test("parses network custom scalar fields with a network-only fetch policy", asy
   });
 });
 
-test.failing(
-  "parses custom scalar fields with a no-cache fetch policy",
-  async () => {
-    const query = gql`
-      query Event {
-        event {
-          id
-          startDate
-        }
+test("parses custom scalar fields with a no-cache fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
       }
-    `;
-    const client = new ApolloClient({
-      cache: new InMemoryCache({
-        scalars: { Date: dateScalar },
-        typePolicies: {
-          Event: {
-            fields: {
-              startDate: { scalar: "Date" },
-            },
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
           },
-        },
-      }),
-      link: new ApolloLink(() =>
-        of({
-          data: {
-            event: {
-              __typename: "Event",
-              id: "1",
-              startDate: "2026-01-01",
-            },
-          },
-        }).pipe(delay(20))
-      ),
-    });
-
-    await expect(
-      client.query({
-        query,
-        fetchPolicy: "no-cache",
-      })
-    ).resolves.toStrictEqualTyped({
-      data: {
-        event: {
-          __typename: "Event",
-          id: "1",
-          startDate: new Date(2026, 0, 1),
         },
       },
-    });
-  }
-);
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  await expect(
+    client.query({
+      query,
+      fetchPolicy: "no-cache",
+    })
+  ).resolves.toStrictEqualTyped({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+  });
+});
 
 test("preserves referential identity when fetching identical serialized scalar values", async () => {
   const query = gql`

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -872,70 +872,67 @@ test("parses network custom scalar fields with a network-only fetch policy", asy
   await expect(stream).not.toEmitAnything();
 });
 
-test.failing(
-  "parses custom scalar fields with a no-cache fetch policy",
-  async () => {
-    const query = gql`
-      query Event {
-        event {
-          id
-          startDate
-        }
+test("parses custom scalar fields with a no-cache fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
       }
-    `;
-    const client = new ApolloClient({
-      cache: new InMemoryCache({
-        scalars: { Date: dateScalar },
-        typePolicies: {
-          Event: {
-            fields: {
-              startDate: { scalar: "Date" },
-            },
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
           },
-        },
-      }),
-      link: new ApolloLink(() =>
-        of({
-          data: {
-            event: {
-              __typename: "Event",
-              id: "1",
-              startDate: "2026-01-01",
-            },
-          },
-        }).pipe(delay(20))
-      ),
-    });
-
-    using stream = new ObservableStream(
-      client.watchQuery({
-        query,
-        fetchPolicy: "no-cache",
-      })
-    );
-
-    await expect(stream).toEmitTypedValue({
-      data: undefined,
-      dataState: "empty",
-      loading: true,
-      networkStatus: NetworkStatus.loading,
-      partial: true,
-    });
-    await expect(stream).toEmitTypedValue({
-      data: {
-        event: {
-          __typename: "Event",
-          id: "1",
-          startDate: new Date(2026, 0, 1),
         },
       },
-      dataState: "complete",
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
-  }
-);
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "no-cache",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+});
 
 test("preserves referential identity when refetching identical serialized scalar values", async () => {
   const query = gql`

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -874,70 +874,67 @@ test("parses network custom scalar fields with a network-only fetch policy", asy
   await expect(stream).not.toEmitAnything();
 });
 
-test.failing(
-  "parses custom scalar fields with a no-cache fetch policy",
-  async () => {
-    const query = gql`
-      query Event {
-        event {
-          id
-          startDate
-        }
+test("parses custom scalar fields with a no-cache fetch policy", async () => {
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
       }
-    `;
-    const client = new ApolloClient({
-      cache: new InMemoryCache({
-        scalars: { Date: dateScalar },
-        typePolicies: {
-          Event: {
-            fields: {
-              startDate: { scalar: "Date" },
-            },
+    }
+  `;
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Event: {
+          fields: {
+            startDate: { scalar: "Date" },
           },
-        },
-      }),
-      link: new ApolloLink(() =>
-        of({
-          data: {
-            event: {
-              __typename: "Event",
-              id: "1",
-              startDate: "2026-01-01",
-            },
-          },
-        }).pipe(delay(20))
-      ),
-    });
-
-    using stream = new ObservableStream(
-      client.watchQuery({
-        query,
-        fetchPolicy: "no-cache",
-      })
-    );
-
-    await expect(stream).toEmitTypedValue({
-      data: undefined,
-      dataState: "empty",
-      loading: true,
-      networkStatus: NetworkStatus.loading,
-      partial: true,
-    });
-    await expect(stream).toEmitTypedValue({
-      data: {
-        event: {
-          __typename: "Event",
-          id: "1",
-          startDate: new Date(2026, 0, 1),
         },
       },
-      dataState: "complete",
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      partial: false,
-    });
-  }
-);
+    }),
+    link: new ApolloLink(() =>
+      of({
+        data: {
+          event: {
+            __typename: "Event",
+            id: "1",
+            startDate: "2026-01-01",
+          },
+        },
+      }).pipe(delay(20))
+    ),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "no-cache",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(stream).toEmitTypedValue({
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+});
 
 test("preserves referential identity when refetching identical serialized scalar values", async () => {
   const query = gql`

--- a/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
+++ b/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
@@ -501,6 +501,234 @@ test("parses custom scalar fields selected by an inline fragment", () => {
   });
 });
 
+test("parses custom scalar fields selected by an inline fragment without a type condition", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        ... {
+          startDate
+        }
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields selected by a fragment spread at the root of the query", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+      User: {
+        fields: {
+          lastSeenAt: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query EventAndViewer {
+      event {
+        id
+        startDate
+      }
+      ...ViewerFields
+    }
+
+    fragment ViewerFields on Query {
+      viewer {
+        id
+        lastSeenAt
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+    viewer: {
+      __typename: "User",
+      id: "2",
+      lastSeenAt: "2026-02-02",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+    viewer: {
+      __typename: "User",
+      id: "2",
+      lastSeenAt: new Date(2026, 1, 2),
+    },
+  });
+});
+
+test("keeps parsed values when a fragment selects no custom scalar fields", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        startDate
+        ...EventName
+      }
+    }
+
+    fragment EventName on Event {
+      name
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      name: "GraphQL Summit",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      name: "GraphQL Summit",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields selected by a fragment on an interface type", () => {
+  const cache = new InMemoryCache({
+    possibleTypes: { Node: ["Event"] },
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          createdAt: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        ... on Node {
+          createdAt
+        }
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      createdAt: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      createdAt: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields selected by a fragment on a supertype missing from possibleTypes", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+          createdAt: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+        ... on Node {
+          createdAt
+        }
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-06-15",
+      createdAt: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 5, 15),
+      createdAt: new Date(2026, 0, 1),
+    },
+  });
+});
+
 test("ignores fields from inline fragments that don't match the returned type", () => {
   const cache = new InMemoryCache({
     scalars: { Date: dateScalar },

--- a/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
+++ b/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
@@ -96,14 +96,25 @@ test("does not parse fields on objects without a __typename", () => {
           startDate: { scalar: "Date" },
         },
       },
+      Conference: {
+        fields: {
+          openedAt: { scalar: "Date" },
+        },
+      },
     },
   });
 
   const query = gql`
-    query Event {
+    query EventAndConference {
       event {
         id
         startDate
+      }
+      conference {
+        id
+        venue {
+          openedAt
+        }
       }
     }
   `;
@@ -113,12 +124,26 @@ test("does not parse fields on objects without a __typename", () => {
       id: "1",
       startDate: "2026-01-01",
     },
+    conference: {
+      __typename: "Conference",
+      id: "2",
+      venue: {
+        openedAt: "2026-02-02",
+      },
+    },
   };
 
   expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
     event: {
       id: "1",
       startDate: "2026-01-01",
+    },
+    conference: {
+      __typename: "Conference",
+      id: "2",
+      venue: {
+        openedAt: "2026-02-02",
+      },
     },
   });
 });

--- a/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
+++ b/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
@@ -839,6 +839,52 @@ test("ignores fields from inline fragments that don't match the returned type", 
   });
 });
 
+test("does not coerce an overlapping alias using a non-matching fragment field", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar, Price: priceScalar },
+    typePolicies: {
+      Dog: {
+        fields: {
+          lastWalkedAt: { scalar: "Date" },
+          lastFedAt: { scalar: "Price" },
+        },
+      },
+      Cat: {
+        fields: {
+          lastFedAt: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Pet {
+      pet {
+        ... on Dog {
+          when: lastWalkedAt
+        }
+        ... on Cat {
+          when: lastFedAt
+        }
+      }
+    }
+  `;
+
+  const result = {
+    pet: {
+      __typename: "Dog",
+      when: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    pet: {
+      __typename: "Dog",
+      when: new Date(2026, 0, 1),
+    },
+  });
+});
+
 test("does not parse values that are already parsed", () => {
   const cache = new InMemoryCache({
     scalars: { Date: dateScalar },

--- a/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
+++ b/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
@@ -1,0 +1,835 @@
+import { gql } from "@apollo/client";
+import { InMemoryCache } from "@apollo/client/cache";
+import {
+  dateScalar,
+  jsonObjectScalar,
+  priceScalar,
+} from "@apollo/client/testing/internal";
+import { coerceScalarFieldsToParsed } from "@apollo/client/utilities/internal";
+
+test("parses custom scalar fields on nested objects", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        name
+        startDate
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      name: "GraphQL Summit",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      name: "GraphQL Summit",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields when the query selects __typename", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        __typename
+        id
+        startDate
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields on root fields", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Query: {
+        fields: {
+          today: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Today {
+      today
+    }
+  `;
+
+  const result = { today: "2026-01-01" };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    today: new Date(2026, 0, 1),
+  });
+});
+
+test("parses custom scalar fields for aliased fields", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        start: startDate
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      start: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      start: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields in deeply nested objects", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Session: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        keynote {
+          id
+          session {
+            id
+            startDate
+          }
+        }
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      keynote: {
+        __typename: "Talk",
+        id: "2",
+        session: {
+          __typename: "Session",
+          id: "3",
+          startDate: "2026-01-01",
+        },
+      },
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      keynote: {
+        __typename: "Talk",
+        id: "2",
+        session: {
+          __typename: "Session",
+          id: "3",
+          startDate: new Date(2026, 0, 1),
+        },
+      },
+    },
+  });
+});
+
+test("parses custom scalar fields for objects in a list", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Events {
+      events {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const result = {
+    events: [
+      { __typename: "Event", id: "1", startDate: "2026-01-01" },
+      { __typename: "Event", id: "2", startDate: "2026-06-15" },
+    ],
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    events: [
+      { __typename: "Event", id: "1", startDate: new Date(2026, 0, 1) },
+      { __typename: "Event", id: "2", startDate: new Date(2026, 5, 15) },
+    ],
+  });
+});
+
+test("parses custom scalar values in a list of scalars", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          dates: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        dates
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      dates: ["2026-01-01", "2026-06-15"],
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      dates: [new Date(2026, 0, 1), new Date(2026, 5, 15)],
+    },
+  });
+});
+
+test("parses custom scalar fields for objects in a list of lists", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query EventsByYear {
+      eventsByYear {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const result = {
+    eventsByYear: [
+      [
+        { __typename: "Event", id: "1", startDate: "2026-01-01" },
+        { __typename: "Event", id: "2", startDate: "2026-06-15" },
+      ],
+      [{ __typename: "Event", id: "3", startDate: "2027-03-10" }],
+    ],
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    eventsByYear: [
+      [
+        { __typename: "Event", id: "1", startDate: new Date(2026, 0, 1) },
+        { __typename: "Event", id: "2", startDate: new Date(2026, 5, 15) },
+      ],
+      [{ __typename: "Event", id: "3", startDate: new Date(2027, 2, 10) }],
+    ],
+  });
+});
+
+test("parses custom scalar values in a list of lists", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          datesByYear: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        datesByYear
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      datesByYear: [["2026-01-01", "2026-06-15"], ["2027-03-10"]],
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      datesByYear: [
+        [new Date(2026, 0, 1), new Date(2026, 5, 15)],
+        [new Date(2027, 2, 10)],
+      ],
+    },
+  });
+});
+
+test("parses custom scalar fields selected by a named fragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        ...EventFields
+      }
+    }
+
+    fragment EventFields on Event {
+      name
+      startDate
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      name: "GraphQL Summit",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      name: "GraphQL Summit",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields selected by nested fragments", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        ...EventFields
+      }
+    }
+
+    fragment EventFields on Event {
+      name
+      ...EventDateFields
+    }
+
+    fragment EventDateFields on Event {
+      startDate
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      name: "GraphQL Summit",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      name: "GraphQL Summit",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("parses custom scalar fields selected by an inline fragment", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        ... on Event {
+          startDate
+        }
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("ignores fields from inline fragments that don't match the returned type", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Dog: {
+        fields: {
+          adoptedAt: { scalar: "Date" },
+        },
+      },
+      Cat: {
+        fields: {
+          microchippedAt: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Pet {
+      pet {
+        ... on Dog {
+          name
+          adoptedAt
+        }
+        ... on Cat {
+          name
+          microchippedAt
+        }
+      }
+    }
+  `;
+
+  const result = {
+    pet: {
+      __typename: "Dog",
+      name: "Fido",
+      adoptedAt: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    pet: {
+      __typename: "Dog",
+      name: "Fido",
+      adoptedAt: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("does not parse values that are already parsed", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("leaves null scalar values as-is", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: null,
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: null,
+    },
+  });
+});
+
+test("leaves null objects as-is", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const result = { event: null };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: null,
+  });
+});
+
+test("does not modify fields without a configured scalar", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toBe(result);
+});
+
+test("maintains referential equality of unchanged subtrees", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query EventAndViewer {
+      event {
+        id
+        startDate
+      }
+      viewer {
+        id
+        name
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      startDate: "2026-01-01",
+    },
+    viewer: {
+      __typename: "User",
+      id: "2",
+      name: "Test User",
+    },
+  };
+
+  const coerced = coerceScalarFieldsToParsed(result, query, cache);
+
+  expect(coerced).not.toBe(result);
+  expect(coerced.event).not.toBe(result.event);
+  expect(coerced.viewer).toBe(result.viewer);
+});
+
+test("maintains referential equality of unchanged objects in a list", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Events {
+      events {
+        id
+        name
+      }
+    }
+  `;
+
+  const result = {
+    events: [
+      { __typename: "Event", id: "1", name: "GraphQL Summit" },
+      { __typename: "Event", id: "2", name: "GraphQL Conf" },
+    ],
+  };
+
+  const coerced = coerceScalarFieldsToParsed(result, query, cache);
+
+  expect(coerced).toBe(result);
+  expect(coerced.events).toBe(result.events);
+});
+
+test("parses scalars that serialize to primitive values", () => {
+  const cache = new InMemoryCache({
+    scalars: { Price: priceScalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          price: { scalar: "Price" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Product {
+      product {
+        id
+        price
+      }
+    }
+  `;
+
+  const result = {
+    product: {
+      __typename: "Product",
+      id: "1",
+      price: 1099,
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    product: {
+      __typename: "Product",
+      id: "1",
+      price: "10.99",
+    },
+  });
+});
+
+test("parses scalars that serialize to object values", () => {
+  const cache = new InMemoryCache({
+    scalars: { JSONObject: jsonObjectScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          metadata: { scalar: "JSONObject" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        metadata
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      metadata: { attendees: 500 },
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      metadata: new Map([["attendees", 500]]),
+    },
+  });
+});

--- a/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
+++ b/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
@@ -721,7 +721,7 @@ test("parses custom scalar fields selected by a fragment on an interface type", 
   });
 });
 
-test("parses custom scalar fields selected by a fragment on a supertype missing from possibleTypes", () => {
+test("does not drop fields selected by a fragment on a supertype missing from possibleTypes", () => {
   const cache = new InMemoryCache({
     scalars: { Date: dateScalar },
     typePolicies: {

--- a/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
+++ b/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
@@ -915,6 +915,54 @@ test("leaves null scalar values as-is", () => {
   });
 });
 
+test("leaves null values in a list as-is", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startDate: { scalar: "Date" },
+          dates: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Events {
+      events {
+        id
+        startDate
+        dates
+      }
+    }
+  `;
+
+  const result = {
+    events: [
+      null,
+      {
+        __typename: "Event",
+        id: "1",
+        startDate: "2026-01-01",
+        dates: [null, "2026-06-15"],
+      },
+    ],
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    events: [
+      null,
+      {
+        __typename: "Event",
+        id: "1",
+        startDate: new Date(2026, 0, 1),
+        dates: [null, new Date(2026, 5, 15)],
+      },
+    ],
+  });
+});
+
 test("leaves null objects as-is", () => {
   const cache = new InMemoryCache({
     scalars: { Date: dateScalar },
@@ -1121,4 +1169,141 @@ test("parses scalars that serialize to object values", () => {
       metadata: new Map([["attendees", 500]]),
     },
   });
+});
+
+test("parses custom scalar fields on mutation root fields", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Mutation: {
+        fields: {
+          touchedAt: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const mutation = gql`
+    mutation TouchEvent {
+      touchedAt
+    }
+  `;
+
+  const result = { touchedAt: "2026-01-01" };
+
+  expect(
+    coerceScalarFieldsToParsed(result, mutation, cache)
+  ).toStrictEqualTyped({
+    touchedAt: new Date(2026, 0, 1),
+  });
+});
+
+test("parses custom scalar fields on renamed root types", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      RootQuery: {
+        queryType: true,
+        fields: {
+          today: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Today {
+      today
+    }
+  `;
+
+  const result = { today: "2026-01-01" };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    today: new Date(2026, 0, 1),
+  });
+});
+
+test("parses custom scalar fields configured on an interface type", () => {
+  const cache = new InMemoryCache({
+    possibleTypes: { Node: ["Event"] },
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Node: {
+        fields: {
+          createdAt: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        createdAt
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      __typename: "Event",
+      id: "1",
+      createdAt: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      __typename: "Event",
+      id: "1",
+      createdAt: new Date(2026, 0, 1),
+    },
+  });
+});
+
+test("does not reparse values when run against an already parsed result", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar, Price: priceScalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          price: { scalar: "Price" },
+          releasedAt: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Product {
+      product {
+        id
+        price
+        releasedAt
+      }
+    }
+  `;
+
+  const result = {
+    product: {
+      __typename: "Product",
+      id: "1",
+      price: 1099,
+      releasedAt: "2026-01-01",
+    },
+  };
+
+  const parsed = coerceScalarFieldsToParsed(result, query, cache);
+
+  expect(parsed).toStrictEqualTyped({
+    product: {
+      __typename: "Product",
+      id: "1",
+      price: "10.99",
+      releasedAt: new Date(2026, 0, 1),
+    },
+  });
+  expect(coerceScalarFieldsToParsed(parsed, query, cache)).toBe(parsed);
 });

--- a/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
+++ b/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
@@ -87,6 +87,42 @@ test("parses custom scalar fields when the query selects __typename", () => {
   });
 });
 
+test("does not parse fields on objects without a __typename", () => {
+  const cache = new InMemoryCache({
+    scalars: { Date: dateScalar },
+    typePolicies: {
+      Query: {
+        fields: {
+          startDate: { scalar: "Date" },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query Event {
+      event {
+        id
+        startDate
+      }
+    }
+  `;
+
+  const result = {
+    event: {
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  };
+
+  expect(coerceScalarFieldsToParsed(result, query, cache)).toStrictEqualTyped({
+    event: {
+      id: "1",
+      startDate: "2026-01-01",
+    },
+  });
+});
+
 test("parses custom scalar fields on root fields", () => {
   const cache = new InMemoryCache({
     scalars: { Date: dateScalar },

--- a/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
+++ b/src/utilities/internal/__tests__/coerceScalarFieldsToParsed.test.ts
@@ -746,7 +746,7 @@ test("parses custom scalar fields selected by a fragment on an interface type", 
   });
 });
 
-test("does not drop fields selected by a fragment on a supertype missing from possibleTypes", () => {
+test("does not parse fields selected by a fragment on a supertype missing from possibleTypes", () => {
   const cache = new InMemoryCache({
     scalars: { Date: dateScalar },
     typePolicies: {
@@ -785,7 +785,7 @@ test("does not drop fields selected by a fragment on a supertype missing from po
       __typename: "Event",
       id: "1",
       startDate: new Date(2026, 5, 15),
-      createdAt: new Date(2026, 0, 1),
+      createdAt: "2026-01-01",
     },
   });
 });

--- a/src/utilities/internal/capitalize.ts
+++ b/src/utilities/internal/capitalize.ts
@@ -1,0 +1,4 @@
+/** @internal */
+export function capitalize(str: string) {
+  return str[0].toUpperCase() + str.slice(1);
+}

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -96,7 +96,7 @@ export function coerceScalarFieldsToParsed(
         const fragment = getFragmentFromSelection(selection, fragmentMap);
         let coerced = data;
 
-        if (fragment && typename && cache.fragmentMatches(fragment, typename)) {
+        if (fragment && cache.fragmentMatches(fragment, typename)) {
           coerced = coerceSelectionSet(fragment.selectionSet, data);
           Object.assign(result, coerced);
         }

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -25,6 +25,10 @@ export function coerceScalarFieldsToParsed(
     const result: Record<string, any> = {};
     let changed = false;
 
+    if (Object.hasOwn(data, "__typename")) {
+      result.__typename = data.__typename;
+    }
+
     for (const selection of selectionSet.selections) {
       if (isField(selection)) {
         const resultName = resultKeyNameFromField(selection);

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -84,12 +84,14 @@ export function coerceScalarFieldsToParsed(
         result[resultName] = coerced;
       } else {
         const fragment = getFragmentFromSelection(selection, fragmentMap);
+        let coerced = data;
 
-        const coerced =
-          fragment ? coerceSelectionSet(fragment.selectionSet, data) : data;
+        if (fragment && typename && cache.fragmentMatches(fragment, typename)) {
+          coerced = coerceSelectionSet(fragment.selectionSet, data);
+          Object.assign(result, coerced);
+        }
+
         changed ||= coerced !== data;
-
-        Object.assign(result, coerced);
       }
     }
 

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -16,7 +16,7 @@ export function coerceScalarFieldsToParsed(
 ): Record<string, any> {
   const fragmentMap = createFragmentMap(getFragmentDefinitions(query));
 
-  function parseValue(
+  function coerce(
     fieldValue: unknown,
     typename: string | undefined,
     field: FieldNode
@@ -43,7 +43,7 @@ export function coerceScalarFieldsToParsed(
       } else if (field.selectionSet) {
         coerced = coerceSelectionSet(field.selectionSet, item);
       } else {
-        coerced = parseValue(item, typename, field);
+        coerced = coerce(item, typename, field);
       }
 
       changed ||= coerced !== item;
@@ -75,7 +75,7 @@ export function coerceScalarFieldsToParsed(
         } else if (selection.selectionSet) {
           coerced = coerceSelectionSet(selection.selectionSet, fieldValue);
         } else {
-          coerced = parseValue(fieldValue, typename, selection);
+          coerced = coerce(fieldValue, typename, selection);
         }
 
         changed ||= coerced !== fieldValue;

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -21,6 +21,8 @@ export function coerceScalarFieldsToParsed(
     typename: string | undefined,
     field: FieldNode
   ) {
+    if (fieldValue === null) return null;
+
     const scalar =
       typename && cache.getScalarForField(typename, field.name.value);
 
@@ -54,7 +56,7 @@ export function coerceScalarFieldsToParsed(
   }
 
   function coerceSelectionSet(selectionSet: SelectionSetNode, data: any): any {
-    if (data == null) return data;
+    if (data === null) return null;
 
     const result: Record<string, any> = {};
     let changed = false;

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -24,8 +24,6 @@ export function coerceScalarFieldsToParsed(
     "Document node must be a query, mutation, or subscription"
   );
 
-  const rootTypename = cache.getRootTypename(operationType);
-
   function coerce(
     fieldValue: unknown,
     typename: string | undefined,
@@ -119,6 +117,6 @@ export function coerceScalarFieldsToParsed(
   return coerceSelectionSet(
     getMainDefinition(query).selectionSet,
     result,
-    rootTypename
+    cache.getRootTypename(operationType)
   );
 }

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -1,4 +1,4 @@
-import type { DocumentNode, SelectionSetNode } from "graphql";
+import type { DocumentNode, FieldNode, SelectionSetNode } from "graphql";
 
 import type { ApolloCache } from "@apollo/client/cache";
 
@@ -8,18 +8,48 @@ import { getFragmentFromSelection } from "./getFragmentFromSelection.js";
 import { getMainDefinition } from "./getMainDefinition.js";
 import { isField } from "./isField.js";
 import { resultKeyNameFromField } from "./resultKeyNameFromField.js";
-import type { FragmentMap } from "./types/FragmentMap.js";
 
 export function coerceScalarFieldsToParsed(
   result: Record<string, any>,
   query: DocumentNode,
   cache: ApolloCache
 ): Record<string, any> {
-  const coerce = (
-    selectionSet: SelectionSetNode,
-    data: any,
-    fragmentMap: FragmentMap
-  ): any => {
+  const fragmentMap = createFragmentMap(getFragmentDefinitions(query));
+
+  function parseValue(
+    fieldValue: unknown,
+    typename: string | undefined,
+    field: FieldNode
+  ) {
+    const scalar =
+      typename && cache.getScalarForField(typename, field.name.value);
+
+    return scalar ? scalar.coerceToParsed(fieldValue) : fieldValue;
+  }
+
+  function coerceArray(field: FieldNode, array: any[], typename: string) {
+    const result: any[] = [];
+    let changed = false;
+
+    for (const item of array) {
+      let coerced: unknown;
+
+      if (Array.isArray(item)) {
+        coerced = coerceArray(field, item, typename);
+      } else if (field.selectionSet) {
+        coerced = coerceSelectionSet(field.selectionSet, item);
+      } else {
+        coerced = parseValue(item, typename, field);
+      }
+
+      changed ||= coerced !== item;
+      result.push(coerced);
+    }
+
+    return changed ? result : array;
+  }
+
+  function coerceSelectionSet(selectionSet: SelectionSetNode, data: any): any {
     if (data == null) return data;
 
     const result: Record<string, any> = {};
@@ -35,21 +65,16 @@ export function coerceScalarFieldsToParsed(
         const fieldValue = data[resultName];
 
         if (Array.isArray(fieldValue)) {
-          const processed = fieldValue.map((item) => {
-            const processedItem = coerce(selectionSet, item, fragmentMap);
-            changed ||= item !== processedItem;
+          const coerced = coerceArray(selection, fieldValue, data.__typename);
 
-            return processedItem;
-          });
-
-          result[resultName] = processed;
+          changed ||= coerced !== fieldValue;
+          result[resultName] = coerced;
 
           continue;
         } else if (selection.selectionSet) {
-          const processed = coerce(
+          const processed = coerceSelectionSet(
             selection.selectionSet,
-            fieldValue,
-            fragmentMap
+            fieldValue
           );
 
           changed ||= processed !== fieldValue;
@@ -72,7 +97,7 @@ export function coerceScalarFieldsToParsed(
         const fragment = getFragmentFromSelection(selection, fragmentMap);
 
         const processed =
-          fragment ? coerce(fragment.selectionSet, data, fragmentMap) : data;
+          fragment ? coerceSelectionSet(fragment.selectionSet, data) : data;
         changed ||= processed !== data;
 
         Object.assign(result, processed);
@@ -80,11 +105,7 @@ export function coerceScalarFieldsToParsed(
     }
 
     return changed ? result : data;
-  };
+  }
 
-  return coerce(
-    getMainDefinition(query).selectionSet,
-    result,
-    createFragmentMap(getFragmentDefinitions(query))
-  );
+  return coerceSelectionSet(getMainDefinition(query).selectionSet, result);
 }

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -31,11 +31,9 @@ export function coerceScalarFieldsToParsed(
     typename: string | undefined,
     field: FieldNode
   ) {
-    if (fieldValue === null) return null;
+    if (fieldValue === null || !typename) return fieldValue;
 
-    const scalar =
-      typename && cache.getScalarForField(typename, field.name.value);
-
+    const scalar = cache.getScalarForField(typename, field.name.value);
     return scalar ? scalar.coerceToParsed(fieldValue) : fieldValue;
   }
 
@@ -53,7 +51,7 @@ export function coerceScalarFieldsToParsed(
       if (Array.isArray(item)) {
         coerced = coerceArray(field, item, typename);
       } else if (field.selectionSet) {
-        coerced = coerceSelectionSet(field.selectionSet, item);
+        coerced = coerceSelectionSet(field.selectionSet, item, typename);
       } else {
         coerced = coerce(item, typename, field);
       }
@@ -65,48 +63,62 @@ export function coerceScalarFieldsToParsed(
     return changed ? result : array;
   }
 
-  function coerceSelectionSet(selectionSet: SelectionSetNode, data: any): any {
-    if (data === null) return null;
+  function coerceSelectionSet(
+    selectionSet: SelectionSetNode,
+    data: any,
+    typename: string | undefined
+  ): any {
+    if (data === null || typeof data !== "object") return data;
 
-    const result: Record<string, any> = {};
+    const result: Record<string, any> = { ...data };
     let changed = false;
-    let typename = rootTypename;
 
     if (Object.hasOwn(data, "__typename")) {
       typename = result.__typename = data.__typename;
     }
 
-    for (const selection of selectionSet.selections) {
-      if (isField(selection)) {
-        const resultName = resultKeyNameFromField(selection);
-        const fieldValue = data[resultName];
+    function visit(selectionSet: SelectionSetNode) {
+      for (const selection of selectionSet.selections) {
+        if (isField(selection)) {
+          const resultName = resultKeyNameFromField(selection);
 
-        let coerced: unknown;
-        if (Array.isArray(fieldValue)) {
-          coerced = coerceArray(selection, fieldValue, typename);
-        } else if (selection.selectionSet) {
-          coerced = coerceSelectionSet(selection.selectionSet, fieldValue);
+          if (!Object.hasOwn(data, resultName)) continue;
+
+          const fieldValue = data[resultName];
+
+          let coerced: unknown;
+          if (Array.isArray(fieldValue)) {
+            coerced = coerceArray(selection, fieldValue, data.__typename);
+          } else if (selection.selectionSet) {
+            coerced = coerceSelectionSet(
+              selection.selectionSet,
+              fieldValue,
+              data.__typename
+            );
+          } else {
+            coerced = coerce(fieldValue, typename, selection);
+          }
+
+          changed ||= coerced !== fieldValue;
+          result[resultName] = coerced;
         } else {
-          coerced = coerce(fieldValue, typename, selection);
+          const fragment = getFragmentFromSelection(selection, fragmentMap);
+
+          if (fragment) {
+            visit(fragment.selectionSet);
+          }
         }
-
-        changed ||= coerced !== fieldValue;
-        result[resultName] = coerced;
-      } else {
-        const fragment = getFragmentFromSelection(selection, fragmentMap);
-        let coerced = data;
-
-        if (fragment && cache.fragmentMatches(fragment, typename)) {
-          coerced = coerceSelectionSet(fragment.selectionSet, data);
-          Object.assign(result, coerced);
-        }
-
-        changed ||= coerced !== data;
       }
     }
+
+    visit(selectionSet);
 
     return changed ? result : data;
   }
 
-  return coerceSelectionSet(getMainDefinition(query).selectionSet, result);
+  return coerceSelectionSet(
+    getMainDefinition(query).selectionSet,
+    result,
+    rootTypename
+  );
 }

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -27,7 +27,11 @@ export function coerceScalarFieldsToParsed(
     return scalar ? scalar.coerceToParsed(fieldValue) : fieldValue;
   }
 
-  function coerceArray(field: FieldNode, array: any[], typename: string) {
+  function coerceArray(
+    field: FieldNode,
+    array: any[],
+    typename: string | undefined
+  ) {
     const result: any[] = [];
     let changed = false;
 
@@ -54,9 +58,10 @@ export function coerceScalarFieldsToParsed(
 
     const result: Record<string, any> = {};
     let changed = false;
+    let typename: string | undefined;
 
     if (Object.hasOwn(data, "__typename")) {
-      result.__typename = data.__typename;
+      typename = result.__typename = data.__typename;
     }
 
     for (const selection of selectionSet.selections) {
@@ -64,35 +69,17 @@ export function coerceScalarFieldsToParsed(
         const resultName = resultKeyNameFromField(selection);
         const fieldValue = data[resultName];
 
+        let coerced: unknown;
         if (Array.isArray(fieldValue)) {
-          const coerced = coerceArray(selection, fieldValue, data.__typename);
-
-          changed ||= coerced !== fieldValue;
-          result[resultName] = coerced;
-
-          continue;
+          coerced = coerceArray(selection, fieldValue, typename);
         } else if (selection.selectionSet) {
-          const processed = coerceSelectionSet(
-            selection.selectionSet,
-            fieldValue
-          );
-
-          changed ||= processed !== fieldValue;
-          result[resultName] = processed;
-
-          continue;
+          coerced = coerceSelectionSet(selection.selectionSet, fieldValue);
+        } else {
+          coerced = parseValue(fieldValue, typename, selection);
         }
 
-        const typename =
-          Object.hasOwn(data, "__typename") ? data.__typename : undefined;
-
-        const scalar =
-          typename && cache.getScalarForField(typename, selection.name.value);
-        const processed =
-          scalar ? scalar.coerceToParsed(fieldValue) : fieldValue;
-
-        changed ||= processed !== fieldValue;
-        result[resultName] = processed;
+        changed ||= coerced !== fieldValue;
+        result[resultName] = coerced;
       } else {
         const fragment = getFragmentFromSelection(selection, fragmentMap);
 

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -66,29 +66,24 @@ export function coerceScalarFieldsToParsed(
       typename = data.__typename;
     }
 
-    function visit(selectionSet: SelectionSetNode) {
-      for (const selection of selectionSet.selections) {
-        if (isField(selection)) {
-          const resultName = resultKeyNameFromField(selection);
+    const workSet = new Set(selectionSet.selections);
+    workSet.forEach((selection) => {
+      if (isField(selection)) {
+        const resultName = resultKeyNameFromField(selection);
+        if (!Object.hasOwn(data, resultName)) return;
 
-          if (!Object.hasOwn(data, resultName)) continue;
+        const fieldValue = data[resultName];
+        const coerced = coerceField(selection, fieldValue, typename);
 
-          const fieldValue = data[resultName];
-          const coerced = coerceField(selection, fieldValue, typename);
-
-          changed ||= coerced !== fieldValue;
-          result[resultName] = coerced;
-        } else {
-          const fragment = getFragmentFromSelection(selection, fragmentMap);
-
-          if (fragment) {
-            visit(fragment.selectionSet);
-          }
-        }
+        changed ||= coerced !== fieldValue;
+        result[resultName] = coerced;
+      } else {
+        getFragmentFromSelection(
+          selection,
+          fragmentMap
+        )?.selectionSet.selections.forEach((s) => workSet.add(s));
       }
-    }
-
-    visit(selectionSet);
+    });
 
     return changed ? result : data;
   }

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -11,6 +11,7 @@ import { getOperationDefinition } from "./getOperationDefinition.js";
 import { isField } from "./isField.js";
 import { resultKeyNameFromField } from "./resultKeyNameFromField.js";
 
+/** @internal */
 export function coerceScalarFieldsToParsed(
   result: Record<string, any>,
   query: DocumentNode,

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -24,47 +24,38 @@ export function coerceScalarFieldsToParsed(
     "Document node must be a query, mutation, or subscription"
   );
 
-  function coerce(
+  function coerceField(
+    field: FieldNode,
     fieldValue: unknown,
-    typename: string | undefined,
-    field: FieldNode
-  ) {
+    typename: string | undefined
+  ): unknown {
+    let changed = false;
+
+    if (Array.isArray(fieldValue)) {
+      const items = fieldValue.map((item) => {
+        const coerced = coerceField(field, item, typename);
+
+        changed ||= coerced !== item;
+        return coerced;
+      });
+
+      return changed ? items : fieldValue;
+    }
+
+    if (field.selectionSet) {
+      return coerceSelectionSet(field.selectionSet, fieldValue);
+    }
+
     if (fieldValue === null || !typename) return fieldValue;
 
     const scalar = cache.getScalarForField(typename, field.name.value);
     return scalar ? scalar.coerceToParsed(fieldValue) : fieldValue;
   }
 
-  function coerceArray(
-    field: FieldNode,
-    array: any[],
-    typename: string | undefined
-  ) {
-    const result: any[] = [];
-    let changed = false;
-
-    for (const item of array) {
-      let coerced: unknown;
-
-      if (Array.isArray(item)) {
-        coerced = coerceArray(field, item, typename);
-      } else if (field.selectionSet) {
-        coerced = coerceSelectionSet(field.selectionSet, item, typename);
-      } else {
-        coerced = coerce(item, typename, field);
-      }
-
-      changed ||= coerced !== item;
-      result.push(coerced);
-    }
-
-    return changed ? result : array;
-  }
-
   function coerceSelectionSet(
     selectionSet: SelectionSetNode,
     data: any,
-    typename: string | undefined
+    typename?: string
   ): any {
     if (data === null || typeof data !== "object") return data;
 
@@ -83,19 +74,7 @@ export function coerceScalarFieldsToParsed(
           if (!Object.hasOwn(data, resultName)) continue;
 
           const fieldValue = data[resultName];
-
-          let coerced: unknown;
-          if (Array.isArray(fieldValue)) {
-            coerced = coerceArray(selection, fieldValue, data.__typename);
-          } else if (selection.selectionSet) {
-            coerced = coerceSelectionSet(
-              selection.selectionSet,
-              fieldValue,
-              data.__typename
-            );
-          } else {
-            coerced = coerce(fieldValue, typename, selection);
-          }
+          const coerced = coerceField(selection, fieldValue, typename);
 
           changed ||= coerced !== fieldValue;
           result[resultName] = coerced;

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -85,11 +85,11 @@ export function coerceScalarFieldsToParsed(
       } else {
         const fragment = getFragmentFromSelection(selection, fragmentMap);
 
-        const processed =
+        const coerced =
           fragment ? coerceSelectionSet(fragment.selectionSet, data) : data;
-        changed ||= processed !== data;
+        changed ||= coerced !== data;
 
-        Object.assign(result, processed);
+        Object.assign(result, coerced);
       }
     }
 

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -1,0 +1,86 @@
+import type { DocumentNode, SelectionSetNode } from "graphql";
+
+import type { ApolloCache } from "@apollo/client/cache";
+
+import { createFragmentMap } from "./createFragmentMap.js";
+import { getFragmentDefinitions } from "./getFragmentDefinitions.js";
+import { getFragmentFromSelection } from "./getFragmentFromSelection.js";
+import { getMainDefinition } from "./getMainDefinition.js";
+import { isField } from "./isField.js";
+import { resultKeyNameFromField } from "./resultKeyNameFromField.js";
+import type { FragmentMap } from "./types/FragmentMap.js";
+
+export function coerceScalarFieldsToParsed(
+  result: Record<string, any>,
+  query: DocumentNode,
+  cache: ApolloCache
+): Record<string, any> {
+  const coerce = (
+    selectionSet: SelectionSetNode,
+    data: any,
+    fragmentMap: FragmentMap
+  ): any => {
+    if (data == null) return data;
+
+    const result: Record<string, any> = {};
+    let changed = false;
+
+    for (const selection of selectionSet.selections) {
+      if (isField(selection)) {
+        const resultName = resultKeyNameFromField(selection);
+        const fieldValue = data[resultName];
+
+        if (Array.isArray(fieldValue)) {
+          const processed = fieldValue.map((item) => {
+            const processedItem = coerce(selectionSet, item, fragmentMap);
+            changed ||= item !== processedItem;
+
+            return processedItem;
+          });
+
+          result[resultName] = processed;
+
+          continue;
+        } else if (selection.selectionSet) {
+          const processed = coerce(
+            selection.selectionSet,
+            fieldValue,
+            fragmentMap
+          );
+
+          changed ||= processed !== fieldValue;
+          result[resultName] = processed;
+
+          continue;
+        }
+
+        const typename =
+          Object.hasOwn(data, "__typename") ? data.__typename : undefined;
+
+        const scalar =
+          typename && cache.getScalarForField(typename, selection.name.value);
+        const processed =
+          scalar ? scalar.coerceToParsed(fieldValue) : fieldValue;
+
+        changed ||= processed !== fieldValue;
+        result[resultName] = processed;
+      } else {
+        const fragment = getFragmentFromSelection(selection, fragmentMap);
+
+        const processed =
+          fragment ? coerce(fragment.selectionSet, data, fragmentMap) : data;
+        changed ||= processed !== data;
+
+        Object.assign(result, processed);
+      }
+    }
+
+    return changed ? result : data;
+  };
+
+  return coerce(
+    getMainDefinition(query).selectionSet,
+    result,
+    createFragmentMap(getFragmentDefinitions(query))
+  );
+}

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -79,10 +79,11 @@ export function coerceScalarFieldsToParsed(
         changed ||= coerced !== fieldValue;
         result[resultName] = coerced;
       } else {
-        getFragmentFromSelection(
-          selection,
-          fragmentMap
-        )?.selectionSet.selections.forEach((s) => workSet.add(s));
+        const fragment = getFragmentFromSelection(selection, fragmentMap);
+
+        if (fragment && typename && cache.fragmentMatches(fragment, typename)) {
+          fragment.selectionSet.selections.forEach((s) => workSet.add(s));
+        }
       }
     });
 

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -72,7 +72,7 @@ export function coerceScalarFieldsToParsed(
     let changed = false;
 
     if (Object.hasOwn(data, "__typename")) {
-      typename = result.__typename = data.__typename;
+      typename = data.__typename;
     }
 
     function visit(selectionSet: SelectionSetNode) {

--- a/src/utilities/internal/coerceScalarFieldsToParsed.ts
+++ b/src/utilities/internal/coerceScalarFieldsToParsed.ts
@@ -1,11 +1,13 @@
 import type { DocumentNode, FieldNode, SelectionSetNode } from "graphql";
 
 import type { ApolloCache } from "@apollo/client/cache";
+import { invariant } from "@apollo/client/utilities/invariant";
 
 import { createFragmentMap } from "./createFragmentMap.js";
 import { getFragmentDefinitions } from "./getFragmentDefinitions.js";
 import { getFragmentFromSelection } from "./getFragmentFromSelection.js";
 import { getMainDefinition } from "./getMainDefinition.js";
+import { getOperationDefinition } from "./getOperationDefinition.js";
 import { isField } from "./isField.js";
 import { resultKeyNameFromField } from "./resultKeyNameFromField.js";
 
@@ -14,7 +16,15 @@ export function coerceScalarFieldsToParsed(
   query: DocumentNode,
   cache: ApolloCache
 ): Record<string, any> {
+  const operationType = getOperationDefinition(query)?.operation;
   const fragmentMap = createFragmentMap(getFragmentDefinitions(query));
+
+  invariant(
+    operationType,
+    "Document node must be a query, mutation, or subscription"
+  );
+
+  const rootTypename = cache.getRootTypename(operationType);
 
   function coerce(
     fieldValue: unknown,
@@ -60,7 +70,7 @@ export function coerceScalarFieldsToParsed(
 
     const result: Record<string, any> = {};
     let changed = false;
-    let typename: string | undefined;
+    let typename = rootTypename;
 
     if (Object.hasOwn(data, "__typename")) {
       typename = result.__typename = data.__typename;

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -28,6 +28,7 @@ export { argumentsObjectFromField } from "./argumentsObjectFromField.js";
 export { canUseDOM } from "./canUseDOM.js";
 export { checkDocument } from "./checkDocument.js";
 export { cloneDeep } from "./cloneDeep.js";
+export { coerceScalarFieldsToParsed } from "./coerceScalarFieldsToParsed.js";
 export { combineLatestBatched } from "./combineLatestBatched.js";
 export { compact } from "./compact.js";
 export { createFragmentMap } from "./createFragmentMap.js";

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -27,6 +27,7 @@ export { argumentsObjectFromField } from "./argumentsObjectFromField.js";
 export { canUseDOM } from "./canUseDOM.js";
 export { checkDocument } from "./checkDocument.js";
 export { cloneDeep } from "./cloneDeep.js";
+export { coerceScalarFieldsToParsed } from "./coerceScalarFieldsToParsed.js";
 export { combineLatestBatched } from "./combineLatestBatched.js";
 export { compact } from "./compact.js";
 export { createFragmentMap } from "./createFragmentMap.js";

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -25,6 +25,7 @@ export type { OptionWithFallback } from "./types/OptionWithFallback.js";
 
 export { addDeferFragmentLabels } from "./addDeferFragmentLabels.js";
 export { argumentsObjectFromField } from "./argumentsObjectFromField.js";
+export { capitalize } from "./capitalize.js";
 export { canUseDOM } from "./canUseDOM.js";
 export { checkDocument } from "./checkDocument.js";
 export { cloneDeep } from "./cloneDeep.js";


### PR DESCRIPTION
Parse custom scalars for `no-cache` queries. Adds the necessary cache hooks and logic for this to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom scalar values are now parsed for successful `no-cache` queries and watched queries.
  * Cache APIs now provide root operation type and scalar configuration/lookup information.
* **Bug Fixes**
  * Improved scalar parsing across nested objects, lists, aliases, fragments, interfaces, and renamed root types.
  * Preserved unchanged result structures when no scalar conversion is needed.
* **Tests**
  * Expanded coverage for custom scalar parsing and complex query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->