### PR TITLE
fix: thread errorPolicy through useLazyQuery execute return type

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -708,9 +708,9 @@ export namespace useLazyQuery {
         }
     }
     // (undocumented)
-    export type ExecFunction<TData, TVariables extends OperationVariables> = (...args: {} extends TVariables ? [
+    export type ExecFunction<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...args: {} extends TVariables ? [
     options?: useLazyQuery.ExecOptions<TVariables>
-    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData>>;
+    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData, TErrorPolicy>>;
     // (undocumented)
     export type ExecOptions<TVariables extends OperationVariables = OperationVariables> = {
         context?: DefaultContext;
@@ -739,10 +739,14 @@ export namespace useLazyQuery {
         dataState: "empty";
     });
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables>> = ResultTuple<TData, TVariables, "complete" | "streaming" | "empty" | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial")>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = ResultTuple<TData, TVariables, "complete" | "streaming" | "empty" | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"), [
+    TErrorPolicy
+    ] extends [undefined] ? DefaultOptions extends {
+        errorPolicy: infer D;
+    } ? D : undefined : TErrorPolicy>;
     // (undocumented)
-    export type ResultTuple<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
-    execute: ExecFunction<TData, TVariables>,
+    export type ResultTuple<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
+    execute: ExecFunction<TData, TVariables, TErrorPolicy>,
     result: useLazyQuery.Result<TData, TVariables, TStates>
     ];
     export interface Signature extends Signatures.Evaluated {
@@ -776,7 +780,9 @@ export namespace useLazyQuery {
                 variables?: {
                     [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
                 };
-            }>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: TOptions): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
+            }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: TOptions & {
+                errorPolicy?: TErrorPolicy;
+            }): useLazyQuery.ResultForOptions<TData, TVariables, TOptions, TErrorPolicy>;
         }
     }
 }

--- a/.changeset/lazy-lions-argue.md
+++ b/.changeset/lazy-lions-argue.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+`useLazyQuery`'s `execute` function now threads the hook-level `errorPolicy` through its return type. When `errorPolicy: "none"` is set (the default), the resolved promise's `data` is typed as defined rather than possibly `undefined`, since GraphQL errors reject the promise instead of resolving with partial data.

--- a/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
@@ -168,7 +168,7 @@ test("uses masked types when using masked document", async () => {
   {
     const { data } = await execute();
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 
   {
@@ -284,7 +284,7 @@ test("uses unmodified types when using TypedDocumentNode", async () => {
   {
     const { data } = await execute();
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 
   {
@@ -478,4 +478,36 @@ test("execution result has `.retain` method", () => {
 
   // retain should return the same type as the original result
   expectTypeOf(result.retain()).toEqualTypeOf(result);
+});
+
+test("threads errorPolicy through the execute function", async () => {
+  const { query } = setupSimpleCase();
+
+  {
+    const [execute] = useLazyQuery(query, { errorPolicy: "none" });
+    const { data } = await execute();
+
+    expectTypeOf(data).toEqualTypeOf<SimpleCaseData>();
+  }
+
+  {
+    const [execute] = useLazyQuery(query, { errorPolicy: "all" });
+    const { data } = await execute();
+
+    expectTypeOf(data).toEqualTypeOf<SimpleCaseData | undefined>();
+  }
+
+  {
+    const [execute] = useLazyQuery(query, { errorPolicy: "ignore" });
+    const { data } = await execute();
+
+    expectTypeOf(data).toEqualTypeOf<SimpleCaseData | undefined>();
+  }
+
+  {
+    const [execute] = useLazyQuery(query);
+    const { data } = await execute();
+
+    expectTypeOf(data).toEqualTypeOf<SimpleCaseData>();
+  }
 });

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -216,16 +216,23 @@ export declare namespace useLazyQuery {
     TVariables extends OperationVariables,
     TStates extends
       DataState<TData>["dataState"] = DataState<TData>["dataState"],
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = [
-    execute: ExecFunction<TData, TVariables>,
+    execute: ExecFunction<TData, TVariables, TErrorPolicy>,
     result: useLazyQuery.Result<TData, TVariables, TStates>,
   ];
 
-  export type ExecFunction<TData, TVariables extends OperationVariables> = (
+  export type ExecFunction<
+    TData,
+    TVariables extends OperationVariables,
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = (
     ...args: {} extends TVariables ?
       [options?: useLazyQuery.ExecOptions<TVariables>]
     : [options: useLazyQuery.ExecOptions<TVariables>]
-  ) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData>>;
+  ) => ObservableQuery.ResultPromise<
+    ApolloClient.QueryResult<TData, TErrorPolicy>
+  >;
 
   namespace DocumentationTypes {
     namespace useLazyQuery {
@@ -240,6 +247,7 @@ export declare namespace useLazyQuery {
     TData,
     TVariables extends OperationVariables,
     TOptions extends Record<string, never> | Options<TData, TVariables>,
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = ResultTuple<
     TData,
     TVariables,
@@ -252,7 +260,12 @@ export declare namespace useLazyQuery {
         "returnPartialData"
       > extends false ?
         never
-      : "partial")
+      : "partial"),
+    [TErrorPolicy] extends [undefined] ?
+      DefaultOptions extends { errorPolicy: infer D } ?
+        D
+      : undefined
+    : TErrorPolicy
   >;
 
   namespace DocumentationTypes {
@@ -441,10 +454,19 @@ export declare namespace useLazyQuery {
             >]?: never;
           };
         },
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options?: TOptions
-      ): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
+        options?: TOptions & {
+          /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
+          errorPolicy?: TErrorPolicy;
+        }
+      ): useLazyQuery.ResultForOptions<
+        TData,
+        TVariables,
+        TOptions,
+        TErrorPolicy
+      >;
     }
 
     export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;


### PR DESCRIPTION
Fixes #13371

The `useLazyQuery` `execute` function's return type hardcoded `ApolloClient.QueryResult<TData>` without threading the hook-level `errorPolicy`, so the resolved `data` was always typed as possibly `undefined`, even with `errorPolicy: "none"` where the promise rejects on GraphQL errors instead of resolving with partial data.

## Changes

- Added a `TErrorPolicy` type parameter to `ExecFunction`, `ResultTuple`, and `ResultForOptions`, threading it into `ApolloClient.QueryResult<TData, TErrorPolicy>`.
- The modern signature now infers `TErrorPolicy` from the `errorPolicy` hook option, mirroring the pattern already used by `useMutation`.
- When no `errorPolicy` is provided, it falls back to `DefaultOptions.errorPolicy` (matches `useMutation` behavior).

## Testing

- Added a type test asserting `data` is narrowed for `errorPolicy: "none"`, `"all"`, and `"ignore"`, plus the default case.
- Updated existing type tests that asserted `execute()` resolves with `data: Query | undefined` in the default case, since the default `errorPolicy` of `"none"` now narrows `data` to defined.
- Ran the type tests, unit tests for `useLazyQuery`, prettier, eslint, and the api-extractor build.

## Changesets

Added a `patch` changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript inference for `useLazyQuery` execution results based on the configured `errorPolicy`.
  * Results now correctly indicate when data is guaranteed to be defined with the default policy or `errorPolicy: "none"`.
  * Preserved optional data typing for `errorPolicy: "all"` and `"ignore"`.
* **Documentation**
  * Added release notes describing the updated `useLazyQuery` return types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->