### PR TITLE
Always take the latest network result when polling

### DIFF
--- a/.changeset/serious-pumas-knock.md
+++ b/.changeset/serious-pumas-knock.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where a cache write in the middle of polling would remain as the query value if future poll requests returned deep equal results to previous polling results.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 50985,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 45361,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 38468,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31847
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 51053,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 45350,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 38421,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31787
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1473,6 +1473,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           !isNetworkRequestInFlight(this.networkStatus) &&
           !this.options.skipPollAttempt?.()
         ) {
+          this._lastWrite = undefined;
           this._reobserve(
             {
               // Most fetchPolicy options don't make sense to use in a polling context, as

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3253,10 +3253,6 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
-    // The polled result is `hello` again, identical to what this query last
-    // wrote, so the cache write is skipped. The emitted result still comes from
-    // the cache, so the `read` function is applied instead of delivering the
-    // raw network value.
     await expect(stream).toEmitTypedValue({
       data: { greeting: "HELLO" },
       dataState: "complete",

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3118,7 +3118,7 @@ describe("ApolloClient", () => {
     await expect(stream).not.toEmitAnything();
   });
 
-  it("keeps the clobbered cache value when a polled result matches the last written result", async () => {
+  it("writes the latest polled result over a clobbered cache value when polled result equals last polled result", async () => {
     const query = gql`
       query {
         hero {
@@ -3161,7 +3161,6 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
-    // Another writer clobbers the field this query wrote.
     client.writeQuery({
       query,
       data: { hero: { __typename: "Hero", id: "1", name: "Clobbered" } },

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3118,6 +3118,158 @@ describe("ApolloClient", () => {
     await expect(stream).not.toEmitAnything();
   });
 
+  it("keeps the clobbered cache value when a polled result matches the last written result", async () => {
+    const query = gql`
+      query {
+        hero {
+          id
+          name
+        }
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new MockLink([
+        {
+          request: { query },
+          result: {
+            data: { hero: { __typename: "Hero", id: "1", name: "Luke" } },
+          },
+          delay: 20,
+          maxUsageCount: Number.POSITIVE_INFINITY,
+        },
+      ]),
+    });
+
+    const observable = client.watchQuery({ query, pollInterval: 10 });
+    const stream = new ObservableStream(observable);
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { hero: { __typename: "Hero", id: "1", name: "Luke" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    // Another writer clobbers the field this query wrote.
+    client.writeQuery({
+      query,
+      data: { hero: { __typename: "Hero", id: "1", name: "Clobbered" } },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { hero: { __typename: "Hero", id: "1", name: "Clobbered" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { hero: { __typename: "Hero", id: "1", name: "Clobbered" } },
+      dataState: "complete",
+      loading: true,
+      networkStatus: NetworkStatus.poll,
+      partial: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { hero: { __typename: "Hero", id: "1", name: "Luke" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    observable.stopPolling();
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  it("applies read functions when a polled result matches the last written result", async () => {
+    const query = gql`
+      query {
+        greeting
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        typePolicies: {
+          Query: {
+            fields: {
+              greeting: {
+                read: (existing: string | undefined) =>
+                  existing && existing.toUpperCase(),
+              },
+            },
+          },
+        },
+      }),
+      link: new MockLink([
+        {
+          request: { query },
+          result: { data: { greeting: "hello" } },
+          delay: 20,
+          maxUsageCount: Number.POSITIVE_INFINITY,
+        },
+      ]),
+    });
+
+    const observable = client.watchQuery({ query, pollInterval: 10 });
+    const stream = new ObservableStream(observable);
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { greeting: "HELLO" },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { greeting: "HELLO" },
+      dataState: "complete",
+      loading: true,
+      networkStatus: NetworkStatus.poll,
+      partial: false,
+    });
+
+    // The polled result is `hello` again, identical to what this query last
+    // wrote, so the cache write is skipped. The emitted result still comes from
+    // the cache, so the `read` function is applied instead of delivering the
+    // raw network value.
+    await expect(stream).toEmitTypedValue({
+      data: { greeting: "HELLO" },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    observable.stopPolling();
+
+    await expect(stream).not.toEmitAnything();
+  });
+
   it("should not error when replacing unidentified data with a normalized ID", async () => {
     const queryWithoutId = gql`
       query {


### PR DESCRIPTION
This is something I discovered while experimenting with an unrelated issue. When a cache write happens in the middle of a polling request, but data never changes from the last network result when the cache re-polls, the updated cache result remains. We should always take the newest network result since it is fresh from the server.

`_lastDiff` was never updated to `undefined` before a poll request was issued, so when `QueryInfo#markQueryResult` checked `shouldWrite`, it avoided the cache write and re-applied `lastDiff` to the result. Now the updated polling query both writes to the cache with its latest value and reports it in the query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed polling so cache updates are correctly applied even when consecutive poll responses are deeply equal.
  * Preserved externally updated entity values until the next poll completes.
  * Ensured field read behavior is applied consistently to polling results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->