### PR TITLE
Fix some wrong `dataState` values with network-only and errorPolicy: "none" queries

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1407,8 +1407,8 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 // Warnings were encountered during analysis:
 //
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:376:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -197,13 +197,13 @@ export namespace Incremental {
     }
     // (undocumented)
     export interface IncrementalRequest<Chunk extends Record<string, unknown>, TData> {
-        // (undocumented)
+        // @internal @deprecated (undocumented)
         getPendingWithInfo?: () => Array<PendingItemWithInfo>;
         // (undocumented)
         handle: (cacheData: TData | DeepPartial<TData> | undefined | null, chunk: Chunk) => FormattedExecutionResult<TData>;
         // (undocumented)
         hasNext: boolean;
-        // (undocumented)
+        // @internal @deprecated (undocumented)
         readonly streamInfo?: StreamInfoTrie;
     }
     // (undocumented)
@@ -217,10 +217,7 @@ export namespace Incremental {
         // (undocumented)
         type: "defer";
     }
-    // Warning: (ae-incompatible-release-tags) The symbol "PendingItemWithInfo" is marked as @public, but its signature references "Incremental" which is marked as @internal
-    // Warning: (ae-incompatible-release-tags) The symbol "PendingItemWithInfo" is marked as @public, but its signature references "Incremental" which is marked as @internal
-    //
-    // (undocumented)
+    // @internal @deprecated (undocumented)
     export type PendingItemWithInfo = PendingDeferResultWithInfo | PendingStreamResultWithInfo;
     // (undocumented)
     export interface PendingResult {

--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -197,16 +197,28 @@ export namespace Incremental {
     // (undocumented)
     export interface IncrementalRequest<Chunk extends Record<string, unknown>, TData> {
         // (undocumented)
-        getPendingType?: (id: string) => "defer" | "stream";
+        getPendingWithInfo?: () => Array<PendingItemWithInfo>;
         // (undocumented)
         handle: (cacheData: TData | DeepPartial<TData> | undefined | null, chunk: Chunk) => FormattedExecutionResult<TData>;
         // (undocumented)
         hasNext: boolean;
-        // (undocumented)
-        pending?: Array<Incremental.PendingResult>;
     }
     // (undocumented)
     export type Path = ReadonlyArray<string | number>;
+    // @internal @deprecated (undocumented)
+    export interface PendingDeferResultWithInfo {
+        // (undocumented)
+        delivered: boolean;
+        // (undocumented)
+        path: Incremental.Path;
+        // (undocumented)
+        type: "defer";
+    }
+    // Warning: (ae-incompatible-release-tags) The symbol "PendingItemWithInfo" is marked as @public, but its signature references "Incremental" which is marked as @internal
+    // Warning: (ae-incompatible-release-tags) The symbol "PendingItemWithInfo" is marked as @public, but its signature references "Incremental" which is marked as @internal
+    //
+    // (undocumented)
+    export type PendingItemWithInfo = PendingDeferResultWithInfo | PendingStreamResultWithInfo;
     // (undocumented)
     export interface PendingResult {
         // (undocumented)
@@ -215,6 +227,13 @@ export namespace Incremental {
         label?: string;
         // (undocumented)
         path: Incremental.Path;
+    }
+    // @internal @deprecated (undocumented)
+    export interface PendingStreamResultWithInfo {
+        // (undocumented)
+        path: Incremental.Path;
+        // (undocumented)
+        type: "stream";
     }
     // @internal @deprecated (undocumented)
     export interface StartRequestOptions {
@@ -233,13 +252,19 @@ export namespace Incremental {
 // @public (undocumented)
 class IncrementalRequest<TData> implements Incremental.IncrementalRequest<GraphQL17Alpha9Handler.Chunk<TData>, TData> {
     // (undocumented)
-    getPendingType(id: string): "defer" | "stream";
+    getPendingWithInfo(): ({
+        type: "stream";
+        path: Incremental.Path;
+        delivered?: undefined;
+    } | {
+        type: "defer";
+        delivered: boolean;
+        path: Incremental.Path;
+    })[];
     // (undocumented)
     handle(cacheData: TData | DeepPartial<TData> | null | undefined, chunk: GraphQL17Alpha9Handler.Chunk<TData>): FormattedExecutionResult<TData>;
     // (undocumented)
     hasNext: boolean;
-    // (undocumented)
-    get pending(): GraphQL17Alpha9Handler.PendingResult[];
 }
 
 // @public (undocumented)

--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -251,7 +251,7 @@ export namespace Incremental {
 
 // @public (undocumented)
 class IncrementalRequest<TData> implements Incremental.IncrementalRequest<GraphQL17Alpha9Handler.Chunk<TData>, TData> {
-    // (undocumented)
+    // @internal @deprecated (undocumented)
     getPendingWithInfo(): ({
         type: "stream";
         path: Incremental.Path;
@@ -265,7 +265,7 @@ class IncrementalRequest<TData> implements Incremental.IncrementalRequest<GraphQ
     handle(cacheData: TData | DeepPartial<TData> | null | undefined, chunk: GraphQL17Alpha9Handler.Chunk<TData>): FormattedExecutionResult<TData>;
     // (undocumented)
     hasNext: boolean;
-    // (undocumented)
+    // @internal @deprecated (undocumented)
     get streamInfo(): StreamInfoTrie | undefined;
 }
 

--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -10,9 +10,7 @@ import type { DocumentNode } from 'graphql';
 import type { FormattedExecutionResult } from 'graphql';
 import type { GraphQLFormattedError } from 'graphql';
 import type { HKT } from '@apollo/client/utilities';
-import type { Incremental as Incremental_2 } from '@apollo/client/incremental';
-import { StreamInfoTrie as StreamInfoTrie_2 } from '@apollo/client/utilities/internal';
-import type { Trie } from '@wry/trie';
+import { StreamInfoTrie } from '@apollo/client/utilities/internal';
 
 // @public (undocumented)
 namespace Defer20220824Handler {
@@ -205,8 +203,6 @@ export namespace Incremental {
         handle: (cacheData: TData | DeepPartial<TData> | undefined | null, chunk: Chunk) => FormattedExecutionResult<TData>;
         // (undocumented)
         hasNext: boolean;
-        // Warning: (ae-forgotten-export) The symbol "StreamInfoTrie" needs to be exported by the entry point index.d.ts
-        //
         // (undocumented)
         readonly streamInfo?: StreamInfoTrie;
     }
@@ -273,7 +269,7 @@ class IncrementalRequest<TData> implements Incremental.IncrementalRequest<GraphQ
     // (undocumented)
     hasNext: boolean;
     // (undocumented)
-    get streamInfo(): StreamInfoTrie_2 | undefined;
+    get streamInfo(): StreamInfoTrie | undefined;
 }
 
 // @public (undocumented)
@@ -305,33 +301,6 @@ export class NotImplementedHandler implements Incremental.Handler<never> {
     // (undocumented)
     startRequest: any;
 }
-
-// @public (undocumented)
-class StreamArrayState {
-    constructor(path: Incremental_2.Path);
-    // (undocumented)
-    depend(): void;
-    // (undocumented)
-    get streamPosition(): number;
-    set streamPosition(value: number);
-    // (undocumented)
-    truncate: boolean;
-}
-
-// @internal @deprecated (undocumented)
-type StreamInfoTrie = Trie<{
-    current: Incremental_2.StreamFieldInfo;
-    state: StreamArrayState;
-    previous?: {
-        incoming: unknown;
-        streamFieldInfo: Incremental_2.StreamFieldInfo;
-        result: unknown;
-    };
-}>;
-
-// Warnings were encountered during analysis:
-//
-// src/utilities/internal/types/StreamInfoTrie.ts:10:3 - (ae-forgotten-export) The symbol "StreamArrayState" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -10,6 +10,9 @@ import type { DocumentNode } from 'graphql';
 import type { FormattedExecutionResult } from 'graphql';
 import type { GraphQLFormattedError } from 'graphql';
 import type { HKT } from '@apollo/client/utilities';
+import type { Incremental as Incremental_2 } from '@apollo/client/incremental';
+import { StreamInfoTrie as StreamInfoTrie_2 } from '@apollo/client/utilities/internal';
+import type { Trie } from '@wry/trie';
 
 // @public (undocumented)
 namespace Defer20220824Handler {
@@ -202,6 +205,10 @@ export namespace Incremental {
         handle: (cacheData: TData | DeepPartial<TData> | undefined | null, chunk: Chunk) => FormattedExecutionResult<TData>;
         // (undocumented)
         hasNext: boolean;
+        // Warning: (ae-forgotten-export) The symbol "StreamInfoTrie" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
+        readonly streamInfo?: StreamInfoTrie;
     }
     // (undocumented)
     export type Path = ReadonlyArray<string | number>;
@@ -265,6 +272,8 @@ class IncrementalRequest<TData> implements Incremental.IncrementalRequest<GraphQ
     handle(cacheData: TData | DeepPartial<TData> | null | undefined, chunk: GraphQL17Alpha9Handler.Chunk<TData>): FormattedExecutionResult<TData>;
     // (undocumented)
     hasNext: boolean;
+    // (undocumented)
+    get streamInfo(): StreamInfoTrie_2 | undefined;
 }
 
 // @public (undocumented)
@@ -296,6 +305,33 @@ export class NotImplementedHandler implements Incremental.Handler<never> {
     // (undocumented)
     startRequest: any;
 }
+
+// @public (undocumented)
+class StreamArrayState {
+    constructor(path: Incremental_2.Path);
+    // (undocumented)
+    depend(): void;
+    // (undocumented)
+    get streamPosition(): number;
+    set streamPosition(value: number);
+    // (undocumented)
+    truncate: boolean;
+}
+
+// @internal @deprecated (undocumented)
+type StreamInfoTrie = Trie<{
+    current: Incremental_2.StreamFieldInfo;
+    state: StreamArrayState;
+    previous?: {
+        incoming: unknown;
+        streamFieldInfo: Incremental_2.StreamFieldInfo;
+        result: unknown;
+    };
+}>;
+
+// Warnings were encountered during analysis:
+//
+// src/utilities/internal/types/StreamInfoTrie.ts:10:3 - (ae-forgotten-export) The symbol "StreamArrayState" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1633,6 +1633,8 @@ namespace Incremental {
         handle: (cacheData: TData | DeepPartial<TData> | undefined | null, chunk: Chunk) => FormattedExecutionResult<TData>;
         // (undocumented)
         hasNext: boolean;
+        // (undocumented)
+        readonly streamInfo?: StreamInfoTrie;
     }
     // (undocumented)
     type Path = ReadonlyArray<string | number>;
@@ -3313,8 +3315,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:162:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
-// src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:376:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:202:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:245:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1627,13 +1627,13 @@ namespace Incremental {
     interface IncrementalRequest<Chunk extends Record<string, unknown>, TData> {
         // Warning: (ae-forgotten-export) The symbol "Incremental" needs to be exported by the entry point index.d.ts
         //
-        // (undocumented)
+        // @internal @deprecated (undocumented)
         getPendingWithInfo?: () => Array<PendingItemWithInfo>;
         // (undocumented)
         handle: (cacheData: TData | DeepPartial<TData> | undefined | null, chunk: Chunk) => FormattedExecutionResult<TData>;
         // (undocumented)
         hasNext: boolean;
-        // (undocumented)
+        // @internal @deprecated (undocumented)
         readonly streamInfo?: StreamInfoTrie;
     }
     // (undocumented)
@@ -1650,7 +1650,7 @@ namespace Incremental {
     // Warning: (ae-forgotten-export) The symbol "Incremental" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "Incremental" needs to be exported by the entry point index.d.ts
     //
-    // (undocumented)
+    // @internal @deprecated (undocumented)
     type PendingItemWithInfo = PendingDeferResultWithInfo | PendingStreamResultWithInfo;
     // (undocumented)
     interface PendingResult {

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -1625,17 +1625,31 @@ namespace Incremental {
     }
     // (undocumented)
     interface IncrementalRequest<Chunk extends Record<string, unknown>, TData> {
+        // Warning: (ae-forgotten-export) The symbol "Incremental" needs to be exported by the entry point index.d.ts
+        //
         // (undocumented)
-        getPendingType?: (id: string) => "defer" | "stream";
+        getPendingWithInfo?: () => Array<PendingItemWithInfo>;
         // (undocumented)
         handle: (cacheData: TData | DeepPartial<TData> | undefined | null, chunk: Chunk) => FormattedExecutionResult<TData>;
         // (undocumented)
         hasNext: boolean;
-        // (undocumented)
-        pending?: Array<Incremental.PendingResult>;
     }
     // (undocumented)
     type Path = ReadonlyArray<string | number>;
+    // @internal @deprecated (undocumented)
+    interface PendingDeferResultWithInfo {
+        // (undocumented)
+        delivered: boolean;
+        // (undocumented)
+        path: Incremental.Path;
+        // (undocumented)
+        type: "defer";
+    }
+    // Warning: (ae-forgotten-export) The symbol "Incremental" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Incremental" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    type PendingItemWithInfo = PendingDeferResultWithInfo | PendingStreamResultWithInfo;
     // (undocumented)
     interface PendingResult {
         // (undocumented)
@@ -1644,6 +1658,13 @@ namespace Incremental {
         label?: string;
         // (undocumented)
         path: Incremental.Path;
+    }
+    // @internal @deprecated (undocumented)
+    interface PendingStreamResultWithInfo {
+        // (undocumented)
+        path: Incremental.Path;
+        // (undocumented)
+        type: "stream";
     }
     // @internal @deprecated (undocumented)
     interface StartRequestOptions {

--- a/.changeset/chilly-actors-complain.md
+++ b/.changeset/chilly-actors-complain.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where a `network-only` query leaked partial cache data for `@defer` fragments that were not delivered by the network due to an error that bubbled to the `@defer` fragment boundary.

--- a/.changeset/loud-bulldogs-pay.md
+++ b/.changeset/loud-bulldogs-pay.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an issue where a `@defer` query reported the `dataState` as `complete` instead of `streaming` when an error occurs on a deferred field that bubbled to the defer boundary.

--- a/.changeset/swift-starfishes-know.md
+++ b/.changeset/swift-starfishes-know.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix an invariant error thrown when a `@defer` boundary received a payload after it had already been marked complete.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 51011,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 45357,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 38419,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31820
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 51378,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 45439,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 38760,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31837
 }

--- a/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
+++ b/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
@@ -9645,6 +9645,57 @@ test("strips both a partial pending @defer boundary and a complete pending sibli
   });
 });
 
+test("keeps fields shared with a delivered @defer boundary while pruning a pending boundary at a nested path", () => {
+  const cache = new InMemoryCache();
+  const query = gql`
+    query {
+      ... @defer {
+        hero {
+          name
+        }
+      }
+      hero {
+        id
+        ... @defer {
+          name
+          homePlanet
+        }
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      hero: {
+        __typename: "Hero",
+        id: "1",
+        name: "Luke",
+        homePlanet: "Tatooine",
+      },
+    },
+  });
+
+  const deferInfo: DeferInfoTrie = new Trie();
+  deferInfo.lookup("hero");
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: true,
+      returnPartialData: false,
+      [handleIncrementalSymbol]: { deferInfo },
+    })
+  ).toStrictEqualTyped({
+    result: markAsStreaming({
+      hero: { __typename: "Hero", id: "1", name: "Luke" },
+    }),
+    dataState: "streaming",
+    complete: false,
+    missing: undefined,
+  });
+});
+
 function getMissingMessage(fieldName: string, obj: Record<string, unknown>) {
   return `Can't find field '${fieldName}' on ${
     isReference(obj) ?

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -55,6 +55,7 @@ import type {
   UpdateQueryOptions,
   WatchQueryFetchPolicy,
 } from "./watchQueryOptions.js";
+import { dataStateErrorCache } from "./dataStateErrorCache.js";
 
 const { assign, hasOwnProperty } = Object;
 
@@ -2022,7 +2023,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         : notification.value;
 
       if (notification.kind === "E" && result.dataState === "streaming") {
-        result.dataState = "complete" as any;
+        result.dataState =
+          dataStateErrorCache.get(notification.error) ?? ("complete" as any);
       }
 
       if (result.error) {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -34,6 +34,7 @@ import {
 import { invariant } from "@apollo/client/utilities/invariant";
 
 import type { ApolloClient } from "./ApolloClient.js";
+import { dataStateErrorCache } from "./dataStateErrorCache.js";
 import { NetworkStatus } from "./networkStatus.js";
 import type { QueryManager } from "./QueryManager.js";
 import type {
@@ -55,7 +56,6 @@ import type {
   UpdateQueryOptions,
   WatchQueryFetchPolicy,
 } from "./watchQueryOptions.js";
-import { dataStateErrorCache } from "./dataStateErrorCache.js";
 
 const { assign, hasOwnProperty } = Object;
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -399,7 +399,7 @@ export class QueryInfo<
             // Never deliver partial data for network-only requests
             returnPartialData: returnPartialData && !isNetworkOnly,
           },
-          this.getIncrementalInfo(result, { isNetworkOnly })
+          this.getIncrementalInfo({ isNetworkOnly })
         );
 
         if (
@@ -430,12 +430,9 @@ export class QueryInfo<
     return result;
   }
 
-  private getIncrementalInfo(
-    result: MarkQueryResult<any, ExtensionsWithStreamInfo>,
-    { isNetworkOnly }: { isNetworkOnly: boolean }
-  ) {
+  private getIncrementalInfo({ isNetworkOnly }: { isNetworkOnly: boolean }) {
     const pending = this.incremental?.getPendingWithInfo?.() ?? [];
-    const streamInfo = result.extensions?.[streamInfoSymbol]?.deref();
+    const streamInfo = this.incremental?.streamInfo;
     const incrementalInfo: DiffIncrementalInfo = { streamInfo };
 
     // We don't want to deliver stream items or complete defer boundaries

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -301,7 +301,7 @@ export class QueryInfo<
         // to see if it fulfills the selection set. For such a narrow case where
         // its incorrect on a format that is now outdated is not worth the
         // fix so we are ok with reporting a `streaming` here.
-        (!this.incremental?.pending &&
+        (!this.incremental?.getPendingWithInfo &&
           this.hasNext &&
           hasDirectives(["defer"], query))
       ) {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -18,7 +18,6 @@ import {
   graphQLResultHasError,
   handleIncrementalSymbol,
   hasDirectives,
-  streamInfoSymbol,
 } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -254,6 +254,8 @@ export class QueryInfo<
       variables,
       optimistic: true,
     };
+    const isNetworkOnly =
+      fetchPolicy === "network-only" && networkStatus !== NetworkStatus.refetch;
 
     // Cancel the pending notify timeout (if it exists) to prevent extraneous network
     // requests. To allow future notify timeouts, diff and dirty are reset as well.
@@ -262,15 +264,23 @@ export class QueryInfo<
     const skipCache = cacheWriteBehavior === CacheWriteBehavior.FORBID;
     const diff =
       skipCache ? undefined : (
-        this.getDiff({
-          ...diffOptions,
-          // Always request partial data to ensure the network incremental
-          // result is merged with all existing data (especially true to
-          // maintain @stream arrays with partial list items in the right order
-          // or when chunk might otherwise replace a partial non-normalized
-          // object)
-          returnPartialData: true,
-        })
+        this.getDiff(
+          {
+            ...diffOptions,
+            // We usually request partial data to ensure the network incremental
+            // result is merged with all existing data (especially true to
+            // maintain @stream arrays with partial list items in the right order
+            // or when chunk might otherwise replace a partial non-normalized
+            // object), but if we are about to throw away the result anyways due
+            // to the error policy (which early returns below), prune any
+            // pending boundaries so that CombinedGraphQLErrors contains the
+            // right `data` value.
+            returnPartialData:
+              errorPolicy !== "none" ||
+              !this.incrementalHandler.extractErrors(incoming)?.length,
+          },
+          this.getIncrementalInfo({ isNetworkOnly })
+        )
       );
 
     const incrementalResult = this.maybeHandleIncrementalResult(
@@ -388,10 +398,6 @@ export class QueryInfo<
           };
           written = true;
         }
-
-        const isNetworkOnly =
-          fetchPolicy === "network-only" &&
-          networkStatus !== NetworkStatus.refetch;
 
         const { dataState, result: diffResult } = this.getDiff(
           {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -203,6 +203,10 @@ export class QueryInfo<
     return this.incremental ? this.incremental.hasNext : false;
   }
 
+  get incrementalHandler() {
+    return this.queryManager.incrementalHandler;
+  }
+
   private maybeHandleIncrementalResult(
     cacheData: TData | DeepPartial<TData> | undefined | null,
     incoming: ApolloLink.Result<TData>,
@@ -211,10 +215,8 @@ export class QueryInfo<
     DataValue.Complete<TData> | DataValue.Streaming<TData>,
     ExtensionsWithStreamInfo
   > {
-    const { incrementalHandler } = this.queryManager;
-
-    if (incrementalHandler.isIncrementalResult(incoming)) {
-      this.incremental ||= incrementalHandler.startRequest<
+    if (this.incrementalHandler.isIncrementalResult(incoming)) {
+      this.incremental ||= this.incrementalHandler.startRequest<
         TData & Record<string, unknown>
       >({
         query,

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -263,7 +263,9 @@ export class QueryInfo<
           ...diffOptions,
           // Always request partial data to ensure the network incremental
           // result is merged with all existing data (especially true to
-          // maintain @stream arrays with partial list items in the right order)
+          // maintain @stream arrays with partial list items in the right order
+          // or when chunk might otherwise replace a partial non-normalized
+          // object)
           returnPartialData: true,
         })
       );

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -293,33 +293,33 @@ export class QueryInfo<
       dataState: incrementalResult.data == null ? "empty" : "complete",
     };
 
+    const hasPendingDefer = this.incremental
+      ?.getPendingWithInfo?.()
+      .some((pending) => pending.type === "defer" && !pending.delivered);
+
+    if (
+      hasPendingDefer ||
+      // The Defer20220824Handler cannot track pending/completed incremental
+      // chunks due to its data format so we naively set dataState to
+      // streaming if we are still processing chunks. The only case where
+      // streaming is incorrect and should actually be complete is when
+      // both a @defer and @stream boundary is present and the @defer chunk
+      // has completed before the `@stream` array.
+      //
+      // Assigning the naive "streaming" value avoids a much more expensive
+      // pass over `result.data` that would otherwise need to traverse the
+      // selection sets and evaluate the data object at each defer boundary
+      // to see if it fulfills the selection set. For such a narrow case where
+      // its incorrect on a format that is now outdated is not worth the
+      // fix so we are ok with reporting a `streaming` here.
+      (!this.incremental?.getPendingWithInfo &&
+        this.hasNext &&
+        hasDirectives(["defer"], query))
+    ) {
+      result.dataState = "streaming";
+    }
+
     if (skipCache) {
-      const hasPendingDefer = this.incremental
-        ?.getPendingWithInfo?.()
-        .some((pending) => pending.type === "defer" && !pending.delivered);
-
-      if (
-        hasPendingDefer ||
-        // The Defer20220824Handler cannot track pending/completed incremental
-        // chunks due to its data format so we naively set dataState to
-        // streaming if we are still processing chunks. The only case where
-        // streaming is incorrect and should actually be complete is when
-        // both a @defer and @stream boundary is present and the @defer chunk
-        // has completed before the `@stream` array.
-        //
-        // Assigning the naive "streaming" value avoids a much more expensive
-        // pass over `result.data` that would otherwise need to traverse the
-        // selection sets and evaluate the data object at each defer boundary
-        // to see if it fulfills the selection set. For such a narrow case where
-        // its incorrect on a format that is now outdated is not worth the
-        // fix so we are ok with reporting a `streaming` here.
-        (!this.incremental?.getPendingWithInfo &&
-          this.hasNext &&
-          hasDirectives(["defer"], query))
-      ) {
-        result.dataState = "streaming";
-      }
-
       return result;
     }
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -19,7 +19,6 @@ import {
   graphQLResultHasError,
   handleIncrementalSymbol,
   hasDirectives,
-  streamInfoSymbol,
 } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -60,6 +60,7 @@ interface LastWrite {
   result: FormattedExecutionResult<any, ExtensionsWithStreamInfo>;
   variables: ApolloClient.WatchQueryOptions["variables"];
   dmCount: number | undefined;
+  hasNext: boolean;
 }
 
 const destructiveMethodCounts = new WeakMap<ApolloCache, number>();
@@ -194,8 +195,7 @@ export class QueryInfo<
       // We have to compare these values because its possible the final chunk
       // emitted in the incremental result is just `hasNext: false`. This
       // ensures we trigger a cache write when we get `isLastChunk: true`.
-      result.extensions?.[streamInfoSymbol] !==
-        lastWrite.result.extensions?.[streamInfoSymbol]
+      lastWrite.hasNext !== this.hasNext
     );
   }
 
@@ -392,6 +392,7 @@ export class QueryInfo<
             result,
             variables,
             dmCount: destructiveMethodCounts.get(this.cache),
+            hasNext: this.hasNext,
           };
         }
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -395,7 +395,7 @@ export class QueryInfo<
             // Never deliver partial data for network-only requests
             returnPartialData: returnPartialData && !isNetworkOnly,
           },
-          this.getIncrementalInfo(result, { isNetworkOnly })
+          this.getIncrementalInfo({ isNetworkOnly })
         );
 
         if (
@@ -411,12 +411,9 @@ export class QueryInfo<
     return result;
   }
 
-  private getIncrementalInfo(
-    result: MarkQueryResult<any, ExtensionsWithStreamInfo>,
-    { isNetworkOnly }: { isNetworkOnly: boolean }
-  ) {
+  private getIncrementalInfo({ isNetworkOnly }: { isNetworkOnly: boolean }) {
     const pending = this.incremental?.getPendingWithInfo?.() ?? [];
-    const streamInfo = result.extensions?.[streamInfoSymbol]?.deref();
+    const streamInfo = this.incremental?.streamInfo;
     const incrementalInfo: DiffIncrementalInfo = { streamInfo };
 
     // We don't want to deliver stream items or complete defer boundaries

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -264,7 +264,9 @@ export class QueryInfo<
           ...diffOptions,
           // Always request partial data to ensure the network incremental
           // result is merged with all existing data (especially true to
-          // maintain @stream arrays with partial list items in the right order)
+          // maintain @stream arrays with partial list items in the right order
+          // or when chunk might otherwise replace a partial non-normalized
+          // object)
           returnPartialData: true,
         })
       );

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -61,6 +61,7 @@ interface LastWrite {
   result: FormattedExecutionResult<any, ExtensionsWithStreamInfo>;
   variables: ApolloClient.WatchQueryOptions["variables"];
   dmCount: number | undefined;
+  hasNext: boolean;
 }
 
 const destructiveMethodCounts = new WeakMap<ApolloCache, number>();
@@ -195,8 +196,7 @@ export class QueryInfo<
       // We have to compare these values because its possible the final chunk
       // emitted in the incremental result is just `hasNext: false`. This
       // ensures we trigger a cache write when we get `isLastChunk: true`.
-      result.extensions?.[streamInfoSymbol] !==
-        lastWrite.result.extensions?.[streamInfoSymbol]
+      lastWrite.hasNext !== this.hasNext
     );
   }
 
@@ -395,6 +395,7 @@ export class QueryInfo<
             result,
             variables,
             dmCount: destructiveMethodCounts.get(this.cache),
+            hasNext: this.hasNext,
           };
           written = true;
         }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -282,9 +282,9 @@ export class QueryInfo<
     };
 
     if (skipCache) {
-      const hasPendingDefer = this.incremental?.pending?.some(
-        (pending) => this.incremental?.getPendingType?.(pending.id) === "defer"
-      );
+      const hasPendingDefer = this.incremental
+        ?.getPendingWithInfo?.()
+        .some((pending) => pending.type === "defer" && !pending.delivered);
 
       if (
         hasPendingDefer ||
@@ -413,7 +413,7 @@ export class QueryInfo<
     result: MarkQueryResult<any, ExtensionsWithStreamInfo>,
     { isNetworkOnly }: { isNetworkOnly: boolean }
   ) {
-    const pending = this.incremental?.pending ?? [];
+    const pending = this.incremental?.getPendingWithInfo?.() ?? [];
     const streamInfo = result.extensions?.[streamInfoSymbol]?.deref();
     const incrementalInfo: DiffIncrementalInfo = { streamInfo };
 
@@ -423,12 +423,12 @@ export class QueryInfo<
     // can prune complete defer/stream boundaries at those paths.
     if (isNetworkOnly) {
       for (const item of pending) {
-        const type = this.incremental?.getPendingType?.(item.id);
-
-        if (type === "defer") {
+        if (item.type === "defer") {
           incrementalInfo.deferInfo ||= new Trie(true, () => true);
-          incrementalInfo.deferInfo.lookupArray(item.path as any[]);
-        } else if (streamInfo && type === "stream") {
+          if (!item.delivered) {
+            incrementalInfo.deferInfo.lookupArray(item.path as any[]);
+          }
+        } else if (streamInfo && item.type === "stream") {
           streamInfo.lookupArray(item.path as any[]).state.truncate = true;
         }
       }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -396,8 +396,8 @@ export class QueryInfo<
 
         if (
           dataState === "complete" ||
-          (returnPartialData && dataState === "partial" && shouldWrite) ||
-          (this.hasNext && dataState === "streaming")
+          dataState === "streaming" ||
+          (returnPartialData && dataState === "partial" && shouldWrite)
         ) {
           result = { ...result, data: diffResult, dataState };
         }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -441,11 +441,9 @@ export class QueryInfo<
     // can prune complete defer/stream boundaries at those paths.
     if (isNetworkOnly) {
       for (const item of pending) {
-        if (item.type === "defer") {
+        if (item.type === "defer" && !item.delivered) {
           incrementalInfo.deferInfo ||= new Trie(true, () => true);
-          if (!item.delivered) {
-            incrementalInfo.deferInfo.lookupArray(item.path as any[]);
-          }
+          incrementalInfo.deferInfo.lookupArray(item.path as any[]);
         } else if (streamInfo && item.type === "stream") {
           streamInfo.lookupArray(item.path as any[]).state.truncate = true;
         }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -302,7 +302,7 @@ export class QueryInfo<
         // to see if it fulfills the selection set. For such a narrow case where
         // its incorrect on a format that is now outdated is not worth the
         // fix so we are ok with reporting a `streaming` here.
-        (!this.incremental?.pending &&
+        (!this.incremental?.getPendingWithInfo &&
           this.hasNext &&
           hasDirectives(["defer"], query))
       ) {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -422,11 +422,9 @@ export class QueryInfo<
     // can prune complete defer/stream boundaries at those paths.
     if (isNetworkOnly) {
       for (const item of pending) {
-        if (item.type === "defer") {
+        if (item.type === "defer" && !item.delivered) {
           incrementalInfo.deferInfo ||= new Trie(true, () => true);
-          if (!item.delivered) {
-            incrementalInfo.deferInfo.lookupArray(item.path as any[]);
-          }
+          incrementalInfo.deferInfo.lookupArray(item.path as any[]);
         } else if (streamInfo && item.type === "stream") {
           streamInfo.lookupArray(item.path as any[]).state.truncate = true;
         }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -294,33 +294,33 @@ export class QueryInfo<
       dataState: incrementalResult.data == null ? "empty" : "complete",
     };
 
+    const hasPendingDefer = this.incremental
+      ?.getPendingWithInfo?.()
+      .some((pending) => pending.type === "defer" && !pending.delivered);
+
+    if (
+      hasPendingDefer ||
+      // The Defer20220824Handler cannot track pending/completed incremental
+      // chunks due to its data format so we naively set dataState to
+      // streaming if we are still processing chunks. The only case where
+      // streaming is incorrect and should actually be complete is when
+      // both a @defer and @stream boundary is present and the @defer chunk
+      // has completed before the `@stream` array.
+      //
+      // Assigning the naive "streaming" value avoids a much more expensive
+      // pass over `result.data` that would otherwise need to traverse the
+      // selection sets and evaluate the data object at each defer boundary
+      // to see if it fulfills the selection set. For such a narrow case where
+      // its incorrect on a format that is now outdated is not worth the
+      // fix so we are ok with reporting a `streaming` here.
+      (!this.incremental?.getPendingWithInfo &&
+        this.hasNext &&
+        hasDirectives(["defer"], query))
+    ) {
+      result.dataState = "streaming";
+    }
+
     if (skipCache) {
-      const hasPendingDefer = this.incremental
-        ?.getPendingWithInfo?.()
-        .some((pending) => pending.type === "defer" && !pending.delivered);
-
-      if (
-        hasPendingDefer ||
-        // The Defer20220824Handler cannot track pending/completed incremental
-        // chunks due to its data format so we naively set dataState to
-        // streaming if we are still processing chunks. The only case where
-        // streaming is incorrect and should actually be complete is when
-        // both a @defer and @stream boundary is present and the @defer chunk
-        // has completed before the `@stream` array.
-        //
-        // Assigning the naive "streaming" value avoids a much more expensive
-        // pass over `result.data` that would otherwise need to traverse the
-        // selection sets and evaluate the data object at each defer boundary
-        // to see if it fulfills the selection set. For such a narrow case where
-        // its incorrect on a format that is now outdated is not worth the
-        // fix so we are ok with reporting a `streaming` here.
-        (!this.incremental?.getPendingWithInfo &&
-          this.hasNext &&
-          hasDirectives(["defer"], query))
-      ) {
-        result.dataState = "streaming";
-      }
-
       return result;
     }
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -204,6 +204,10 @@ export class QueryInfo<
     return this.incremental ? this.incremental.hasNext : false;
   }
 
+  get incrementalHandler() {
+    return this.queryManager.incrementalHandler;
+  }
+
   private maybeHandleIncrementalResult(
     cacheData: TData | DeepPartial<TData> | undefined | null,
     incoming: ApolloLink.Result<TData>,
@@ -212,10 +216,8 @@ export class QueryInfo<
     DataValue.Complete<TData> | DataValue.Streaming<TData>,
     ExtensionsWithStreamInfo
   > {
-    const { incrementalHandler } = this.queryManager;
-
-    if (incrementalHandler.isIncrementalResult(incoming)) {
-      this.incremental ||= incrementalHandler.startRequest<
+    if (this.incrementalHandler.isIncrementalResult(incoming)) {
+      this.incremental ||= this.incrementalHandler.startRequest<
         TData & Record<string, unknown>
       >({
         query,

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -253,6 +253,8 @@ export class QueryInfo<
       variables,
       optimistic: true,
     };
+    const isNetworkOnly =
+      fetchPolicy === "network-only" && networkStatus !== NetworkStatus.refetch;
 
     // Cancel the pending notify timeout (if it exists) to prevent extraneous network
     // requests. To allow future notify timeouts, diff and dirty are reset as well.
@@ -261,15 +263,23 @@ export class QueryInfo<
     const skipCache = cacheWriteBehavior === CacheWriteBehavior.FORBID;
     const diff =
       skipCache ? undefined : (
-        this.getDiff({
-          ...diffOptions,
-          // Always request partial data to ensure the network incremental
-          // result is merged with all existing data (especially true to
-          // maintain @stream arrays with partial list items in the right order
-          // or when chunk might otherwise replace a partial non-normalized
-          // object)
-          returnPartialData: true,
-        })
+        this.getDiff(
+          {
+            ...diffOptions,
+            // We usually request partial data to ensure the network incremental
+            // result is merged with all existing data (especially true to
+            // maintain @stream arrays with partial list items in the right order
+            // or when chunk might otherwise replace a partial non-normalized
+            // object), but if we are about to throw away the result anyways due
+            // to the error policy (which early returns below), prune any
+            // pending boundaries so that CombinedGraphQLErrors contains the
+            // right `data` value.
+            returnPartialData:
+              errorPolicy !== "none" ||
+              !this.incrementalHandler.extractErrors(incoming)?.length,
+          },
+          this.getIncrementalInfo({ isNetworkOnly })
+        )
       );
 
     const incrementalResult = this.maybeHandleIncrementalResult(
@@ -384,10 +394,6 @@ export class QueryInfo<
             dmCount: destructiveMethodCounts.get(this.cache),
           };
         }
-
-        const isNetworkOnly =
-          fetchPolicy === "network-only" &&
-          networkStatus !== NetworkStatus.refetch;
 
         const { dataState, result: diffResult } = this.getDiff(
           {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -400,8 +400,8 @@ export class QueryInfo<
 
         if (
           dataState === "complete" ||
-          (returnPartialData && dataState === "partial" && shouldWrite) ||
-          (this.hasNext && dataState === "streaming")
+          dataState === "streaming" ||
+          (returnPartialData && dataState === "partial" && shouldWrite)
         ) {
           result = { ...result, data: diffResult, dataState };
         } else if (

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -283,9 +283,9 @@ export class QueryInfo<
     };
 
     if (skipCache) {
-      const hasPendingDefer = this.incremental?.pending?.some(
-        (pending) => this.incremental?.getPendingType?.(pending.id) === "defer"
-      );
+      const hasPendingDefer = this.incremental
+        ?.getPendingWithInfo?.()
+        .some((pending) => pending.type === "defer" && !pending.delivered);
 
       if (
         hasPendingDefer ||
@@ -432,7 +432,7 @@ export class QueryInfo<
     result: MarkQueryResult<any, ExtensionsWithStreamInfo>,
     { isNetworkOnly }: { isNetworkOnly: boolean }
   ) {
-    const pending = this.incremental?.pending ?? [];
+    const pending = this.incremental?.getPendingWithInfo?.() ?? [];
     const streamInfo = result.extensions?.[streamInfoSymbol]?.deref();
     const incrementalInfo: DiffIncrementalInfo = { streamInfo };
 
@@ -442,12 +442,12 @@ export class QueryInfo<
     // can prune complete defer/stream boundaries at those paths.
     if (isNetworkOnly) {
       for (const item of pending) {
-        const type = this.incremental?.getPendingType?.(item.id);
-
-        if (type === "defer") {
+        if (item.type === "defer") {
           incrementalInfo.deferInfo ||= new Trie(true, () => true);
-          incrementalInfo.deferInfo.lookupArray(item.path as any[]);
-        } else if (streamInfo && type === "stream") {
+          if (!item.delivered) {
+            incrementalInfo.deferInfo.lookupArray(item.path as any[]);
+          }
+        } else if (streamInfo && item.type === "stream") {
           streamInfo.lookupArray(item.path as any[]).state.truncate = true;
         }
       }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -75,6 +75,7 @@ import {
 import { defaultCacheSizes } from "../utilities/caching/sizes.js";
 
 import type { ApolloClient } from "./ApolloClient.js";
+import { dataStateErrorCache } from "./dataStateErrorCache.js";
 import { NetworkStatus } from "./networkStatus.js";
 import { logMissingFieldErrors, ObservableQuery } from "./ObservableQuery.js";
 import { CacheWriteBehavior, QueryInfo } from "./QueryInfo.js";
@@ -95,7 +96,6 @@ import type {
   MutationFetchPolicy,
   WatchQueryFetchPolicy,
 } from "./watchQueryOptions.js";
-import { dataStateErrorCache } from "./dataStateErrorCache.js";
 
 interface MutationStoreValue {
   mutation: DocumentNode;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -95,6 +95,7 @@ import type {
   MutationFetchPolicy,
   WatchQueryFetchPolicy,
 } from "./watchQueryOptions.js";
+import { dataStateErrorCache } from "./dataStateErrorCache.js";
 
 interface MutationStoreValue {
   mutation: DocumentNode;
@@ -1079,9 +1080,12 @@ export class QueryManager {
         if (hasErrors && errorPolicy === "none") {
           queryInfo.resetLastWrite();
           observableQuery?.["resetNotifications"]();
-          throw new CombinedGraphQLErrors(
+          const error = new CombinedGraphQLErrors(
             removeStreamDetailsFromExtensions(result)
           );
+
+          dataStateErrorCache.set(error, dataState);
+          throw error;
         }
 
         const partial = dataState !== "complete";

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -6088,6 +6088,106 @@ test('does not return complete cached deferred data when a defer boundary comple
   await expect(stream).not.toEmitAnything();
 });
 
+test('does not return complete cached deferred data when a defer boundary completes with errors with a "network-only" fetch policy and errorPolicy "none"', async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  cache.writeQuery({
+    query,
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Cached hello",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+  });
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "network-only" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    completed: [
+      {
+        id: "0",
+        errors: [
+          {
+            message: "Could not fetch recipient",
+            path: ["greeting", "recipient"],
+          },
+        ],
+      },
+    ],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    error: new CombinedGraphQLErrors({
+      data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+      errors: [
+        {
+          message: "Could not fetch recipient",
+          path: ["greeting", "recipient"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    partial: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test('does not return a partial cached defer boundary while streaming with a "network-only" fetch policy', async () => {
   const query = gql`
     query {

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -5984,6 +5984,110 @@ test('does not return complete cached deferred data while streaming with a "netw
   await expect(stream).not.toEmitAnything();
 });
 
+test('does not return complete cached deferred data when a defer boundary completes with errors with a "network-only" fetch policy', async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  cache.writeQuery({
+    query,
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Cached hello",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+  });
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "network-only",
+      errorPolicy: "all",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    completed: [
+      {
+        id: "0",
+        errors: [
+          {
+            message: "Could not fetch recipient",
+            path: ["greeting", "recipient"],
+          },
+        ],
+      },
+    ],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    error: new CombinedGraphQLErrors({
+      data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+      errors: [
+        {
+          message: "Could not fetch recipient",
+          path: ["greeting", "recipient"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    partial: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test('does not return a partial cached defer boundary while streaming with a "network-only" fetch policy', async () => {
   const query = gql`
     query {

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -1825,6 +1825,169 @@ test('reports partial cached data inside a defer boundary as "partial" when the 
   await expect(stream).not.toEmitAnything();
 });
 
+test("reports partial data correctly when a mid-stream request is abandoned and the query is subscribed to again", async () => {
+  // Suppress expected missing field warning when writing partial value after
+  // first chunk
+  using _ = spyOnConsole("error");
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+            email
+          }
+        }
+      }
+    }
+  `;
+
+  const defer1 = mockDeferStreamGraphQL17Alpha9();
+  const defer2 = mockDeferStreamGraphQL17Alpha9();
+  let requests = 0;
+  const link = ApolloLink.from([
+    new ApolloLink((operation, forward) => {
+      requests++;
+      return forward(operation);
+    }),
+    ApolloLink.split(() => requests === 1, defer1.httpLink, defer2.httpLink),
+  ]);
+
+  const cache = new InMemoryCache();
+  cache.writeQuery({
+    query,
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+  });
+
+  const client = new ApolloClient({
+    cache,
+    link,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const observable = client.watchQuery({
+    query,
+    fetchPolicy: "cache-first",
+    returnPartialData: true,
+  });
+
+  const initialChunk = {
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  };
+
+  const streamA = new ObservableStream(observable);
+
+  await expect(streamA).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  defer1.enqueueInitialChunk({ ...initialChunk });
+
+  await expect(streamA).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  // Abandon the request before the boundary is delivered.
+  streamA.unsubscribe();
+
+  const streamB = new ObservableStream(observable);
+
+  await expect(streamB).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  defer2.enqueueInitialChunk({ ...initialChunk });
+
+  await expect(streamB).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  defer2.enqueueSubsequentChunk({
+    incremental: [
+      {
+        data: {
+          __typename: "Greeting",
+          recipient: {
+            name: "Alice",
+            email: "alice@example.com",
+            __typename: "Person",
+          },
+        },
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(streamB).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: {
+          __typename: "Person",
+          name: "Alice",
+          email: "alice@example.com",
+        },
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(streamB).not.toEmitAnything();
+});
+
 test("emits empty then streaming results for deferred queries with no data in the cache and returnPartialData", async () => {
   const query = gql`
     query {

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -1739,7 +1739,6 @@ test('reports partial cached data inside a defer boundary as "partial" when the 
   const stream = new ObservableStream(
     client.watchQuery({
       query,
-      fetchPolicy: "cache-first",
       returnPartialData: true,
       errorPolicy: "all",
     })
@@ -1871,11 +1870,7 @@ test("reports partial data correctly when a mid-stream request is abandoned and 
     incrementalHandler: new GraphQL17Alpha9Handler(),
   });
 
-  const observable = client.watchQuery({
-    query,
-    fetchPolicy: "cache-first",
-    returnPartialData: true,
-  });
+  const observable = client.watchQuery({ query, returnPartialData: true });
 
   const initialChunk = {
     data: { greeting: { __typename: "Greeting", message: "Hello world" } },

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -1698,6 +1698,133 @@ test('returns partial deferred cached data as "partial" while streaming with a "
   await expect(stream).not.toEmitAnything();
 });
 
+test('reports partial cached data inside a defer boundary as "partial" when the boundary completes with errors with a "cache-first" fetch policy and returnPartialData', async () => {
+  // Suppress expected missing field warning when writing partial value after
+  // first chunk
+  using _ = spyOnConsole("error");
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+            email
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  cache.writeQuery({
+    query,
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+  });
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "cache-first",
+      returnPartialData: true,
+      errorPolicy: "all",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { message: "Hello world", __typename: "Greeting" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    completed: [
+      {
+        id: "0",
+        errors: [
+          {
+            message: "Could not fetch recipient",
+            path: ["greeting", "recipient"],
+          },
+        ],
+      },
+    ],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "partial",
+    error: new CombinedGraphQLErrors({
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          message: "Hello world",
+          recipient: { __typename: "Person", name: "Cached Alice" },
+        },
+      },
+      errors: [
+        {
+          message: "Could not fetch recipient",
+          path: ["greeting", "recipient"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    partial: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test("emits empty then streaming results for deferred queries with no data in the cache and returnPartialData", async () => {
   const query = gql`
     query {

--- a/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
@@ -4611,3 +4611,126 @@ function createMockStreamMergeFn() {
     return result;
   });
 }
+
+test("does not emit when no data added when a `@stream` completes while a `@defer` boundary is still pending", async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+      friendList @stream(initialCount: 1) {
+        name
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "network-only" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: {
+      greeting: { __typename: "Greeting", message: "Hello world" },
+      friendList: [{ __typename: "Friend", name: "Luke" }],
+    },
+    pending: [
+      { id: "0", path: ["greeting"] },
+      { id: "1", path: ["friendList"] },
+    ],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+      friendList: [{ __typename: "Friend", name: "Luke" }],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ id: "1", items: [{ __typename: "Friend", name: "Han" }] }],
+    hasNext: true,
+  } as any);
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+      friendList: [
+        { __typename: "Friend", name: "Luke" },
+        { __typename: "Friend", name: "Han" },
+      ],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    completed: [{ id: "1" }],
+    hasNext: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
+
+  enqueueSubsequentChunk({
+    incremental: [
+      {
+        id: "0",
+        data: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Alice" },
+        },
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Alice" },
+      },
+      friendList: [
+        { __typename: "Friend", name: "Luke" },
+        { __typename: "Friend", name: "Han" },
+      ],
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});

--- a/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
@@ -4675,9 +4675,11 @@ test("does not emit when no data added when a `@stream` completes while a `@defe
   });
 
   enqueueSubsequentChunk({
-    incremental: [{ id: "1", items: [{ __typename: "Friend", name: "Han" }] }],
+    incremental: [
+      { id: "1", items: [{ __typename: "Friend", name: "Han" }] as any },
+    ],
     hasNext: true,
-  } as any);
+  });
 
   await expect(stream).toEmitTypedValue({
     data: markAsStreaming({

--- a/src/core/dataStateErrorCache.ts
+++ b/src/core/dataStateErrorCache.ts
@@ -1,0 +1,15 @@
+import type { CombinedGraphQLErrors } from "@apollo/client/errors";
+
+import type { DataState } from "./types.js";
+
+// When working with an incremental result, errors in `@defer` fragments might
+// bubble to the fragment boundary which leaves a hole in the data. When the
+// `errorPolicy` is `"none"` we `throw` the constructed error so that it moves
+// through the observable error flow. Because of this, we need a way to
+// communicate the known dataState returned by QueryInfo to ObservableQuery.
+// This ensures a "streaming" dataState can still be reported for errorPolicy:
+// "none" queries.
+export const dataStateErrorCache = new WeakMap<
+  CombinedGraphQLErrors,
+  DataState<any>["dataState"]
+>();

--- a/src/incremental/handlers/__tests__/graphql17Alpha9/defer.test.ts
+++ b/src/incremental/handlers/__tests__/graphql17Alpha9/defer.test.ts
@@ -2506,13 +2506,13 @@ test("stream that returns an error but continues to stream", async () => {
 
   await expect(observableStream).toEmitTypedValue({
     loading: false,
-    data: {
+    data: markAsStreaming({
       hero: {
         __typename: "Hero",
         id: "1",
         name: "slow",
       },
-    },
+    }),
     error: new CombinedGraphQLErrors({
       data: {
         hero: {
@@ -2529,9 +2529,9 @@ test("stream that returns an error but continues to stream", async () => {
         },
       ],
     }),
-    dataState: "complete",
+    dataState: "streaming",
     networkStatus: NetworkStatus.error,
-    partial: false,
+    partial: true,
   });
 });
 

--- a/src/incremental/handlers/__tests__/graphql17Alpha9/defer.test.ts
+++ b/src/incremental/handlers/__tests__/graphql17Alpha9/defer.test.ts
@@ -2705,3 +2705,87 @@ test("ignores `data` property added to subsequent chunks by misbehaving servers"
     partial: false,
   });
 });
+
+test("handles an incremental payload for a defer id that already completed with errors", async () => {
+  // `hero.name` is selected by both deferred fragments, so the server executes
+  // it as a single unit shared between them and reports it with the id of the
+  // fragment with the deepest path (`inner`). Since `nonNullName` errors,
+  // `inner` completes with errors before that shared unit resolves, which means
+  // an `incremental` payload arrives for an id that has already been completed.
+  const query = gql`
+    query {
+      ... @defer(label: "outer") {
+        hero {
+          name
+        }
+      }
+      hero {
+        ... on Hero @defer(label: "inner") {
+          name
+          nonNullName
+        }
+      }
+    }
+  `;
+
+  const handler = new GraphQL17Alpha9Handler();
+  const request = handler.startRequest({ query });
+
+  const incoming = run(query, {
+    hero: {
+      ...hero,
+      name: async () => {
+        await wait(10);
+        return "Luke";
+      },
+      nonNullName: () => null,
+    },
+  });
+
+  {
+    const { value: chunk, done } = await incoming.next();
+
+    assert(!done);
+    assert(handler.isIncrementalResult(chunk));
+    expect(request.handle(undefined, chunk)).toStrictEqualTyped({
+      data: { hero: {} },
+    });
+    expect(request.hasNext).toBe(true);
+  }
+
+  {
+    const { value: chunk, done } = await incoming.next();
+
+    assert(!done);
+    assert(handler.isIncrementalResult(chunk));
+    expect(request.handle(undefined, chunk)).toStrictEqualTyped({
+      data: { hero: {} },
+      errors: [
+        {
+          message:
+            "Cannot return null for non-nullable field Hero.nonNullName.",
+          path: ["hero", "nonNullName"],
+        },
+      ],
+    });
+    expect(request.hasNext).toBe(true);
+  }
+
+  {
+    const { value: chunk, done } = await incoming.next();
+
+    assert(!done);
+    assert(handler.isIncrementalResult(chunk));
+    expect(request.handle(undefined, chunk)).toStrictEqualTyped({
+      data: { hero: { name: "Luke" } },
+      errors: [
+        {
+          message:
+            "Cannot return null for non-nullable field Hero.nonNullName.",
+          path: ["hero", "nonNullName"],
+        },
+      ],
+    });
+    expect(request.hasNext).toBe(false);
+  }
+});

--- a/src/incremental/handlers/__tests__/graphql17Alpha9/stream.test.ts
+++ b/src/incremental/handlers/__tests__/graphql17Alpha9/stream.test.ts
@@ -2829,6 +2829,81 @@ test("properly merges streamed data into list with more items", async () => {
   }
 });
 
+test("truncates cache data to the streamed items when the stream completes with errors", async () => {
+  const query = gql`
+    query {
+      nonNullFriendList @stream(initialCount: 1) {
+        name
+        id
+      }
+    }
+  `;
+
+  const handler = new GraphQL17Alpha9Handler();
+  const request = handler.startRequest({ query });
+
+  const incoming = run(query, {
+    nonNullFriendList: () => [friends[0], null, friends[1]],
+  });
+
+  {
+    const { value: chunk, done } = await incoming.next();
+
+    assert(!done);
+    assert(handler.isIncrementalResult(chunk));
+    expect(
+      request.handle(
+        {
+          nonNullFriendList: [
+            { name: "Luke Cached", id: "1" },
+            { name: "Han Cached", id: "2" },
+            { name: "Leia Cached", id: "3" },
+          ],
+        },
+        chunk
+      )
+    ).toStrictEqualTyped({
+      data: {
+        nonNullFriendList: [{ name: "Luke", id: "1" }],
+      },
+      extensions: extensionsWithStreamDetails,
+    });
+    expect(request.hasNext).toBe(true);
+  }
+
+  {
+    const { value: chunk, done } = await incoming.next();
+
+    assert(!done);
+    assert(handler.isIncrementalResult(chunk));
+    expect(
+      request.handle(
+        {
+          nonNullFriendList: [
+            { name: "Luke", id: "1" },
+            { name: "Han Cached", id: "2" },
+            { name: "Leia Cached", id: "3" },
+          ],
+        },
+        chunk
+      )
+    ).toStrictEqualTyped({
+      data: {
+        nonNullFriendList: [{ name: "Luke", id: "1" }],
+      },
+      errors: [
+        {
+          message:
+            "Cannot return null for non-nullable field Query.nonNullFriendList.",
+          path: ["nonNullFriendList", 1],
+        },
+      ],
+      extensions: extensionsWithStreamDetails,
+    });
+    expect(request.hasNext).toBe(false);
+  }
+});
+
 test("properly merges cache data when list is included in deferred chunk", async () => {
   const { promise: slowFieldPromise, resolve: resolveSlowField } =
     promiseWithResolvers();

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -101,10 +101,6 @@ class IncrementalRequest<TData>
   // of future stream items from already merged stream items.
   private streamPositions: Record<string, number> = {};
 
-  get pending() {
-    return Array.from(this.pendingMap.values());
-  }
-
   getPendingWithInfo() {
     return Array.from(this.pendingMap.values()).map((pending) => {
       if (pending.id in this.streamPositions) {

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -101,10 +101,12 @@ class IncrementalRequest<TData>
   // of future stream items from already merged stream items.
   private streamPositions: Record<string, number> = {};
 
+  /** @internal */
   get streamInfo() {
     return this._streamInfo["strong"] ? this._streamInfo : undefined;
   }
 
+  /** @internal */
   getPendingWithInfo() {
     return Array.from(this.pendingMap.values()).map((pending) => {
       if (pending.id in this.streamPositions) {

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -232,7 +232,6 @@ class IncrementalRequest<TData>
           };
           details.state.streamPosition = streamPosition;
         }
-        this.pendingMap.delete(completed.id);
 
         if (completed.errors) {
           this.errors.push(...completed.errors);

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -87,6 +87,10 @@ class IncrementalRequest<TData>
   private errors: GraphQLFormattedError[] = [];
   private extensions: Record<string, any> = {};
   private pendingMap = new Map<string, GraphQL17Alpha9Handler.PendingResult>();
+  private completedMap = new Map<
+    /* pendingId */ string,
+    /* delivered */ boolean
+  >();
   private streamInfo = makeStreamInfoTrie();
   // `streamPositions` maps `pending.id` to the index that should be set by the
   // next `incremental` stream chunk to ensure the streamed array item is placed
@@ -103,6 +107,20 @@ class IncrementalRequest<TData>
 
   getPendingType(id: string): "defer" | "stream" {
     return id in this.streamPositions ? "stream" : "defer";
+  }
+
+  getPendingWithInfo() {
+    return Array.from(this.pendingMap.values()).map((pending) => {
+      if (pending.id in this.streamPositions) {
+        return { type: "stream" as const, path: pending.path };
+      }
+
+      return {
+        type: "defer" as const,
+        delivered: !!this.completedMap.get(pending.id),
+        path: pending.path,
+      };
+    });
   }
 
   handle(
@@ -211,6 +229,7 @@ class IncrementalRequest<TData>
       for (const completed of chunk.completed) {
         const { path } = this.pendingMap.get(completed.id)!;
         const streamPosition = this.streamPositions[completed.id];
+        this.completedMap.set(completed.id, !completed.errors);
 
         // Truncate any stream arrays in case the chunk only contains `hasNext`
         // and `completed`.

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -91,7 +91,7 @@ class IncrementalRequest<TData>
     /* pendingId */ string,
     /* delivered */ boolean
   >();
-  private streamInfo = makeStreamInfoTrie();
+  private _streamInfo = makeStreamInfoTrie();
   // `streamPositions` maps `pending.id` to the index that should be set by the
   // next `incremental` stream chunk to ensure the streamed array item is placed
   // at the correct point in the data array. `this.data` contains cached
@@ -100,6 +100,10 @@ class IncrementalRequest<TData>
   // updated by the cache between a streamed chunk aren't overwritten by merges
   // of future stream items from already merged stream items.
   private streamPositions: Record<string, number> = {};
+
+  get streamInfo() {
+    return this._streamInfo["strong"] ? this._streamInfo : undefined;
+  }
 
   getPendingWithInfo() {
     return Array.from(this.pendingMap.values()).map((pending) => {
@@ -134,7 +138,7 @@ class IncrementalRequest<TData>
 
           if (Array.isArray(dataAtPath)) {
             this.streamPositions[pending.id] = dataAtPath.length;
-            const entry = this.streamInfo.lookupArray(pending.path as any[]);
+            const entry = this._streamInfo.lookupArray(pending.path as any[]);
             entry.current = {
               isFirstChunk: true,
               isLastChunk: false,
@@ -169,7 +173,7 @@ class IncrementalRequest<TData>
           }
 
           this.streamPositions[pending.id] += items.length;
-          const entry = this.streamInfo.lookupArray(path);
+          const entry = this._streamInfo.lookupArray(path);
           entry.current = {
             isFirstChunk: false,
             isLastChunk: false,
@@ -235,7 +239,7 @@ class IncrementalRequest<TData>
         }
 
         // peek instead of lookup to avoid creating an entry for non-array values
-        const details = this.streamInfo.peekArray(path as any[]);
+        const details = this._streamInfo.peekArray(path as any[]);
         if (details) {
           details.current = {
             isFirstChunk: false,
@@ -260,7 +264,7 @@ class IncrementalRequest<TData>
       result.extensions = this.extensions;
     }
 
-    if (this.streamInfo["strong"]) {
+    if (this._streamInfo["strong"]) {
       result.extensions = {
         ...result.extensions,
         // Create a new object so we can check for === in QueryInfo to trigger a
@@ -268,7 +272,7 @@ class IncrementalRequest<TData>
         // We create a `WeakRef`, not a plain object to avoid retaining memory
         // in case the `result` or `extensions` stays around longer than the handler
         // itself.
-        [streamInfoSymbol]: new WeakRef(this.streamInfo),
+        [streamInfoSymbol]: new WeakRef(this._streamInfo),
       } satisfies ExtensionsWithStreamInfo;
     }
 

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -105,10 +105,6 @@ class IncrementalRequest<TData>
     return Array.from(this.pendingMap.values());
   }
 
-  getPendingType(id: string): "defer" | "stream" {
-    return id in this.streamPositions ? "stream" : "defer";
-  }
-
   getPendingWithInfo() {
     return Array.from(this.pendingMap.values()).map((pending) => {
       if (pending.id in this.streamPositions) {

--- a/src/incremental/types.ts
+++ b/src/incremental/types.ts
@@ -40,7 +40,6 @@ export declare namespace Incremental {
     TData,
   > {
     hasNext: boolean;
-    pending?: Array<Incremental.PendingResult>;
     getPendingWithInfo?: () => Array<PendingItemWithInfo>;
     handle: (
       cacheData: TData | DeepPartial<TData> | undefined | null,

--- a/src/incremental/types.ts
+++ b/src/incremental/types.ts
@@ -62,7 +62,7 @@ export declare namespace Incremental {
     path: Incremental.Path;
   }
 
-  /* @internal */
+  /** @internal */
   export type PendingItemWithInfo =
     | PendingDeferResultWithInfo
     | PendingStreamResultWithInfo;

--- a/src/incremental/types.ts
+++ b/src/incremental/types.ts
@@ -6,6 +6,7 @@ import type {
 
 import type { ApolloLink } from "@apollo/client/link";
 import type { DeepPartial } from "@apollo/client/utilities";
+import { StreamInfoTrie } from "../utilities/internal/index.js";
 
 export declare namespace Incremental {
   export type Path = ReadonlyArray<string | number>;
@@ -40,6 +41,7 @@ export declare namespace Incremental {
     TData,
   > {
     hasNext: boolean;
+    readonly streamInfo?: StreamInfoTrie;
     getPendingWithInfo?: () => Array<PendingItemWithInfo>;
     handle: (
       cacheData: TData | DeepPartial<TData> | undefined | null,

--- a/src/incremental/types.ts
+++ b/src/incremental/types.ts
@@ -41,7 +41,6 @@ export declare namespace Incremental {
   > {
     hasNext: boolean;
     pending?: Array<Incremental.PendingResult>;
-    getPendingType?: (id: string) => "defer" | "stream";
     getPendingWithInfo?: () => Array<PendingItemWithInfo>;
     handle: (
       cacheData: TData | DeepPartial<TData> | undefined | null,

--- a/src/incremental/types.ts
+++ b/src/incremental/types.ts
@@ -6,7 +6,7 @@ import type {
 
 import type { ApolloLink } from "@apollo/client/link";
 import type { DeepPartial } from "@apollo/client/utilities";
-import { StreamInfoTrie } from "../utilities/internal/index.js";
+import type { StreamInfoTrie } from "@apollo/client/utilities/internal";
 
 export declare namespace Incremental {
   export type Path = ReadonlyArray<string | number>;

--- a/src/incremental/types.ts
+++ b/src/incremental/types.ts
@@ -41,8 +41,12 @@ export declare namespace Incremental {
     TData,
   > {
     hasNext: boolean;
+
+    /** @internal */
     readonly streamInfo?: StreamInfoTrie;
+    /** @internal */
     getPendingWithInfo?: () => Array<PendingItemWithInfo>;
+
     handle: (
       cacheData: TData | DeepPartial<TData> | undefined | null,
       chunk: Chunk

--- a/src/incremental/types.ts
+++ b/src/incremental/types.ts
@@ -42,11 +42,30 @@ export declare namespace Incremental {
     hasNext: boolean;
     pending?: Array<Incremental.PendingResult>;
     getPendingType?: (id: string) => "defer" | "stream";
+    getPendingWithInfo?: () => Array<PendingItemWithInfo>;
     handle: (
       cacheData: TData | DeepPartial<TData> | undefined | null,
       chunk: Chunk
     ) => FormattedExecutionResult<TData>;
   }
+
+  /** @internal */
+  export interface PendingDeferResultWithInfo {
+    type: "defer";
+    delivered: boolean;
+    path: Incremental.Path;
+  }
+
+  /** @internal */
+  export interface PendingStreamResultWithInfo {
+    type: "stream";
+    path: Incremental.Path;
+  }
+
+  /* @internal */
+  export type PendingItemWithInfo =
+    | PendingDeferResultWithInfo
+    | PendingStreamResultWithInfo;
 
   /** @internal */
   export interface StreamFieldInfo {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of errors in queries using `@defer` and `@stream`.
  - Prevented partial cached data from appearing in `network-only` queries after deferred errors.
  - Preserved the correct streaming state when deferred content encounters errors.
  - Prevented duplicate or invalid updates after incremental boundaries complete.
  - Truncated streamed lists safely when later items cause non-nullability errors.

- **API Updates**
  - Enhanced incremental query metadata with pending-item details and stream information.
  - Replaced legacy pending-item accessors with more descriptive streaming metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->