### PR TITLE
Adjust local-state/export tests broken due to changes in 4.3

### DIFF
--- a/src/__tests__/local-state/export.ts
+++ b/src/__tests__/local-state/export.ts
@@ -1349,10 +1349,10 @@ describe("@client @export tests", () => {
         userId: "1",
         friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
       }),
-      dataState: "streaming",
+      dataState: "complete",
       loading: true,
       networkStatus: NetworkStatus.streaming,
-      partial: true,
+      partial: false,
     });
 
     client.writeFragment({
@@ -2049,10 +2049,10 @@ describe("@client @export tests", () => {
         userId: "1",
         friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
       }),
-      dataState: "streaming",
+      dataState: "complete",
       loading: true,
       networkStatus: NetworkStatus.streaming,
-      partial: true,
+      partial: false,
     });
 
     client.writeQuery({


### PR DESCRIPTION
Fixes broken local-state/export tests added to `main` that changed `dataState` values in 4.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated streamed-response test expectations to reflect completed results and non-partial status for the initial response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->