### PR TITLE
Fix a bad `dataState` value when an error occurs on a deferred field that bubbles to the defer boundary

### DIFF
--- a/.changeset/loud-bulldogs-pay.md
+++ b/.changeset/loud-bulldogs-pay.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where a `@defer` query reported the `dataState` as `complete` instead of `streaming` when an error occurs on a deferred field that bubbled to the defer boundary.

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -396,8 +396,8 @@ export class QueryInfo<
 
         if (
           dataState === "complete" ||
-          (returnPartialData && dataState === "partial" && shouldWrite) ||
-          (this.hasNext && dataState === "streaming")
+          dataState === "streaming" ||
+          (returnPartialData && dataState === "partial" && shouldWrite)
         ) {
           result = { ...result, data: diffResult, dataState };
         }

--- a/src/incremental/handlers/__tests__/graphql17Alpha9/defer.test.ts
+++ b/src/incremental/handlers/__tests__/graphql17Alpha9/defer.test.ts
@@ -2506,13 +2506,13 @@ test("stream that returns an error but continues to stream", async () => {
 
   await expect(observableStream).toEmitTypedValue({
     loading: false,
-    data: {
+    data: markAsStreaming({
       hero: {
         __typename: "Hero",
         id: "1",
         name: "slow",
       },
-    },
+    }),
     error: new CombinedGraphQLErrors({
       data: {
         hero: {
@@ -2529,9 +2529,9 @@ test("stream that returns an error but continues to stream", async () => {
         },
       ],
     }),
-    dataState: "complete",
+    dataState: "streaming",
     networkStatus: NetworkStatus.error,
-    partial: false,
+    partial: true,
   });
 });
 


### PR DESCRIPTION
While working on an experiment for an unrelated issue, I stumbled upon this behavior. Currently an error reported by a `@defer` field that bubbles to the defer boundary reports the final chunk to the user as `complete` instead of `streaming` even though the result still has the hole in the data. This fix unconditionally applies the `diff` data to `result` when the `dataState` is streaming rather than only applying to when `hasNext` is true. This makes sure the final chunk delivers the right `dataState` value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `@defer` queries incorrectly reporting a complete state when deferred-field errors occur.
  * Streaming results now remain marked as streaming while additional data may still arrive.
  * Streamed data and associated errors are preserved correctly in the final payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->