### PR TITLE
Fix widening of default options types when variables contain constant types

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -79,6 +79,7 @@ import { OptimisticStoreItem } from '@apollo/client/cache';
 import type { OptionWithFallback } from '@apollo/client/utilities/internal';
 import { parseAndCheckHttpResponse } from '@apollo/client/link/http';
 import { PossibleTypesMap } from '@apollo/client/cache';
+import type { Prettify } from '@apollo/client/utilities/internal';
 import { ReactiveVar } from '@apollo/client/cache';
 import { ReadMergeModifyContext } from '@apollo/client/cache';
 import { ReadQueryOptions } from '@apollo/client/cache';
@@ -232,7 +233,17 @@ export namespace ApolloClient {
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Mutate.Calculated {
         }
         // (undocumented)
-        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | MutateOptions<any, TVariables, TCache>> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+        export type OptionsFor<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions> = MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & {
+            variables?: Prettify<TVariables & {
+                [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+            }>;
+        } & ([Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>] extends ([
+        never
+        ]) ? unknown : {
+            [K in Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>]: never;
+        });
+        // (undocumented)
+        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | Omit<MutateOptions<any, any, TCache>, "variables">> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
         }
         // (undocumented)
@@ -251,9 +262,9 @@ export namespace ApolloClient {
             export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
             // (undocumented)
             export interface Modern {
-                <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends ApolloClient.MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & VariablesOption<TVariables & {
-                    [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-                }>>(options: TOptions & {
+                <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Omit<ApolloClient.MutateOptions<NoInfer<TData>, any, TCache>, "variables"> & {
+                    variables?: unknown;
+                }>(options: TOptions & ApolloClient.mutate.OptionsFor<TData, TVariables, TCache, TOptions> & {
                     mutation: TypedDocumentNode<TData, TVariables>;
                 }): Promise<ApolloClient.mutate.ResultForOptions<TData, TVariables, TCache, TOptions>>;
             }
@@ -332,7 +343,17 @@ export namespace ApolloClient {
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Query.Calculated {
         }
         // (undocumented)
-        export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, unknown> | QueryOptions<any, TVariables>> = LazyType<QueryResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+        export type OptionsFor<TData, TVariables extends OperationVariables, TOptions> = QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & {
+            variables?: Prettify<TVariables & {
+                [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+            }>;
+        } & ([Exclude<keyof TOptions, keyof QueryOptions<any, any>>] extends ([
+        never
+        ]) ? unknown : {
+            [K in Exclude<keyof TOptions, keyof QueryOptions<any, any>>]: never;
+        });
+        // (undocumented)
+        export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, unknown> | Omit<QueryOptions<any, any>, "variables">> = LazyType<QueryResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
         }
         // (undocumented)
@@ -351,9 +372,9 @@ export namespace ApolloClient {
             export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
             // (undocumented)
             export interface Modern {
-                <TData, TVariables extends OperationVariables, TOptions extends ApolloClient.QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & VariablesOption<TVariables & {
-                    [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-                }>>(options: TOptions & {
+                <TData, TVariables extends OperationVariables, TOptions extends Omit<ApolloClient.QueryOptions<NoInfer<TData>, any>, "variables"> & {
+                    variables?: unknown;
+                }>(options: TOptions & ApolloClient.query.OptionsFor<TData, TVariables, TOptions> & {
                     query: TypedDocumentNode<TData, TVariables>;
                 }): Promise<ApolloClient.query.ResultForOptions<TData, TVariables, TOptions>>;
             }
@@ -1367,7 +1388,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:633:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:678:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -233,15 +233,17 @@ export namespace ApolloClient {
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Mutate.Calculated {
         }
         // (undocumented)
-        export type OptionsFor<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions> = MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & {
+        export type OptionsFor<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends {
+            variables?: unknown;
+        }> = MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & {
             variables?: Prettify<TVariables & {
-                [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+                [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
             }>;
-        } & ([Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>] extends ([
-        never
-        ]) ? unknown : {
-            [K in Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>]: never;
-        });
+        } & (Exclude<keyof TOptions, keyof MutateOptions<any, any, any>> extends (infer InvalidOptionNames extends string) ? [
+        InvalidOptionNames
+        ] extends [never] ? unknown : {
+            [K in InvalidOptionNames]: never;
+        } : never);
         // (undocumented)
         export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | Omit<MutateOptions<any, any, TCache>, "variables">> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
@@ -343,15 +345,17 @@ export namespace ApolloClient {
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Query.Calculated {
         }
         // (undocumented)
-        export type OptionsFor<TData, TVariables extends OperationVariables, TOptions> = QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & {
+        export type OptionsFor<TData, TVariables extends OperationVariables, TOptions extends {
+            variables?: unknown;
+        }> = QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & {
             variables?: Prettify<TVariables & {
-                [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+                [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
             }>;
-        } & ([Exclude<keyof TOptions, keyof QueryOptions<any, any>>] extends ([
-        never
-        ]) ? unknown : {
-            [K in Exclude<keyof TOptions, keyof QueryOptions<any, any>>]: never;
-        });
+        } & (Exclude<keyof TOptions, keyof QueryOptions<any, any>> extends (infer InvalidOptionNames extends string) ? [
+        InvalidOptionNames
+        ] extends [never] ? unknown : {
+            [K in InvalidOptionNames]: never;
+        } : never);
         // (undocumented)
         export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, unknown> | Omit<QueryOptions<any, any>, "variables">> = LazyType<QueryResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
@@ -1388,7 +1392,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:678:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:669:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -169,15 +169,17 @@ export namespace PreloadQueryFunction {
         }
     }
     // (undocumented)
-    export type OptionsFor<TVariables extends OperationVariables, TOptions> = PreloadQueryOptions<NoInfer_2<TVariables>> & {
+    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
+        variables?: unknown;
+    }> = PreloadQueryOptions<NoInfer_2<TVariables>> & {
         variables?: Prettify<TVariables & {
-            [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
         }>;
-    } & ([Exclude<keyof TOptions, keyof PreloadQueryOptions<any>>] extends ([
-    never
-    ]) ? unknown : {
-        [K in Exclude<keyof TOptions, keyof PreloadQueryOptions<any>>]: never;
-    });
+    } & (Exclude<keyof TOptions, keyof PreloadQueryOptions<any>> extends (infer InvalidOptionNames extends string) ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never);
     // (undocumented)
     export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Omit<PreloadQueryOptions<any>, "variables">> = TOptions extends any ? PreloadedQueryRef_2<TData, TVariables, ResultForOptions.States<TOptions, DefaultOptions>> : never;
     // (undocumented)
@@ -297,6 +299,7 @@ export namespace useBackgroundQuery {
             returnPartialData?: boolean;
             // @deprecated
             skip?: boolean;
+            variables?: unknown;
         }
     }
     // (undocumented)
@@ -309,7 +312,7 @@ export namespace useBackgroundQuery {
         // (undocumented)
         export namespace useBackgroundQuery {
             // (undocumented)
-            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Omit<Base.Options, "variables">, DocumentationTypes.VariableOptions<TVariables> {
             }
         }
     }
@@ -345,15 +348,17 @@ export namespace useBackgroundQuery {
     // (undocumented)
     export type Options<TVariables extends OperationVariables = OperationVariables> = Base.Options & VariablesOption<TVariables>;
     // (undocumented)
-    export type OptionsFor<TVariables extends OperationVariables, TOptions> = Options<NoInfer_2<TVariables>> & {
+    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
+        variables?: unknown;
+    }> = useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
         variables?: Prettify<TVariables & {
-            [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
         }>;
-    } & ([
-    Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>
+    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useBackgroundQuery.Options<any>> extends infer InvalidOptionNames extends string ? [
+    InvalidOptionNames
     ] extends [never] ? unknown : {
-        [K in Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>]: never;
-    });
+        [K in InvalidOptionNames]: never;
+    } : never);
     // (undocumented)
     export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
         fetchMore: FetchMoreFunction<TData, TVariables>;
@@ -566,17 +571,13 @@ export namespace useBackgroundQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useBackgroundQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options & {
-                variables?: unknown;
-            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>
             ] : [
             options: TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>
             ]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options & {
-                variables?: unknown;
-            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>) | SkipToken
             ] : [
             options: (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>) | SkipToken
@@ -761,11 +762,11 @@ export namespace useLazyQuery {
         skipPollAttempt?: () => boolean;
     }
     // (undocumented)
-    export type OptionsFor<TOptions> = [
-    Exclude<keyof TOptions, keyof Options<any, any>>
+    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useLazyQuery.Options<any, any>> extends (infer InvalidOptionNames extends string) ? [
+    InvalidOptionNames
     ] extends [never] ? unknown : {
-        [K in Exclude<keyof TOptions, keyof Options<any, any>>]: never;
-    };
+        [K in InvalidOptionNames]: never;
+    } : never;
     // (undocumented)
     export type Result<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & (({
         called: true;
@@ -859,11 +860,11 @@ export namespace useLoadableQuery {
         returnPartialData?: boolean;
     }
     // (undocumented)
-    export type OptionsFor<TOptions> = [
-    Exclude<keyof TOptions, keyof Options>
+    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useLoadableQuery.Options> extends (infer InvalidOptionNames extends string) ? [
+    InvalidOptionNames
     ] extends [never] ? unknown : {
-        [K in Exclude<keyof TOptions, keyof Options>]: never;
-    };
+        [K in InvalidOptionNames]: never;
+    } : never;
     // (undocumented)
     export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
     loadQuery: LoadQueryFunction<TVariables>,
@@ -987,13 +988,11 @@ export namespace useMutation {
         variables?: Partial<TVariables> & TConfiguredVariables;
     }
     // (undocumented)
-    export type OptionsFor<TOptions> = [
-    Exclude<keyof TOptions, keyof Options<any, any, any, any>>
-    ] extends ([
-    never
-    ]) ? unknown : {
-        [K in Exclude<keyof TOptions, keyof Options<any, any, any, any>>]: never;
-    };
+    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useMutation.Options<any, any, any, any>> extends infer InvalidOptionNames extends string ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never;
     // (undocumented)
     export type Result<TData = unknown, TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result & ResultStateMap<TData>[`${TErrorPolicy}`];
     // Warning: (ae-forgotten-export) The symbol "MakeRequiredVariablesOptional" needs to be exported by the entry point index.d.ts
@@ -1089,6 +1088,7 @@ export namespace useQuery {
             skip?: boolean;
             skipPollAttempt?: () => boolean;
             ssr?: boolean;
+            variables?: unknown;
         }
     }
     // (undocumented)
@@ -1120,7 +1120,7 @@ export namespace useQuery {
         // (undocumented)
         export namespace useQuery {
             // (undocumented)
-            export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> extends Base.Options<TData, TVariables>, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> extends Omit<Base.Options<TData, TVariables>, "variables">, DocumentationTypes.VariableOptions<TVariables> {
             }
         }
     }
@@ -1148,15 +1148,17 @@ export namespace useQuery {
     // (undocumented)
     export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<TVariables>;
     // (undocumented)
-    export type OptionsFor<TData, TVariables extends OperationVariables, TOptions> = Options<TData, NoInfer_2<TVariables>> & {
+    export type OptionsFor<TData, TVariables extends OperationVariables, TOptions extends {
+        variables?: unknown;
+    }> = useQuery.Options<TData, NoInfer_2<TVariables>> & {
         variables?: Prettify<TVariables & {
-            [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
         }>;
-    } & ([
-    Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<TData, TVariables>>
+    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useQuery.Options<TData, TVariables>> extends infer InvalidOptionNames extends string ? [
+    InvalidOptionNames
     ] extends [never] ? unknown : {
-        [K in Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<TData, TVariables>>]: never;
-    });
+        [K in InvalidOptionNames]: never;
+    } : never);
     // (undocumented)
     export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables> = Base.Result<TData, TVariables, TReturnVariables> & GetDataState<MaybeMasked_2<TData>, TStates>;
     // (undocumented)
@@ -1222,9 +1224,7 @@ export namespace useQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer_2<TVariables>> & {
-                variables?: unknown;
-            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer_2<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
             TVariables
             ] extends [never] ? [options: never] : {} extends TVariables ? [
             options?: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>
@@ -1232,9 +1232,7 @@ export namespace useQuery {
             options: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends SkipToken>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer_2<TVariables>> & {
-                variables?: unknown;
-            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer_2<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
             TVariables
             ] extends [never] ? [options: never] : {} extends TVariables ? [
             options?: (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>) | SkipToken
@@ -1478,6 +1476,7 @@ export namespace useSuspenseQuery {
             returnPartialData?: boolean;
             // @deprecated
             skip?: boolean;
+            variables?: unknown;
         }
     }
     // (undocumented)
@@ -1502,7 +1501,7 @@ export namespace useSuspenseQuery {
         // (undocumented)
         export namespace useSuspenseQuery {
             // (undocumented)
-            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options<TVariables>, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Omit<Base.Options<TVariables>, "variables">, DocumentationTypes.VariableOptions<TVariables> {
             }
         }
     }
@@ -1532,15 +1531,17 @@ export namespace useSuspenseQuery {
     // (undocumented)
     export type Options<TVariables extends OperationVariables = OperationVariables> = Base.Options<TVariables> & VariablesOption<TVariables>;
     // (undocumented)
-    export type OptionsFor<TVariables extends OperationVariables, TOptions> = Options<NoInfer_2<TVariables>> & {
+    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
+        variables?: unknown;
+    }> = useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
         variables?: Prettify<TVariables & {
-            [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
         }>;
-    } & ([
-    Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>
+    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useSuspenseQuery.Options<any>> extends infer InvalidOptionNames extends string ? [
+    InvalidOptionNames
     ] extends [never] ? unknown : {
-        [K in Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>]: never;
-    });
+        [K in InvalidOptionNames]: never;
+    } : never);
     // (undocumented)
     export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & GetDataState<MaybeMasked<TData>, TStates>;
     // (undocumented)
@@ -1620,17 +1621,13 @@ export namespace useSuspenseQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useSuspenseQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer_2<TVariables>> & {
-                variables?: unknown;
-            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer_2<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>
             ] : [
             options: TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>
             ]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer_2<TVariables>> & {
-                variables?: unknown;
-            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer_2<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
             options?: (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>) | SkipToken
             ] : [
             options: (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>) | SkipToken

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -169,7 +169,17 @@ export namespace PreloadQueryFunction {
         }
     }
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | PreloadQueryOptions<TVariables>> = TOptions extends any ? PreloadedQueryRef_2<TData, TVariables, ResultForOptions.States<TOptions, DefaultOptions>> : never;
+    export type OptionsFor<TVariables extends OperationVariables, TOptions> = PreloadQueryOptions<NoInfer_2<TVariables>> & {
+        variables?: Prettify<TVariables & {
+            [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+        }>;
+    } & ([Exclude<keyof TOptions, keyof PreloadQueryOptions<any>>] extends ([
+    never
+    ]) ? unknown : {
+        [K in Exclude<keyof TOptions, keyof PreloadQueryOptions<any>>]: never;
+    });
+    // (undocumented)
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Omit<PreloadQueryOptions<any>, "variables">> = TOptions extends any ? PreloadedQueryRef_2<TData, TVariables, ResultForOptions.States<TOptions, DefaultOptions>> : never;
     // (undocumented)
     export namespace ResultForOptions {
         // (undocumented)
@@ -214,9 +224,13 @@ export namespace PreloadQueryFunction {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): PreloadQueryFunction.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends PreloadQueryOptions<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): PreloadQueryFunction.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends Omit<PreloadQueryOptions<any>, "variables"> & {
+                variables?: unknown;
+            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: TOptions & PreloadQueryFunction.OptionsFor<TVariables, TOptions>
+            ] : [
+            options: TOptions & PreloadQueryFunction.OptionsFor<TVariables, TOptions>
+            ]): PreloadQueryFunction.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -331,13 +345,23 @@ export namespace useBackgroundQuery {
     // (undocumented)
     export type Options<TVariables extends OperationVariables = OperationVariables> = Base.Options & VariablesOption<TVariables>;
     // (undocumented)
+    export type OptionsFor<TVariables extends OperationVariables, TOptions> = Options<NoInfer_2<TVariables>> & {
+        variables?: Prettify<TVariables & {
+            [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+        }>;
+    } & ([
+    Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>
+    ] extends [never] ? unknown : {
+        [K in Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>]: never;
+    });
+    // (undocumented)
     export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
         fetchMore: FetchMoreFunction<TData, TVariables>;
         refetch: RefetchFunction<TData, TVariables>;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     }
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TVariables> | SkipToken> = [
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options | SkipToken> = [
     queryRef: TOptions extends any ? TOptions extends SkipToken ? undefined : QueryRef_2<TData, TVariables, "complete" | "streaming" | ((OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"))> | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends false ? never : undefined) : never,
     result: useBackgroundQuery.Result<TData, TVariables>
     ];
@@ -542,13 +566,21 @@ export namespace useBackgroundQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useBackgroundQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options & {
+                variables?: unknown;
+            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>
+            ] : [
+            options: TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>
+            ]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options & {
+                variables?: unknown;
+            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>) | SkipToken
+            ] : [
+            options: (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>) | SkipToken
+            ]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
         }
     }
 }
@@ -729,6 +761,12 @@ export namespace useLazyQuery {
         skipPollAttempt?: () => boolean;
     }
     // (undocumented)
+    export type OptionsFor<TOptions> = [
+    Exclude<keyof TOptions, keyof Options<any, any>>
+    ] extends [never] ? unknown : {
+        [K in Exclude<keyof TOptions, keyof Options<any, any>>]: never;
+    };
+    // (undocumented)
     export type Result<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & (({
         called: true;
         variables: TVariables;
@@ -772,11 +810,7 @@ export namespace useLazyQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode | TypedDocumentNode<TData, TVariables>): useLazyQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
-                variables?: {
-                    [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-                };
-            }>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: TOptions): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: TOptions & useLazyQuery.OptionsFor<TOptions>): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -825,6 +859,12 @@ export namespace useLoadableQuery {
         returnPartialData?: boolean;
     }
     // (undocumented)
+    export type OptionsFor<TOptions> = [
+    Exclude<keyof TOptions, keyof Options>
+    ] extends [never] ? unknown : {
+        [K in Exclude<keyof TOptions, keyof Options>]: never;
+    };
+    // (undocumented)
     export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
     loadQuery: LoadQueryFunction<TVariables>,
     queryRef: QueryRef_2<TData, TVariables, TStates> | null,
@@ -868,7 +908,7 @@ export namespace useLoadableQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>): useLoadableQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useLoadableQuery.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: TOptions): useLoadableQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends useLoadableQuery.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: TOptions & useLoadableQuery.OptionsFor<TOptions>): useLoadableQuery.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -947,6 +987,14 @@ export namespace useMutation {
         variables?: Partial<TVariables> & TConfiguredVariables;
     }
     // (undocumented)
+    export type OptionsFor<TOptions> = [
+    Exclude<keyof TOptions, keyof Options<any, any, any, any>>
+    ] extends ([
+    never
+    ]) ? unknown : {
+        [K in Exclude<keyof TOptions, keyof Options<any, any, any, any>>]: never;
+    };
+    // (undocumented)
     export type Result<TData = unknown, TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result & ResultStateMap<TData>[`${TErrorPolicy}`];
     // Warning: (ae-forgotten-export) The symbol "MakeRequiredVariablesOptional" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ExtractConfiguredVariables" needs to be exported by the entry point index.d.ts
@@ -1011,7 +1059,7 @@ export namespace useMutation {
                 variables?: {
                     [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
                 };
-            }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: TOptions & {
+            }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: TOptions & useMutation.OptionsFor<TOptions> & {
                 errorPolicy?: TErrorPolicy;
             }): useMutation.ResultForOptions<TData, TVariables, TCache, TOptions, TErrorPolicy>;
         }
@@ -1100,9 +1148,19 @@ export namespace useQuery {
     // (undocumented)
     export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<TVariables>;
     // (undocumented)
+    export type OptionsFor<TData, TVariables extends OperationVariables, TOptions> = Options<TData, NoInfer_2<TVariables>> & {
+        variables?: Prettify<TVariables & {
+            [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+        }>;
+    } & ([
+    Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<TData, TVariables>>
+    ] extends [never] ? unknown : {
+        [K in Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<TData, TVariables>>]: never;
+    });
+    // (undocumented)
     export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables> = Base.Result<TData, TVariables, TReturnVariables> & GetDataState<MaybeMasked_2<TData>, TStates>;
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never)>>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never)>>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
@@ -1164,20 +1222,24 @@ export namespace useQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer_2<TVariables>> & {
+                variables?: unknown;
+            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
             TVariables
-            ] extends [never] ? [options: never] : {} extends TVariables ? [options?: TOptions] : [
-            options: TOptions
+            ] extends [never] ? [options: never] : {} extends TVariables ? [
+            options?: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>
+            ] : [
+            options: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends SkipToken>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer_2<TVariables>> & {
+                variables?: unknown;
+            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
             TVariables
-            ] extends [never] ? [options: never] : {} extends TVariables ? [options?: TOptions | SkipToken] : [
-            options: TOptions | SkipToken
+            ] extends [never] ? [options: never] : {} extends TVariables ? [
+            options?: (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>) | SkipToken
+            ] : [
+            options: (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>) | SkipToken
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
             // (undocumented)
             ssrDisabledResult: ObservableQuery.Result<any>;
@@ -1470,9 +1532,19 @@ export namespace useSuspenseQuery {
     // (undocumented)
     export type Options<TVariables extends OperationVariables = OperationVariables> = Base.Options<TVariables> & VariablesOption<TVariables>;
     // (undocumented)
+    export type OptionsFor<TVariables extends OperationVariables, TOptions> = Options<NoInfer_2<TVariables>> & {
+        variables?: Prettify<TVariables & {
+            [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+        }>;
+    } & ([
+    Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>
+    ] extends [never] ? unknown : {
+        [K in Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>]: never;
+    });
+    // (undocumented)
     export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & GetDataState<MaybeMasked<TData>, TStates>;
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TVariables> | SkipToken> = Result<TData, TVariables, "complete" | "streaming" | (TOptions extends any ? TOptions extends SkipToken ? "empty" : (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends (false) ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial") : never) | ([TOptions] extends [SkipToken] ? DefaultOptions extends {
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TVariables> | SkipToken> = Result<TData, TVariables, "complete" | "streaming" | (TOptions extends any ? TOptions extends SkipToken ? "empty" : (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends (false) ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial") : never) | ([TOptions] extends [SkipToken] ? DefaultOptions extends {
         returnPartialData: false;
     } ? never : "partial" : never)>;
     export interface Signature extends Signatures.Evaluated {
@@ -1548,13 +1620,21 @@ export namespace useSuspenseQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useSuspenseQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer_2<TVariables>> & {
+                variables?: unknown;
+            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>
+            ] : [
+            options: TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>
+            ]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer_2<TVariables>> & {
+                variables?: unknown;
+            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>) | SkipToken
+            ] : [
+            options: (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>) | SkipToken
+            ]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
         }
     }
 }

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -273,15 +273,17 @@ export namespace ApolloClient {
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Mutate.Calculated {
         }
         // (undocumented)
-        export type OptionsFor<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions> = MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & {
+        export type OptionsFor<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends {
+            variables?: unknown;
+        }> = MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & {
             variables?: Prettify<TVariables & {
-                [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+                [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
             }>;
-        } & ([Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>] extends ([
-        never
-        ]) ? unknown : {
-            [K in Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>]: never;
-        });
+        } & (Exclude<keyof TOptions, keyof MutateOptions<any, any, any>> extends (infer InvalidOptionNames extends string) ? [
+        InvalidOptionNames
+        ] extends [never] ? unknown : {
+            [K in InvalidOptionNames]: never;
+        } : never);
         // Warning: (ae-forgotten-export) The symbol "LazyType" needs to be exported by the entry point index.d.ts
         // Warning: (ae-forgotten-export) The symbol "OptionWithFallback" needs to be exported by the entry point index.d.ts
         //
@@ -397,15 +399,17 @@ export namespace ApolloClient {
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Query.Calculated {
         }
         // (undocumented)
-        export type OptionsFor<TData, TVariables extends OperationVariables, TOptions> = QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & {
+        export type OptionsFor<TData, TVariables extends OperationVariables, TOptions extends {
+            variables?: unknown;
+        }> = QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & {
             variables?: Prettify<TVariables & {
-                [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+                [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
             }>;
-        } & ([Exclude<keyof TOptions, keyof QueryOptions<any, any>>] extends ([
-        never
-        ]) ? unknown : {
-            [K in Exclude<keyof TOptions, keyof QueryOptions<any, any>>]: never;
-        });
+        } & (Exclude<keyof TOptions, keyof QueryOptions<any, any>> extends (infer InvalidOptionNames extends string) ? [
+        InvalidOptionNames
+        ] extends [never] ? unknown : {
+            [K in InvalidOptionNames]: never;
+        } : never);
         // (undocumented)
         export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, unknown> | Omit<QueryOptions<any, any>, "variables">> = LazyType<QueryResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
@@ -3090,7 +3094,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:678:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:669:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -272,11 +272,21 @@ export namespace ApolloClient {
         // (undocumented)
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Mutate.Calculated {
         }
+        // (undocumented)
+        export type OptionsFor<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions> = MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & {
+            variables?: Prettify<TVariables & {
+                [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+            }>;
+        } & ([Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>] extends ([
+        never
+        ]) ? unknown : {
+            [K in Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>]: never;
+        });
         // Warning: (ae-forgotten-export) The symbol "LazyType" needs to be exported by the entry point index.d.ts
         // Warning: (ae-forgotten-export) The symbol "OptionWithFallback" needs to be exported by the entry point index.d.ts
         //
         // (undocumented)
-        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | MutateOptions<any, TVariables, TCache>> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | Omit<MutateOptions<any, any, TCache>, "variables">> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
         }
         // (undocumented)
@@ -297,9 +307,9 @@ export namespace ApolloClient {
             export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
             // (undocumented)
             export interface Modern {
-                <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends ApolloClient.MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & VariablesOption<TVariables & {
-                    [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-                }>>(options: TOptions & {
+                <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Omit<ApolloClient.MutateOptions<NoInfer<TData>, any, TCache>, "variables"> & {
+                    variables?: unknown;
+                }>(options: TOptions & ApolloClient.mutate.OptionsFor<TData, TVariables, TCache, TOptions> & {
                     mutation: TypedDocumentNode<TData, TVariables>;
                 }): Promise<ApolloClient.mutate.ResultForOptions<TData, TVariables, TCache, TOptions>>;
             }
@@ -387,7 +397,17 @@ export namespace ApolloClient {
         export interface DefaultOptions extends ApolloClient.DefaultOptions.Query.Calculated {
         }
         // (undocumented)
-        export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, unknown> | QueryOptions<any, TVariables>> = LazyType<QueryResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+        export type OptionsFor<TData, TVariables extends OperationVariables, TOptions> = QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & {
+            variables?: Prettify<TVariables & {
+                [K in keyof TOptions["variables" & keyof TOptions]]: K extends (keyof TVariables) ? TVariables[K] : never;
+            }>;
+        } & ([Exclude<keyof TOptions, keyof QueryOptions<any, any>>] extends ([
+        never
+        ]) ? unknown : {
+            [K in Exclude<keyof TOptions, keyof QueryOptions<any, any>>]: never;
+        });
+        // (undocumented)
+        export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, unknown> | Omit<QueryOptions<any, any>, "variables">> = LazyType<QueryResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
         }
         // (undocumented)
@@ -406,9 +426,9 @@ export namespace ApolloClient {
             export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
             // (undocumented)
             export interface Modern {
-                <TData, TVariables extends OperationVariables, TOptions extends ApolloClient.QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & VariablesOption<TVariables & {
-                    [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-                }>>(options: TOptions & {
+                <TData, TVariables extends OperationVariables, TOptions extends Omit<ApolloClient.QueryOptions<NoInfer<TData>, any>, "variables"> & {
+                    variables?: unknown;
+                }>(options: TOptions & ApolloClient.query.OptionsFor<TData, TVariables, TOptions> & {
                     query: TypedDocumentNode<TData, TVariables>;
                 }): Promise<ApolloClient.query.ResultForOptions<TData, TVariables, TOptions>>;
             }
@@ -3069,8 +3089,8 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:201:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:633:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:678:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/lucky-donkeys-listen.md
+++ b/.changeset/lucky-donkeys-listen.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix result types widened when a query's variables had constant types (e.g. `TypedDocumentNode<Data, { type: "main" }>`). This caused options such as `returnPartialData` or `errorPolicy` to be reported as their widened types (e.g. `boolean`, `ErrorPolicy`) instead of the value that was passed which returned the wrong `data` and `dataState` types.

--- a/.changeset/rotten-steaks-refuse.md
+++ b/.changeset/rotten-steaks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue where unknown options were permitted by TypeScript when passed alongside a valid option to APIs with modern signatures.

--- a/integration-tests/type-tests/signatures/modern/createQueryPreloader.ts
+++ b/integration-tests/type-tests/signatures/modern/createQueryPreloader.ts
@@ -1111,3 +1111,184 @@ test("returns correct TData type when combined with options unrelated to TData",
     }
   } */
 });
+
+test("rejects unknown options", () => {
+  type Data = { character: string };
+  const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;
+  const widenedVariables: TypedDocumentNode<Data, { type: string }> = gql``;
+  const noVariables: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  preloadQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialData: true,
+    errorPolicy: "all",
+    context: { foo: 1 },
+    fetchPolicy: "cache-first",
+  });
+
+  preloadQuery(literalVariables, {
+    variables: { type: "main" },
+    // @ts-expect-error unknown option
+    returnPartialDta: false,
+  });
+
+  preloadQuery(widenedVariables, {
+    variables: { type: "main" },
+    // @ts-expect-error unknown option
+    returnPartialDta: false,
+  });
+
+  preloadQuery(noVariables, {
+    // @ts-expect-error unknown option
+    returnPartialDta: false,
+  });
+
+  preloadQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialData: true,
+    // @ts-expect-error unknown option
+    bogusOption: 1,
+  });
+});
+
+test("rejects a known option with an invalid value", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  preloadQuery(query, { variables: { id: "1" }, fetchPolicy: "cache-first" });
+  // @ts-expect-error invalid fetchPolicy
+  preloadQuery(query, { variables: { id: "1" }, fetchPolicy: "bogus" });
+  // @ts-expect-error invalid errorPolicy
+  preloadQuery(query, { variables: { id: "1" }, errorPolicy: "bogus" });
+});
+
+test("rejects invalid variable values for constant variable types", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  preloadQuery(query, { variables: { type: "main" } });
+  // @ts-expect-error invalid variable value
+  preloadQuery(query, { variables: { type: "nope" } });
+  // @ts-expect-error unknown variable
+  preloadQuery(query, { variables: { type: "main", foo: "bar" } });
+});
+
+test("constant variable types do not widen returnPartialData or errorPolicy", () => {
+  type Data = { character: string };
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const queryRef = preloadQuery(query, { variables: { type: "main" } });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      PreloadedQueryRef<Data, { type: "main" }, "complete" | "streaming">
+    >();
+
+    const { data, dataState } = useReadQuery(queryRef);
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const queryRef = preloadQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      PreloadedQueryRef<Data, { type: "main" }, "complete" | "streaming">
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const queryRef = preloadQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      PreloadedQueryRef<
+        Data,
+        { type: "main" },
+        "complete" | "streaming" | "partial"
+      >
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const queryRef = preloadQuery(query, {
+      variables: { type: "main" },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      PreloadedQueryRef<Data, { type: "main" }, "complete" | "streaming">
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const queryRef = preloadQuery(query, {
+      variables: { type: "main" },
+      errorPolicy: "all",
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      PreloadedQueryRef<
+        Data,
+        { type: "main" },
+        "complete" | "streaming" | "empty"
+      >
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { episode: 10 }> = gql``;
+
+    const queryRef = preloadQuery(query, {
+      variables: { episode: 10 },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      PreloadedQueryRef<Data, { episode: 10 }, "complete" | "streaming">
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { main: true }> = gql``;
+
+    const queryRef = preloadQuery(query, {
+      variables: { main: true },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      PreloadedQueryRef<Data, { main: true }, "complete" | "streaming">
+    >();
+  }
+});
+
+test("passes through generic variables", () => {
+  function wrapper<TData, TVariables extends OperationVariables>(
+    query: TypedDocumentNode<TData, TVariables>,
+    variables: TVariables
+  ) {
+    return preloadQuery(query, { variables });
+  }
+
+  const query: TypedDocumentNode<{ character: string }, { id: string }> = gql``;
+
+  wrapper(query, { id: "1" });
+});

--- a/integration-tests/type-tests/signatures/modern/mutate.ts
+++ b/integration-tests/type-tests/signatures/modern/mutate.ts
@@ -1,0 +1,188 @@
+import {
+  ApolloClient,
+  ErrorLike,
+  gql,
+  OperationVariables,
+  TypedDocumentNode,
+} from "@apollo/client";
+import { expectTypeOf } from "expect-type";
+
+import { test } from "./shared.js";
+
+declare const client: ApolloClient;
+
+test("rejects unknown options", () => {
+  interface Data {
+    character: string;
+  }
+
+  const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;
+  const widenedVariables: TypedDocumentNode<Data, { type: string }> = gql``;
+  const noVariables: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  client.mutate({
+    mutation: literalVariables,
+    variables: { type: "main" },
+    errorPolicy: "all",
+    context: { foo: 1 },
+    awaitRefetchQueries: true,
+    keepRootFields: true,
+  });
+
+  client.mutate({
+    mutation: literalVariables,
+    variables: { type: "main" },
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  client.mutate({
+    mutation: widenedVariables,
+    variables: { type: "main" },
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  client.mutate({
+    mutation: noVariables,
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  client.mutate({
+    mutation: literalVariables,
+    variables: { type: "main" },
+    errorPolicy: "all",
+    // @ts-expect-error unknown option
+    bogusOption: 1,
+  });
+});
+
+test("rejects a known option with an invalid value", () => {
+  interface Data {
+    character: string;
+  }
+
+  const mutation: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  client.mutate({
+    mutation,
+    variables: { id: "1" },
+    fetchPolicy: "network-only",
+  });
+  // @ts-expect-error invalid fetchPolicy
+  client.mutate({ mutation, variables: { id: "1" }, fetchPolicy: "bogus" });
+  // @ts-expect-error invalid errorPolicy
+  client.mutate({ mutation, variables: { id: "1" }, errorPolicy: "bogus" });
+});
+
+test("rejects invalid variable values for constant variable types", () => {
+  interface Data {
+    character: string;
+  }
+
+  const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  client.mutate({ mutation, variables: { type: "main" } });
+  // @ts-expect-error invalid variable value
+  client.mutate({ mutation, variables: { type: "nope" } });
+  // @ts-expect-error unknown variable
+  client.mutate({ mutation, variables: { type: "main", foo: "bar" } });
+});
+
+test("constant variable types do not widen errorPolicy", async () => {
+  interface Data {
+    character: string;
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { type: "main" },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { type: "main" },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { type: "main" },
+      errorPolicy: "all",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { type: "main" },
+      errorPolicy: "ignore",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { episode: 10 }> = gql``;
+
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { episode: 10 },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { main: true }> = gql``;
+
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { main: true },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("passes through generic variables", () => {
+  function wrapper<TData, TVariables extends OperationVariables>(
+    mutation: TypedDocumentNode<TData, TVariables>,
+    variables: TVariables
+  ) {
+    return client.mutate({ mutation, variables });
+  }
+
+  const mutation: TypedDocumentNode<{ character: string }, { id: string }> =
+    gql``;
+
+  wrapper(mutation, { id: "1" });
+});

--- a/integration-tests/type-tests/signatures/modern/query.ts
+++ b/integration-tests/type-tests/signatures/modern/query.ts
@@ -1,0 +1,182 @@
+import {
+  ApolloClient,
+  ErrorLike,
+  gql,
+  OperationVariables,
+  TypedDocumentNode,
+} from "@apollo/client";
+import { expectTypeOf } from "expect-type";
+
+import { test } from "./shared.js";
+
+declare const client: ApolloClient;
+
+test("rejects unknown options", () => {
+  interface Data {
+    character: string;
+  }
+
+  const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;
+  const widenedVariables: TypedDocumentNode<Data, { type: string }> = gql``;
+  const noVariables: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  client.query({
+    query: literalVariables,
+    variables: { type: "main" },
+    errorPolicy: "all",
+    context: { foo: 1 },
+    fetchPolicy: "network-only",
+  });
+
+  client.query({
+    query: literalVariables,
+    variables: { type: "main" },
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  client.query({
+    query: widenedVariables,
+    variables: { type: "main" },
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  client.query({
+    query: noVariables,
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  client.query({
+    query: literalVariables,
+    variables: { type: "main" },
+    errorPolicy: "all",
+    // @ts-expect-error unknown option
+    bogusOption: 1,
+  });
+});
+
+test("rejects a known option with an invalid value", () => {
+  interface Data {
+    character: string;
+  }
+
+  const query: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  client.query({ query, variables: { id: "1" }, fetchPolicy: "network-only" });
+  // @ts-expect-error invalid fetchPolicy
+  client.query({ query, variables: { id: "1" }, fetchPolicy: "bogus" });
+  // @ts-expect-error invalid errorPolicy
+  client.query({ query, variables: { id: "1" }, errorPolicy: "bogus" });
+});
+
+test("rejects invalid variable values for constant variable types", () => {
+  interface Data {
+    character: string;
+  }
+
+  const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  client.query({ query, variables: { type: "main" } });
+  // @ts-expect-error invalid variable value
+  client.query({ query, variables: { type: "nope" } });
+  // @ts-expect-error unknown variable
+  client.query({ query, variables: { type: "main", foo: "bar" } });
+});
+
+test("constant variable types do not widen errorPolicy", async () => {
+  interface Data {
+    character: string;
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, error } = await client.query({
+      query,
+      variables: { type: "main" },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, error } = await client.query({
+      query,
+      variables: { type: "main" },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, error } = await client.query({
+      query,
+      variables: { type: "main" },
+      errorPolicy: "all",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, error } = await client.query({
+      query,
+      variables: { type: "main" },
+      errorPolicy: "ignore",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { episode: 10 }> = gql``;
+
+    const { data, error } = await client.query({
+      query,
+      variables: { episode: 10 },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { main: true }> = gql``;
+
+    const { data, error } = await client.query({
+      query,
+      variables: { main: true },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("passes through generic variables", () => {
+  function wrapper<TData, TVariables extends OperationVariables>(
+    query: TypedDocumentNode<TData, TVariables>,
+    variables: TVariables
+  ) {
+    return client.query({ query, variables });
+  }
+
+  const query: TypedDocumentNode<{ character: string }, { id: string }> = gql``;
+
+  wrapper(query, { id: "1" });
+});

--- a/integration-tests/type-tests/signatures/modern/useBackgroundQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useBackgroundQuery.ts
@@ -2491,3 +2491,205 @@ test("requires variables with mixed TVariables", () => {
     )
   );
 });
+
+test("rejects unknown options", () => {
+  type Data = { character: string };
+  const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;
+  const widenedVariables: TypedDocumentNode<Data, { type: string }> = gql``;
+  const noVariables: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  useBackgroundQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialData: true,
+    errorPolicy: "all",
+    context: { foo: 1 },
+    fetchPolicy: "cache-first",
+    queryKey: "key",
+  });
+
+  // @ts-expect-error unknown option
+  useBackgroundQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useBackgroundQuery(widenedVariables, {
+    variables: { type: "main" },
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useBackgroundQuery(noVariables, {
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useBackgroundQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialData: true,
+    bogusOption: 1,
+  });
+
+  let skip!: boolean;
+  // @ts-expect-error unknown option
+  useBackgroundQuery(
+    noVariables,
+    skip ? skipToken : { returnPartialDta: false }
+  );
+  useBackgroundQuery(
+    literalVariables,
+    // @ts-expect-error unknown option
+    skip ? skipToken : { variables: { type: "main" }, returnPartialDta: false }
+  );
+});
+
+test("rejects a known option with an invalid value", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  useBackgroundQuery(query, {
+    variables: { id: "1" },
+    fetchPolicy: "cache-first",
+  });
+  // @ts-expect-error invalid fetchPolicy
+  useBackgroundQuery(query, { variables: { id: "1" }, fetchPolicy: "bogus" });
+  // @ts-expect-error invalid errorPolicy
+  useBackgroundQuery(query, { variables: { id: "1" }, errorPolicy: "bogus" });
+});
+
+test("rejects invalid variable values for constant variable types", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  useBackgroundQuery(query, { variables: { type: "main" } });
+  // @ts-expect-error invalid variable value
+  useBackgroundQuery(query, { variables: { type: "nope" } });
+  // @ts-expect-error unknown variable
+  useBackgroundQuery(query, { variables: { type: "main", foo: "bar" } });
+});
+
+test("constant variable types do not widen returnPartialData, errorPolicy or skip", () => {
+  type Data = { character: string };
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [queryRef] = useBackgroundQuery(query, {
+      variables: { type: "main" },
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      QueryRef<Data, { type: "main" }, "complete" | "streaming">
+    >();
+
+    const { data, dataState } = useReadQuery(queryRef);
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [queryRef] = useBackgroundQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      QueryRef<Data, { type: "main" }, "complete" | "streaming">
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [queryRef] = useBackgroundQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      QueryRef<Data, { type: "main" }, "complete" | "streaming" | "partial">
+    >();
+
+    const { data, dataState } = useReadQuery(queryRef);
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<Data>
+      | DataValue.Partial<Data>
+      | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<
+      "complete" | "streaming" | "partial"
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [queryRef] = useBackgroundQuery(query, {
+      variables: { type: "main" },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      QueryRef<Data, { type: "main" }, "complete" | "streaming">
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [queryRef] = useBackgroundQuery(query, {
+      variables: { type: "main" },
+      errorPolicy: "all",
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      QueryRef<Data, { type: "main" }, "complete" | "streaming" | "empty">
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [queryRef] = useBackgroundQuery(query, {
+      variables: { type: "main" },
+      skip: false,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      QueryRef<Data, { type: "main" }, "complete" | "streaming">
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { episode: 10 }> = gql``;
+
+    const [queryRef] = useBackgroundQuery(query, {
+      variables: { episode: 10 },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      QueryRef<Data, { episode: 10 }, "complete" | "streaming">
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { main: true }> = gql``;
+
+    const [queryRef] = useBackgroundQuery(query, {
+      variables: { main: true },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(queryRef).toEqualTypeOf<
+      QueryRef<Data, { main: true }, "complete" | "streaming">
+    >();
+  }
+});

--- a/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
@@ -479,3 +479,121 @@ test("execution result has `.retain` method", () => {
   // retain should return the same type as the original result
   expectTypeOf(result.retain()).toEqualTypeOf(result);
 });
+
+test("rejects unknown options", () => {
+  type Data = { character: string };
+  const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;
+  const noVariables: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  useLazyQuery(literalVariables, {
+    returnPartialData: true,
+    errorPolicy: "all",
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: "cache-first",
+  });
+
+  useLazyQuery(literalVariables, {
+    // @ts-expect-error unknown option
+    returnPartialDta: false,
+  });
+
+  useLazyQuery(noVariables, {
+    // @ts-expect-error unknown option
+    returnPartialDta: false,
+  });
+
+  useLazyQuery(literalVariables, {
+    returnPartialData: true,
+    // @ts-expect-error unknown option
+    bogusOption: 1,
+  });
+
+  useLazyQuery(literalVariables, {
+    // @ts-expect-error variables are passed to the execute function
+    variables: { type: "main" },
+  });
+});
+
+test("rejects a known option with an invalid value", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  useLazyQuery(query, { fetchPolicy: "cache-first" });
+  // @ts-expect-error invalid fetchPolicy
+  useLazyQuery(query, { fetchPolicy: "bogus" });
+  // @ts-expect-error invalid errorPolicy
+  useLazyQuery(query, { errorPolicy: "bogus" });
+});
+
+test("rejects invalid variable values for constant variable types", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+  const stringVariables: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  const [execute] = useLazyQuery(query);
+  const [executeStringVariables] = useLazyQuery(stringVariables);
+
+  execute({ variables: { type: "main" } });
+  // @ts-expect-error invalid variable value
+  execute({ variables: { type: "nope" } });
+  // @ts-expect-error unknown variable
+  execute({ variables: { type: "main", foo: "bar" } });
+  // @ts-expect-error wrong variable type
+  executeStringVariables({ variables: { id: 1 } });
+  // @ts-expect-error variables must be an object
+  executeStringVariables({ variables: "nonsense" });
+});
+
+test("constant variable types do not widen returnPartialData", () => {
+  type Data = { character: string };
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [, { dataState }] = useLazyQuery(query);
+
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [, { dataState }] = useLazyQuery(query, {
+      returnPartialData: false,
+    });
+
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [, { dataState }] = useLazyQuery(query, {
+      returnPartialData: true,
+    });
+
+    expectTypeOf(dataState).toEqualTypeOf<
+      "empty" | "complete" | "streaming" | "partial"
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { episode: 10 }> = gql``;
+
+    const [, { dataState }] = useLazyQuery(query, {
+      returnPartialData: false,
+    });
+
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { main: true }> = gql``;
+
+    const [, { dataState }] = useLazyQuery(query, {
+      returnPartialData: false,
+    });
+
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "complete" | "streaming">();
+  }
+});

--- a/integration-tests/type-tests/signatures/modern/useLoadableQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useLoadableQuery.ts
@@ -916,3 +916,146 @@ it("returns correct TData type when combined options that do not affect TData", 
     }
   } */
 });
+
+it("rejects unknown options", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  useLoadableQuery(query, {
+    returnPartialData: true,
+    errorPolicy: "all",
+    fetchPolicy: "cache-first",
+    queryKey: "key",
+  });
+
+  useLoadableQuery(query, {
+    // @ts-expect-error unknown option
+    returnPartialDta: false,
+  });
+
+  useLoadableQuery(query, {
+    returnPartialData: true,
+    // @ts-expect-error unknown option
+    bogusOption: 1,
+  });
+
+  useLoadableQuery(query, {
+    // @ts-expect-error variables are passed to the loadQuery function
+    variables: { type: "main" },
+  });
+});
+
+it("rejects a known option with an invalid value", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  useLoadableQuery(query, { fetchPolicy: "cache-first" });
+  // @ts-expect-error invalid fetchPolicy
+  useLoadableQuery(query, { fetchPolicy: "bogus" });
+  // @ts-expect-error invalid errorPolicy
+  useLoadableQuery(query, { errorPolicy: "bogus" });
+});
+
+it("rejects invalid variable values for constant variable types", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  const [loadQuery] = useLoadableQuery(query);
+
+  const stringVariables: TypedDocumentNode<Data, { id: string }> = gql``;
+  const [loadStringQuery] = useLoadableQuery(stringVariables);
+
+  loadQuery({ type: "main" });
+  // @ts-expect-error invalid variable value
+  loadQuery({ type: "nope" });
+  // @ts-expect-error unknown variable
+  loadQuery({ type: "main", foo: "bar" });
+  // @ts-expect-error wrong variable type
+  loadStringQuery({ id: 1 });
+  // @ts-expect-error variables must be an object
+  loadStringQuery("nonsense");
+});
+
+it("constant variable types do not widen returnPartialData or errorPolicy", () => {
+  type Data = { character: string };
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [loadQuery, queryRef] = useLoadableQuery(query, {
+      returnPartialData: false,
+    });
+
+    loadQuery({ type: "main" });
+
+    expectTypeOf(queryRef).toEqualTypeOf<QueryRef<
+      Data,
+      { type: "main" },
+      "complete" | "streaming"
+    > | null>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [loadQuery, queryRef] = useLoadableQuery(query, {
+      returnPartialData: true,
+    });
+
+    loadQuery({ type: "main" });
+
+    expectTypeOf(queryRef).toEqualTypeOf<QueryRef<
+      Data,
+      { type: "main" },
+      "complete" | "streaming" | "partial"
+    > | null>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [loadQuery, queryRef] = useLoadableQuery(query, {
+      errorPolicy: "all",
+    });
+
+    loadQuery({ type: "main" });
+
+    expectTypeOf(queryRef).toEqualTypeOf<QueryRef<
+      Data,
+      { type: "main" },
+      "complete" | "streaming" | "empty"
+    > | null>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { episode: 10 }> = gql``;
+
+    const [loadQuery, queryRef] = useLoadableQuery(query, {
+      returnPartialData: false,
+    });
+
+    loadQuery({ episode: 10 });
+
+    expectTypeOf(queryRef).toEqualTypeOf<QueryRef<
+      Data,
+      { episode: 10 },
+      "complete" | "streaming"
+    > | null>();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { main: true }> = gql``;
+
+    const [loadQuery, queryRef] = useLoadableQuery(query, {
+      returnPartialData: false,
+    });
+
+    loadQuery({ main: true });
+
+    expectTypeOf(queryRef).toEqualTypeOf<QueryRef<
+      Data,
+      { main: true },
+      "complete" | "streaming"
+    > | null>();
+  }
+});

--- a/integration-tests/type-tests/signatures/modern/useMutation.ts
+++ b/integration-tests/type-tests/signatures/modern/useMutation.ts
@@ -1385,3 +1385,142 @@ test("requires variables with mixed TVariables", () => {
     });
   }
 });
+
+test("rejects unknown options", () => {
+  type Data = { character: string };
+  const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;
+  const widenedVariables: TypedDocumentNode<Data, { type: string }> = gql``;
+  const noVariables: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  useMutation(literalVariables, {
+    variables: { type: "main" },
+    errorPolicy: "all",
+    awaitRefetchQueries: true,
+    keepRootFields: true,
+    fetchPolicy: "network-only",
+  });
+
+  useMutation(literalVariables, {
+    variables: { type: "main" },
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  useMutation(widenedVariables, {
+    variables: { type: "main" },
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  useMutation(noVariables, {
+    // @ts-expect-error unknown option
+    errorPolcy: "all",
+  });
+
+  useMutation(literalVariables, {
+    variables: { type: "main" },
+    errorPolicy: "all",
+    // @ts-expect-error unknown option
+    bogusOption: 1,
+  });
+});
+
+test("rejects a known option with an invalid value", () => {
+  type Data = { character: string };
+  const mutation: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  useMutation(mutation, {
+    variables: { id: "1" },
+    fetchPolicy: "network-only",
+  });
+  // @ts-expect-error invalid fetchPolicy
+  useMutation(mutation, { variables: { id: "1" }, fetchPolicy: "bogus" });
+  // @ts-expect-error invalid errorPolicy
+  useMutation(mutation, { variables: { id: "1" }, errorPolicy: "bogus" });
+});
+
+test("rejects invalid variable values for constant variable types", () => {
+  type Data = { character: string };
+  const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  const stringVariables: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  useMutation(mutation, { variables: { type: "main" } });
+  // @ts-expect-error invalid variable value
+  useMutation(mutation, { variables: { type: "nope" } });
+  // @ts-expect-error unknown variable
+  useMutation(mutation, { variables: { type: "main", foo: "bar" } });
+  // @ts-expect-error wrong variable type
+  useMutation(stringVariables, { variables: { id: 1 } });
+  // @ts-expect-error variables must be an object
+  useMutation(stringVariables, { variables: "nonsense" });
+});
+
+test("constant variable types do not widen errorPolicy", () => {
+  type Data = { character: string };
+
+  {
+    const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [mutate, { data }] = useMutation(mutation, {
+      variables: { type: "main" },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data | null | undefined>();
+    expectTypeOf(mutate()).toEqualTypeOf<
+      Promise<ApolloClient.MutateResult<Data, "none">>
+    >();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [mutate] = useMutation(mutation, {
+      variables: { type: "main" },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(mutate()).toEqualTypeOf<
+      Promise<ApolloClient.MutateResult<Data, "none">>
+    >();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [mutate] = useMutation(mutation, {
+      variables: { type: "main" },
+      errorPolicy: "all",
+    });
+
+    expectTypeOf(mutate()).toEqualTypeOf<
+      Promise<ApolloClient.MutateResult<Data, "all">>
+    >();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { episode: 10 }> = gql``;
+
+    const [mutate] = useMutation(mutation, {
+      variables: { episode: 10 },
+      errorPolicy: "all",
+    });
+
+    expectTypeOf(mutate()).toEqualTypeOf<
+      Promise<ApolloClient.MutateResult<Data, "all">>
+    >();
+  }
+
+  {
+    const mutation: TypedDocumentNode<Data, { main: true }> = gql``;
+
+    const [mutate] = useMutation(mutation, {
+      variables: { main: true },
+      errorPolicy: "all",
+    });
+
+    expectTypeOf(mutate()).toEqualTypeOf<
+      Promise<ApolloClient.MutateResult<Data, "all">>
+    >();
+  }
+});

--- a/integration-tests/type-tests/signatures/modern/useQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useQuery.ts
@@ -421,11 +421,8 @@ test("rejects unknown options", () => {
   });
 
   let skip!: boolean;
-  useQuery(
-    noVariables,
-    // @ts-expect-error unknown option
-    skip ? skipToken : { returnPartialDta: false }
-  );
+  // @ts-expect-error unknown option
+  useQuery(noVariables, skip ? skipToken : { returnPartialDta: false });
   useQuery(
     literalVariables,
     // @ts-expect-error unknown option

--- a/integration-tests/type-tests/signatures/modern/useQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useQuery.ts
@@ -193,6 +193,12 @@ test("optional variables are optional", () => {
     },
   });
 
+  let validVariables!: { limit: number };
+  let excessVariables!: { limit: number; foo: string };
+  useQuery(query, { variables: validVariables });
+  // @ts-expect-error unknown variables
+  useQuery(query, { variables: excessVariables });
+
   let skip!: boolean;
   useQuery(query, skip ? skipToken : undefined);
   useQuery(query, skip ? skipToken : {});
@@ -365,6 +371,82 @@ test("requires variables with mixed TVariables", () => {
       }
     )
   );
+});
+
+test("rejects unknown options", () => {
+  const literalVariables: TypedDocumentNode<
+    { character: string },
+    { type: "main" }
+  > = gql``;
+  const widenedVariables: TypedDocumentNode<
+    { character: string },
+    { type: string }
+  > = gql``;
+  const noVariables: TypedDocumentNode<
+    { greeting: string },
+    Record<string, never>
+  > = gql``;
+
+  useQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialData: true,
+    notifyOnNetworkStatusChange: true,
+    errorPolicy: "all",
+    context: { foo: 1 },
+    skipPollAttempt: () => false,
+  });
+
+  // @ts-expect-error unknown option
+  useQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useQuery(widenedVariables, {
+    variables: { type: "main" },
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useQuery(noVariables, {
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialData: true,
+    bogusOption: 1,
+  });
+
+  let skip!: boolean;
+  useQuery(
+    noVariables,
+    // @ts-expect-error unknown option
+    skip ? skipToken : { returnPartialDta: false }
+  );
+  useQuery(
+    literalVariables,
+    // @ts-expect-error unknown option
+    skip ? skipToken : { variables: { type: "main" }, returnPartialDta: false }
+  );
+});
+
+test("rejects a known option with an invalid value", () => {
+  const query: TypedDocumentNode<{ character: string }, { id: string }> = gql``;
+
+  useQuery(query, { variables: { id: "1" }, fetchPolicy: "cache-first" });
+  // @ts-expect-error invalid fetchPolicy
+  useQuery(query, {
+    variables: { id: "1" },
+    fetchPolicy: "bogus",
+  });
+  // @ts-expect-error invalid errorPolicy
+  useQuery(query, {
+    variables: { id: "1" },
+    errorPolicy: "bogus",
+  });
 });
 
 test("constant variable types do not widen returnPartialData", () => {

--- a/integration-tests/type-tests/signatures/modern/useQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useQuery.ts
@@ -367,6 +367,167 @@ test("requires variables with mixed TVariables", () => {
   );
 });
 
+test("constant variable types do not widen returnPartialData", () => {
+  {
+    const query: TypedDocumentNode<{ character: string }, { type: "main" }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { type: "main" },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { type: "main" }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { type: "main" }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | DataValue.Partial<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<
+      "empty" | "partial" | "streaming" | "complete"
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { episode: 10 }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { episode: 10 },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { episode: 10 }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { episode: 10 },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { episode: 10 }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { episode: 10 },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | DataValue.Partial<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<
+      "empty" | "partial" | "streaming" | "complete"
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { main: true }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { main: true },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { main: true }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { main: true },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const query: TypedDocumentNode<{ character: string }, { main: true }> =
+      gql``;
+
+    const { data, dataState } = useQuery(query, {
+      variables: { main: true },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<{ character: string }>
+      | DataValue.Streaming<{ character: string }>
+      | DataValue.Partial<{ character: string }>
+      | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<
+      "empty" | "partial" | "streaming" | "complete"
+    >();
+  }
+});
+
 test("always returns empty data/dataState with unconditional skipToken", () => {
   const query: TypedDocumentNode<
     { character: string },

--- a/integration-tests/type-tests/signatures/modern/useQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useQuery.ts
@@ -446,6 +446,25 @@ test("rejects a known option with an invalid value", () => {
   });
 });
 
+test("rejects invalid variable values for constant variable types", () => {
+  const query: TypedDocumentNode<{ character: string }, { type: "main" }> =
+    gql``;
+  const stringVariables: TypedDocumentNode<
+    { character: string },
+    { id: string }
+  > = gql``;
+
+  useQuery(query, { variables: { type: "main" } });
+  // @ts-expect-error invalid variable value
+  useQuery(query, { variables: { type: "nope" } });
+  // @ts-expect-error unknown variable
+  useQuery(query, { variables: { type: "main", foo: "bar" } });
+  // @ts-expect-error wrong variable type
+  useQuery(stringVariables, { variables: { id: 1 } });
+  // @ts-expect-error variables must be an object
+  useQuery(stringVariables, { variables: "nonsense" });
+});
+
 test("constant variable types do not widen returnPartialData", () => {
   {
     const query: TypedDocumentNode<{ character: string }, { type: "main" }> =

--- a/integration-tests/type-tests/signatures/modern/useSuspenseQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useSuspenseQuery.ts
@@ -2495,3 +2495,196 @@ test("requires variables with mixed TVariables", () => {
     )
   );
 });
+
+test("rejects unknown options", () => {
+  type Data = { character: string };
+  const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;
+  const widenedVariables: TypedDocumentNode<Data, { type: string }> = gql``;
+  const noVariables: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  useSuspenseQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialData: true,
+    errorPolicy: "all",
+    context: { foo: 1 },
+    fetchPolicy: "cache-first",
+    queryKey: "key",
+  });
+
+  // @ts-expect-error unknown option
+  useSuspenseQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useSuspenseQuery(widenedVariables, {
+    variables: { type: "main" },
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useSuspenseQuery(noVariables, {
+    returnPartialDta: false,
+  });
+
+  // @ts-expect-error unknown option
+  useSuspenseQuery(literalVariables, {
+    variables: { type: "main" },
+    returnPartialData: true,
+    bogusOption: 1,
+  });
+
+  let skip!: boolean;
+  // @ts-expect-error unknown option
+  useSuspenseQuery(noVariables, skip ? skipToken : { returnPartialDta: false });
+  useSuspenseQuery(
+    literalVariables,
+    // @ts-expect-error unknown option
+    skip ? skipToken : { variables: { type: "main" }, returnPartialDta: false }
+  );
+});
+
+test("rejects a known option with an invalid value", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  useSuspenseQuery(query, {
+    variables: { id: "1" },
+    fetchPolicy: "cache-first",
+  });
+  // @ts-expect-error invalid fetchPolicy
+  useSuspenseQuery(query, { variables: { id: "1" }, fetchPolicy: "bogus" });
+  // @ts-expect-error invalid errorPolicy
+  useSuspenseQuery(query, { variables: { id: "1" }, errorPolicy: "bogus" });
+});
+
+test("rejects invalid variable values for constant variable types", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+  useSuspenseQuery(query, { variables: { type: "main" } });
+  // @ts-expect-error invalid variable value
+  useSuspenseQuery(query, { variables: { type: "nope" } });
+  // @ts-expect-error unknown variable
+  useSuspenseQuery(query, { variables: { type: "main", foo: "bar" } });
+});
+
+test("constant variable types do not widen returnPartialData, errorPolicy or skip", () => {
+  type Data = { character: string };
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, dataState } = useSuspenseQuery(query, {
+      variables: { type: "main" },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, dataState } = useSuspenseQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, dataState } = useSuspenseQuery(query, {
+      variables: { type: "main" },
+      returnPartialData: true,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      | DataValue.Complete<Data>
+      | DataValue.Partial<Data>
+      | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<
+      "complete" | "streaming" | "partial"
+    >();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, dataState } = useSuspenseQuery(query, {
+      variables: { type: "main" },
+      errorPolicy: "none",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, dataState } = useSuspenseQuery(query, {
+      variables: { type: "main" },
+      errorPolicy: "all",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data> | undefined
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming" | "empty">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const { data, dataState } = useSuspenseQuery(query, {
+      variables: { type: "main" },
+      skip: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { episode: 10 }> = gql``;
+
+    const { data, dataState } = useSuspenseQuery(query, {
+      variables: { episode: 10 },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
+  }
+
+  {
+    const query: TypedDocumentNode<Data, { main: true }> = gql``;
+
+    const { data, dataState } = useSuspenseQuery(query, {
+      variables: { main: true },
+      returnPartialData: false,
+    });
+
+    expectTypeOf(data).toEqualTypeOf<
+      DataValue.Complete<Data> | DataValue.Streaming<Data>
+    >();
+    expectTypeOf(dataState).toEqualTypeOf<"complete" | "streaming">();
+  }
+});

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -22,6 +22,7 @@ import { __DEV__ } from "@apollo/client/utilities/environment";
 import type {
   LazyType,
   OptionWithFallback,
+  Prettify,
   SignatureStyle,
   VariablesOption,
   variablesUnknownSymbol,
@@ -244,13 +245,41 @@ export declare namespace ApolloClient {
     export interface DefaultOptions
       extends ApolloClient.DefaultOptions.Mutate.Calculated {}
 
+    export type OptionsFor<
+      TData,
+      TVariables extends OperationVariables,
+      TCache extends ApolloCache,
+      TOptions,
+    > = MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & {
+      variables?: Prettify<
+        TVariables & {
+          // variables that are not part of `TVariables`
+          [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
+            keyof TVariables
+          ) ?
+            TVariables[K]
+          : never;
+        }
+      >;
+    } & ([Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>] extends (
+        [never]
+      ) ?
+        unknown
+      : {
+          // options that are not part of `ApolloClient.MutateOptions`
+          [K in Exclude<
+            keyof TOptions,
+            keyof MutateOptions<any, any, any>
+          >]: never;
+        });
+
     export type ResultForOptions<
       TData,
       TVariables extends OperationVariables,
       TCache extends ApolloCache,
       TOptions extends
         | Record<string, unknown>
-        | MutateOptions<any, TVariables, TCache>,
+        | Omit<MutateOptions<any, any, TCache>, "variables">,
     > = LazyType<
       MutateResult<
         MaybeMasked<TData>,
@@ -298,23 +327,18 @@ export declare namespace ApolloClient {
           TVariables extends OperationVariables,
           TCache extends ApolloCache,
           // this overload should never be manually defined, it should always be inferred
-          TOptions extends ApolloClient.MutateOptions<
-            NoInfer<TData>,
-            NoInfer<TVariables>,
-            TCache
-          > &
-            VariablesOption<
-              TVariables & {
-                [K in Exclude<
-                  keyof TOptions["variables"],
-                  keyof TVariables
-                >]?: never;
-              }
-            >,
+          TOptions extends Omit<
+            ApolloClient.MutateOptions<NoInfer<TData>, any, TCache>,
+            "variables"
+          > & { variables?: unknown },
         >(
-          options: TOptions & {
-            mutation: TypedDocumentNode<TData, TVariables>;
-          }
+          options: TOptions &
+            ApolloClient.mutate.OptionsFor<
+              TData,
+              TVariables,
+              TCache,
+              TOptions
+            > & { mutation: TypedDocumentNode<TData, TVariables> }
         ): Promise<
           ApolloClient.mutate.ResultForOptions<
             TData,
@@ -436,10 +460,36 @@ export declare namespace ApolloClient {
     export interface DefaultOptions
       extends ApolloClient.DefaultOptions.Query.Calculated {}
 
+    export type OptionsFor<
+      TData,
+      TVariables extends OperationVariables,
+      TOptions,
+    > = QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & {
+      variables?: Prettify<
+        TVariables & {
+          // variables that are not part of `TVariables`
+          [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
+            keyof TVariables
+          ) ?
+            TVariables[K]
+          : never;
+        }
+      >;
+    } & ([Exclude<keyof TOptions, keyof QueryOptions<any, any>>] extends (
+        [never]
+      ) ?
+        unknown
+      : {
+          // options that are not part of `ApolloClient.QueryOptions`
+          [K in Exclude<keyof TOptions, keyof QueryOptions<any, any>>]: never;
+        });
+
     export type ResultForOptions<
       TData,
       TVariables extends OperationVariables,
-      TOptions extends Record<string, unknown> | QueryOptions<any, TVariables>,
+      TOptions extends
+        | Record<string, unknown>
+        | Omit<QueryOptions<any, any>, "variables">,
     > = LazyType<
       QueryResult<
         MaybeMasked<TData>,
@@ -483,20 +533,15 @@ export declare namespace ApolloClient {
           TData,
           TVariables extends OperationVariables,
           // this overload should never be manually defined, it should always be inferred
-          TOptions extends ApolloClient.QueryOptions<
-            NoInfer<TData>,
-            NoInfer<TVariables>
-          > &
-            VariablesOption<
-              TVariables & {
-                [K in Exclude<
-                  keyof TOptions["variables"],
-                  keyof TVariables
-                >]?: never;
-              }
-            >,
+          TOptions extends Omit<
+            ApolloClient.QueryOptions<NoInfer<TData>, any>,
+            "variables"
+          > & { variables?: unknown },
         >(
-          options: TOptions & { query: TypedDocumentNode<TData, TVariables> }
+          options: TOptions &
+            ApolloClient.query.OptionsFor<TData, TVariables, TOptions> & {
+              query: TypedDocumentNode<TData, TVariables>;
+            }
         ): Promise<
           ApolloClient.query.ResultForOptions<TData, TVariables, TOptions>
         >;

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -249,29 +249,23 @@ export declare namespace ApolloClient {
       TData,
       TVariables extends OperationVariables,
       TCache extends ApolloCache,
-      TOptions,
+      TOptions extends { variables?: unknown },
     > = MutateOptions<NoInfer<TData>, NoInfer<TVariables>, TCache> & {
       variables?: Prettify<
         TVariables & {
           // variables that are not part of `TVariables`
-          [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
-            keyof TVariables
-          ) ?
+          [K in keyof TOptions["variables"]]: K extends keyof TVariables ?
             TVariables[K]
           : never;
         }
       >;
-    } & ([Exclude<keyof TOptions, keyof MutateOptions<any, any, any>>] extends (
-        [never]
+    } & (Exclude<keyof TOptions, keyof MutateOptions<any, any, any>> extends (
+        infer InvalidOptionNames extends string
       ) ?
-        unknown
-      : {
-          // options that are not part of `ApolloClient.MutateOptions`
-          [K in Exclude<
-            keyof TOptions,
-            keyof MutateOptions<any, any, any>
-          >]: never;
-        });
+        [InvalidOptionNames] extends [never] ?
+          unknown
+        : { [K in InvalidOptionNames]: never }
+      : never);
 
     export type ResultForOptions<
       TData,
@@ -463,26 +457,23 @@ export declare namespace ApolloClient {
     export type OptionsFor<
       TData,
       TVariables extends OperationVariables,
-      TOptions,
+      TOptions extends { variables?: unknown },
     > = QueryOptions<NoInfer<TData>, NoInfer<TVariables>> & {
       variables?: Prettify<
         TVariables & {
           // variables that are not part of `TVariables`
-          [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
-            keyof TVariables
-          ) ?
+          [K in keyof TOptions["variables"]]: K extends keyof TVariables ?
             TVariables[K]
           : never;
         }
       >;
-    } & ([Exclude<keyof TOptions, keyof QueryOptions<any, any>>] extends (
-        [never]
+    } & (Exclude<keyof TOptions, keyof QueryOptions<any, any>> extends (
+        infer InvalidOptionNames extends string
       ) ?
-        unknown
-      : {
-          // options that are not part of `ApolloClient.QueryOptions`
-          [K in Exclude<keyof TOptions, keyof QueryOptions<any, any>>]: never;
-        });
+        [InvalidOptionNames] extends [never] ?
+          unknown
+        : { [K in InvalidOptionNames]: never }
+      : never);
 
     export type ResultForOptions<
       TData,

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -28,6 +28,7 @@ import type {
   DocumentationTypes as UtilityDocumentationTypes,
   NoInfer,
   OptionWithFallback,
+  Prettify,
   SignatureStyle,
   VariablesOption,
 } from "@apollo/client/utilities/internal";
@@ -139,10 +140,36 @@ export declare namespace useBackgroundQuery {
     skip: false;
   }
 
+  export type OptionsFor<
+    TVariables extends OperationVariables,
+    TOptions,
+  > = Options<NoInfer<TVariables>> & {
+    variables?: Prettify<
+      TVariables & {
+        // variables that are not part of `TVariables`
+        [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
+          keyof TVariables
+        ) ?
+          TVariables[K]
+        : never;
+      }
+    >;
+  } & ([
+      Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>,
+    ] extends [never] ?
+      unknown
+    : {
+        // options that are not part of `useBackgroundQuery.Options`
+        [K in Exclude<
+          keyof Exclude<TOptions, SkipToken>,
+          keyof Options<any>
+        >]: never;
+      });
+
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
-    TOptions extends Record<string, never> | Options<TVariables> | SkipToken,
+    TOptions extends Record<string, never> | Base.Options | SkipToken,
   > = [
     queryRef: TOptions extends any ?
       TOptions extends SkipToken ?
@@ -730,19 +757,18 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends useBackgroundQuery.Options<NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TOptions extends Base.Options & { variables?: unknown },
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        ...[options]: {} extends TVariables ? [options?: TOptions]
-        : [options: TOptions]
+        ...[options]: {} extends TVariables ?
+          [
+            options?: TOptions &
+              useBackgroundQuery.OptionsFor<TVariables, TOptions>,
+          ]
+        : [
+            options: TOptions &
+              useBackgroundQuery.OptionsFor<TVariables, TOptions>,
+          ]
       ): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -761,19 +787,20 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends useBackgroundQuery.Options<NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TOptions extends Base.Options & { variables?: unknown },
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken]
-        : [options: TOptions | SkipToken]
+        ...[options]: {} extends TVariables ?
+          [
+            options?:
+              | (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>)
+              | SkipToken,
+          ]
+        : [
+            options:
+              | (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>)
+              | SkipToken,
+          ]
       ): useBackgroundQuery.ResultForOptions<
         TData,
         TVariables,

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -86,6 +86,9 @@ export declare namespace useBackgroundQuery {
        * ```
        */
       skip?: boolean;
+
+      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+      variables?: unknown;
     }
   }
 
@@ -97,7 +100,7 @@ export declare namespace useBackgroundQuery {
     namespace useBackgroundQuery {
       export interface Options<
         TVariables extends OperationVariables = OperationVariables,
-      > extends Base.Options,
+      > extends Omit<Base.Options, "variables">,
           UtilityDocumentationTypes.VariableOptions<TVariables> {}
     }
   }
@@ -142,29 +145,24 @@ export declare namespace useBackgroundQuery {
 
   export type OptionsFor<
     TVariables extends OperationVariables,
-    TOptions,
-  > = Options<NoInfer<TVariables>> & {
+    TOptions extends { variables?: unknown },
+  > = useBackgroundQuery.Options<NoInfer<TVariables>> & {
     variables?: Prettify<
       TVariables & {
         // variables that are not part of `TVariables`
-        [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
-          keyof TVariables
-        ) ?
+        [K in keyof TOptions["variables"]]: K extends keyof TVariables ?
           TVariables[K]
         : never;
       }
     >;
-  } & ([
-      Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>,
-    ] extends [never] ?
-      unknown
-    : {
-        // options that are not part of `useBackgroundQuery.Options`
-        [K in Exclude<
-          keyof Exclude<TOptions, SkipToken>,
-          keyof Options<any>
-        >]: never;
-      });
+  } & (Exclude<
+      keyof Exclude<TOptions, SkipToken>,
+      keyof useBackgroundQuery.Options<any>
+    > extends infer InvalidOptionNames extends string ?
+      [InvalidOptionNames] extends [never] ?
+        unknown
+      : { [K in InvalidOptionNames]: never }
+    : never);
 
   export type ResultForOptions<
     TData,
@@ -757,7 +755,7 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends Base.Options & { variables?: unknown },
+        TOptions extends Base.Options,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?
@@ -787,7 +785,7 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends Base.Options & { variables?: unknown },
+        TOptions extends Base.Options,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -236,6 +236,13 @@ export declare namespace useLazyQuery {
   export interface DefaultOptions
     extends ApolloClient.DefaultOptions.WatchQuery.Calculated {}
 
+  export type OptionsFor<TOptions> =
+    [Exclude<keyof TOptions, keyof Options<any, any>>] extends [never] ? unknown
+    : {
+        // options that are not part of `useLazyQuery.Options`
+        [K in Exclude<keyof TOptions, keyof Options<any, any>>]: never;
+      };
+
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
@@ -433,17 +440,10 @@ export declare namespace useLazyQuery {
         TOptions extends useLazyQuery.Options<
           NoInfer<TData>,
           NoInfer<TVariables>
-        > & {
-          variables?: {
-            [K in Exclude<
-              keyof TOptions["variables"],
-              keyof TVariables
-            >]?: never;
-          };
-        },
+        >,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options?: TOptions
+        options?: TOptions & useLazyQuery.OptionsFor<TOptions>
       ): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
     }
 

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -237,11 +237,13 @@ export declare namespace useLazyQuery {
     extends ApolloClient.DefaultOptions.WatchQuery.Calculated {}
 
   export type OptionsFor<TOptions> =
-    [Exclude<keyof TOptions, keyof Options<any, any>>] extends [never] ? unknown
-    : {
-        // options that are not part of `useLazyQuery.Options`
-        [K in Exclude<keyof TOptions, keyof Options<any, any>>]: never;
-      };
+    Exclude<keyof TOptions, keyof useLazyQuery.Options<any, any>> extends (
+      infer InvalidOptionNames extends string
+    ) ?
+      [InvalidOptionNames] extends [never] ?
+        unknown
+      : { [K in InvalidOptionNames]: never }
+    : never;
 
   export type ResultForOptions<
     TData,

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -112,11 +112,13 @@ export declare namespace useLoadableQuery {
     extends ApolloClient.DefaultOptions.WatchQuery.Calculated {}
 
   export type OptionsFor<TOptions> =
-    [Exclude<keyof TOptions, keyof Options>] extends [never] ? unknown
-    : {
-        // options that are not part of `useLoadableQuery.Options`
-        [K in Exclude<keyof TOptions, keyof Options>]: never;
-      };
+    Exclude<keyof TOptions, keyof useLoadableQuery.Options> extends (
+      infer InvalidOptionNames extends string
+    ) ?
+      [InvalidOptionNames] extends [never] ?
+        unknown
+      : { [K in InvalidOptionNames]: never }
+    : never;
 
   export type ResultForOptions<
     TData,

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -111,6 +111,13 @@ export declare namespace useLoadableQuery {
   export interface DefaultOptions
     extends ApolloClient.DefaultOptions.WatchQuery.Calculated {}
 
+  export type OptionsFor<TOptions> =
+    [Exclude<keyof TOptions, keyof Options>] extends [never] ? unknown
+    : {
+        // options that are not part of `useLoadableQuery.Options`
+        [K in Exclude<keyof TOptions, keyof Options>]: never;
+      };
+
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
@@ -344,7 +351,7 @@ export declare namespace useLoadableQuery {
         TOptions extends useLoadableQuery.Options,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options: TOptions
+        options: TOptions & useLoadableQuery.OptionsFor<TOptions>
       ): useLoadableQuery.ResultForOptions<TData, TVariables, TOptions>;
     }
 

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -255,6 +255,19 @@ export declare namespace useMutation {
   export interface DefaultOptions
     extends ApolloClient.DefaultOptions.Mutate.Calculated {}
 
+  export type OptionsFor<TOptions> =
+    [Exclude<keyof TOptions, keyof Options<any, any, any, any>>] extends (
+      [never]
+    ) ?
+      unknown
+    : {
+        // options that are not part of `useMutation.Options`
+        [K in Exclude<
+          keyof TOptions,
+          keyof Options<any, any, any, any>
+        >]: never;
+      };
+
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
@@ -450,10 +463,11 @@ export declare namespace useMutation {
         TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         mutation: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options?: TOptions & {
-          /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#errorPolicy:member} */
-          errorPolicy?: TErrorPolicy;
-        }
+        options?: TOptions &
+          useMutation.OptionsFor<TOptions> & {
+            /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#errorPolicy:member} */
+            errorPolicy?: TErrorPolicy;
+          }
       ): useMutation.ResultForOptions<
         TData,
         TVariables,

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -256,17 +256,14 @@ export declare namespace useMutation {
     extends ApolloClient.DefaultOptions.Mutate.Calculated {}
 
   export type OptionsFor<TOptions> =
-    [Exclude<keyof TOptions, keyof Options<any, any, any, any>>] extends (
-      [never]
-    ) ?
-      unknown
-    : {
-        // options that are not part of `useMutation.Options`
-        [K in Exclude<
-          keyof TOptions,
-          keyof Options<any, any, any, any>
-        >]: never;
-      };
+    Exclude<
+      keyof TOptions,
+      keyof useMutation.Options<any, any, any, any>
+    > extends infer InvalidOptionNames extends string ?
+      [InvalidOptionNames] extends [never] ?
+        unknown
+      : { [K in InvalidOptionNames]: never }
+    : never;
 
   export type ResultForOptions<
     TData,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -202,14 +202,12 @@ export declare namespace useQuery {
   export type OptionsFor<
     TData,
     TVariables extends OperationVariables,
-    TOptions,
-  > = Options<TData, NoInfer<TVariables>> & {
+    TOptions extends { variables?: unknown },
+  > = useQuery.Options<TData, NoInfer<TVariables>> & {
     variables?: Prettify<
       TVariables & {
         // variables that are not part of `TVariables`
-        [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
-          keyof TVariables
-        ) ?
+        [K in keyof TOptions["variables"]]: K extends keyof TVariables ?
           TVariables[K]
         : never;
       }

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -199,31 +199,6 @@ export declare namespace useQuery {
     skip: false;
   }
 
-  /**
-   * The options as they are checked at the parameter position of the `Modern`
-   * signatures, intersected with the inferred `TOptions`.
-   *
-   * `NoInfer` keeps this from becoming an inference site for `TVariables`.
-   *
-   * The two mapped types report variables that are not part of `TVariables` and
-   * options that are not part of `useQuery.Options`. `TOptions` cannot reject
-   * either on its own, because it is inferred from the very object literal being
-   * checked - every key the user writes becomes part of it. Two details matter
-   * for the option names:
-   *
-   * - `SkipToken` is excluded from `TOptions` first. A conditionally skipped
-   *   query infers `TOptions` as a union of `SkipToken` and the options object,
-   *   and `keyof` of that union is `never`, which would silently make the check
-   *   a no-op.
-   * - The conditional is what keeps the passing case at `unknown` instead of an
-   *   empty mapped type. An empty object type is not a weak type, and an
-   *   intersection is only weak if every member is, so intersecting one in would
-   *   turn the weak type check off for the whole parameter. That check is not
-   *   only about rejecting options objects without a single known option - it
-   *   also affects inference. Without it, an options argument of the type
-   *   `SkipToken | { returnPartialData: false }` infers a `TVariables` that has
-   *   lost the optionality of its properties.
-   */
   export type OptionsFor<
     TData,
     TVariables extends OperationVariables,
@@ -259,8 +234,6 @@ export declare namespace useQuery {
     TVariables extends OperationVariables,
     TOptions extends
       | Record<string, never> // no options
-      // `Base.Options` instead of `Options` because the `variables` option is
-      // not part of `TOptions` - see the `Modern` signatures for details.
       | Base.Options<TData, TVariables>
       | SkipToken,
   > = LazyType<
@@ -577,28 +550,6 @@ export declare namespace useQuery {
     }
 
     /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
-    // Every check on the options lives at the parameter position, in
-    // `OptionsFor`. The constraint only describes the shape of an options
-    // object, because a constraint cannot do the checking.
-    //
-    // TypeScript widens fresh literals when inferring an object literal into a
-    // naked type parameter, so `useQuery(query, { variables: { type: "main" } })`
-    // infers the candidate `{ variables: { type: string } }`. A constraint that
-    // required the exact `TVariables` (`{ type: "main" }`) would reject that
-    // candidate, and TypeScript then silently substitutes the constraint for
-    // `TOptions` - discarding every other inferred option along with it. That is
-    // what made `returnPartialData: false` come back as `boolean` and put
-    // `"partial"` into `dataState`.
-    //
-    // Widening also means the constraint could not do the check even if it did
-    // not collapse: once `{ type: "nope" }` has widened to `{ type: string }`
-    // there is nothing left to distinguish it from a valid value. Only the
-    // parameter position still sees the literal.
-    //
-    // `NoInfer` on `TVariables` there is required. Without it,
-    // `VariablesOption<TVariables>` becomes an inference site and the widened
-    // `{ type: string }` candidate wins over the one from the document, which
-    // stops invalid variable values from being reported at all.
     export interface Modern {
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
       <

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -110,6 +110,9 @@ export declare namespace useQuery {
 
       /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#refetchOn:member} */
       refetchOn?: RefetchOn.Option;
+
+      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+      variables?: unknown;
     }
   }
   export type Options<
@@ -122,7 +125,7 @@ export declare namespace useQuery {
       export interface Options<
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,
-      > extends Base.Options<TData, TVariables>,
+      > extends Omit<Base.Options<TData, TVariables>, "variables">,
           UtilityDocumentationTypes.VariableOptions<TVariables> {}
     }
   }
@@ -561,9 +564,7 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends Base.Options<TData, NoInfer<TVariables>> & {
-          variables?: unknown;
-        },
+        TOptions extends Base.Options<TData, NoInfer<TVariables>>,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: // we generally do not allow for a `TVariables` of `never`
@@ -595,9 +596,7 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends Base.Options<TData, NoInfer<TVariables>> & {
-          variables?: unknown;
-        },
+        TOptions extends Base.Options<TData, NoInfer<TVariables>>,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: // we generally do not allow for a `TVariables` of `never`

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -40,6 +40,7 @@ import type {
   LazyType,
   NoInfer,
   OptionWithFallback,
+  Prettify,
   SignatureStyle,
   VariablesOption,
 } from "@apollo/client/utilities/internal";
@@ -198,12 +199,69 @@ export declare namespace useQuery {
     skip: false;
   }
 
+  /**
+   * The options as they are checked at the parameter position of the `Modern`
+   * signatures, intersected with the inferred `TOptions`.
+   *
+   * `NoInfer` keeps this from becoming an inference site for `TVariables`.
+   *
+   * The two mapped types report variables that are not part of `TVariables` and
+   * options that are not part of `useQuery.Options`. `TOptions` cannot reject
+   * either on its own, because it is inferred from the very object literal being
+   * checked - every key the user writes becomes part of it. Two details matter
+   * for the option names:
+   *
+   * - `SkipToken` is excluded from `TOptions` first. A conditionally skipped
+   *   query infers `TOptions` as a union of `SkipToken` and the options object,
+   *   and `keyof` of that union is `never`, which would silently make the check
+   *   a no-op.
+   * - The conditional is what keeps the passing case at `unknown` instead of an
+   *   empty mapped type. An empty object type is not a weak type, and an
+   *   intersection is only weak if every member is, so intersecting one in would
+   *   turn the weak type check off for the whole parameter. That check is not
+   *   only about rejecting options objects without a single known option - it
+   *   also affects inference. Without it, an options argument of the type
+   *   `SkipToken | { returnPartialData: false }` infers a `TVariables` that has
+   *   lost the optionality of its properties.
+   */
+  export type OptionsFor<
+    TData,
+    TVariables extends OperationVariables,
+    TOptions,
+  > = Options<TData, NoInfer<TVariables>> & {
+    variables?: Prettify<
+      TVariables & {
+        // variables that are not part of `TVariables`
+        [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
+          keyof TVariables
+        ) ?
+          TVariables[K]
+        : never;
+      }
+    >;
+  } & ([
+      Exclude<
+        keyof Exclude<TOptions, SkipToken>,
+        keyof Options<TData, TVariables>
+      >,
+    ] extends [never] ?
+      unknown
+    : {
+        // options that are not part of `useQuery.Options`
+        [K in Exclude<
+          keyof Exclude<TOptions, SkipToken>,
+          keyof Options<TData, TVariables>
+        >]: never;
+      });
+
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
     TOptions extends
       | Record<string, never> // no options
-      | Options<TData, TVariables>
+      // `Base.Options` instead of `Options` because the `variables` option is
+      // not part of `TOptions` - see the `Modern` signatures for details.
+      | Base.Options<TData, TVariables>
       | SkipToken,
   > = LazyType<
     Result<
@@ -519,6 +577,28 @@ export declare namespace useQuery {
     }
 
     /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
+    // Every check on the options lives at the parameter position, in
+    // `OptionsFor`. The constraint only describes the shape of an options
+    // object, because a constraint cannot do the checking.
+    //
+    // TypeScript widens fresh literals when inferring an object literal into a
+    // naked type parameter, so `useQuery(query, { variables: { type: "main" } })`
+    // infers the candidate `{ variables: { type: string } }`. A constraint that
+    // required the exact `TVariables` (`{ type: "main" }`) would reject that
+    // candidate, and TypeScript then silently substitutes the constraint for
+    // `TOptions` - discarding every other inferred option along with it. That is
+    // what made `returnPartialData: false` come back as `boolean` and put
+    // `"partial"` into `dataState`.
+    //
+    // Widening also means the constraint could not do the check even if it did
+    // not collapse: once `{ type: "nope" }` has widened to `{ type: string }`
+    // there is nothing left to distinguish it from a valid value. Only the
+    // parameter position still sees the literal.
+    //
+    // `NoInfer` on `TVariables` there is required. Without it,
+    // `VariablesOption<TVariables>` becomes an inference site and the widened
+    // `{ type: string }` candidate wins over the one from the document, which
+    // stops invalid variable values from being reported at all.
     export interface Modern {
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
       <
@@ -538,24 +618,22 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends useQuery.Options<TData, NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TOptions extends Base.Options<TData, NoInfer<TVariables>> & {
+          variables?: unknown;
+        },
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: // we generally do not allow for a `TVariables` of `never`
         // TODO: check if we need a similar check in other hooks
         [TVariables] extends [never] ? [options: never]
         : // variables optional
-        {} extends TVariables ? [options?: TOptions]
+        {} extends TVariables ?
+          [
+            options?: TOptions &
+              useQuery.OptionsFor<TData, TVariables, TOptions>,
+          ]
         : // variables required
-          [options: TOptions]
+          [options: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>]
       ): useQuery.ResultForOptions<TData, TVariables, TOptions>;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
@@ -574,24 +652,27 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends useQuery.Options<TData, NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TOptions extends Base.Options<TData, NoInfer<TVariables>> & {
+          variables?: unknown;
+        },
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: // we generally do not allow for a `TVariables` of `never`
         // TODO: check if we need a similar check in other hooks
         [TVariables] extends [never] ? [options: never]
         : // variables optional
-        {} extends TVariables ? [options?: TOptions | SkipToken]
+        {} extends TVariables ?
+          [
+            options?:
+              | (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>)
+              | SkipToken,
+          ]
         : // variables required
-          [options: TOptions | SkipToken]
+          [
+            options:
+              | (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>)
+              | SkipToken,
+          ]
       ): useQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
 
       ssrDisabledResult: ObservableQuery.Result<any>;

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -212,20 +212,14 @@ export declare namespace useQuery {
         : never;
       }
     >;
-  } & ([
-      Exclude<
-        keyof Exclude<TOptions, SkipToken>,
-        keyof Options<TData, TVariables>
-      >,
-    ] extends [never] ?
-      unknown
-    : {
-        // options that are not part of `useQuery.Options`
-        [K in Exclude<
-          keyof Exclude<TOptions, SkipToken>,
-          keyof Options<TData, TVariables>
-        >]: never;
-      });
+  } & (Exclude<
+      keyof Exclude<TOptions, SkipToken>,
+      keyof useQuery.Options<TData, TVariables>
+    > extends infer InvalidOptionNames extends string ?
+      [InvalidOptionNames] extends [never] ?
+        unknown
+      : { [K in InvalidOptionNames]: never }
+    : never);
 
   export type ResultForOptions<
     TData,

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -95,6 +95,9 @@ export declare namespace useSuspenseQuery {
        * ```
        */
       skip?: boolean;
+
+      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+      variables?: unknown;
     }
   }
   export type Options<
@@ -105,7 +108,7 @@ export declare namespace useSuspenseQuery {
     namespace useSuspenseQuery {
       export interface Options<
         TVariables extends OperationVariables = OperationVariables,
-      > extends Base.Options<TVariables>,
+      > extends Omit<Base.Options<TVariables>, "variables">,
           UtilityDocumentationTypes.VariableOptions<TVariables> {}
     }
   }
@@ -159,29 +162,24 @@ export declare namespace useSuspenseQuery {
 
   export type OptionsFor<
     TVariables extends OperationVariables,
-    TOptions,
-  > = Options<NoInfer<TVariables>> & {
+    TOptions extends { variables?: unknown },
+  > = useSuspenseQuery.Options<NoInfer<TVariables>> & {
     variables?: Prettify<
       TVariables & {
         // variables that are not part of `TVariables`
-        [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
-          keyof TVariables
-        ) ?
+        [K in keyof TOptions["variables"]]: K extends keyof TVariables ?
           TVariables[K]
         : never;
       }
     >;
-  } & ([
-      Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>,
-    ] extends [never] ?
-      unknown
-    : {
-        // options that are not part of `useSuspenseQuery.Options`
-        [K in Exclude<
-          keyof Exclude<TOptions, SkipToken>,
-          keyof Options<any>
-        >]: never;
-      });
+  } & (Exclude<
+      keyof Exclude<TOptions, SkipToken>,
+      keyof useSuspenseQuery.Options<any>
+    > extends infer InvalidOptionNames extends string ?
+      [InvalidOptionNames] extends [never] ?
+        unknown
+      : { [K in InvalidOptionNames]: never }
+    : never);
 
   export type ResultForOptions<
     TData,
@@ -589,9 +587,7 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends Base.Options<NoInfer<TVariables>> & {
-          variables?: unknown;
-        },
+        TOptions extends Base.Options<NoInfer<TVariables>>,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?
@@ -621,9 +617,7 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends Base.Options<NoInfer<TVariables>> & {
-          variables?: unknown;
-        },
+        TOptions extends Base.Options<NoInfer<TVariables>>,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -29,6 +29,7 @@ import type {
   DocumentationTypes as UtilityDocumentationTypes,
   NoInfer,
   OptionWithFallback,
+  Prettify,
   SignatureStyle,
   VariablesOption,
 } from "@apollo/client/utilities/internal";
@@ -156,12 +157,38 @@ export declare namespace useSuspenseQuery {
     skip: false;
   }
 
+  export type OptionsFor<
+    TVariables extends OperationVariables,
+    TOptions,
+  > = Options<NoInfer<TVariables>> & {
+    variables?: Prettify<
+      TVariables & {
+        // variables that are not part of `TVariables`
+        [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
+          keyof TVariables
+        ) ?
+          TVariables[K]
+        : never;
+      }
+    >;
+  } & ([
+      Exclude<keyof Exclude<TOptions, SkipToken>, keyof Options<any>>,
+    ] extends [never] ?
+      unknown
+    : {
+        // options that are not part of `useSuspenseQuery.Options`
+        [K in Exclude<
+          keyof Exclude<TOptions, SkipToken>,
+          keyof Options<any>
+        >]: never;
+      });
+
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
     TOptions extends
       | Record<string, never> // no options
-      | Options<TVariables>
+      | Base.Options<TVariables>
       | SkipToken,
   > = Result<
     TData,
@@ -562,19 +589,20 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends useSuspenseQuery.Options<NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TOptions extends Base.Options<NoInfer<TVariables>> & {
+          variables?: unknown;
+        },
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        ...[options]: {} extends TVariables ? [options?: TOptions]
-        : [options: TOptions]
+        ...[options]: {} extends TVariables ?
+          [
+            options?: TOptions &
+              useSuspenseQuery.OptionsFor<TVariables, TOptions>,
+          ]
+        : [
+            options: TOptions &
+              useSuspenseQuery.OptionsFor<TVariables, TOptions>,
+          ]
       ): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
@@ -593,19 +621,22 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends useSuspenseQuery.Options<NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TOptions extends Base.Options<NoInfer<TVariables>> & {
+          variables?: unknown;
+        },
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken]
-        : [options: TOptions | SkipToken]
+        ...[options]: {} extends TVariables ?
+          [
+            options?:
+              | (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>)
+              | SkipToken,
+          ]
+        : [
+            options:
+              | (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>)
+              | SkipToken,
+          ]
       ): useSuspenseQuery.ResultForOptions<
         TData,
         TVariables,

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -19,6 +19,7 @@ import {
 import type {
   NoInfer,
   OptionWithFallback,
+  Prettify,
   SignatureStyle,
   VariablesOption,
 } from "@apollo/client/utilities/internal";
@@ -133,10 +134,35 @@ export declare namespace PreloadQueryFunction {
       extends PreloadQueryFunction {}
   }
 
+  export type OptionsFor<
+    TVariables extends OperationVariables,
+    TOptions,
+  > = PreloadQueryOptions<NoInfer<TVariables>> & {
+    variables?: Prettify<
+      TVariables & {
+        // variables that are not part of `TVariables`
+        [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
+          keyof TVariables
+        ) ?
+          TVariables[K]
+        : never;
+      }
+    >;
+  } & ([Exclude<keyof TOptions, keyof PreloadQueryOptions<any>>] extends (
+      [never]
+    ) ?
+      unknown
+    : {
+        // options that are not part of `PreloadQueryOptions`
+        [K in Exclude<keyof TOptions, keyof PreloadQueryOptions<any>>]: never;
+      });
+
   export type ResultForOptions<
     TData,
     TVariables extends OperationVariables,
-    TOptions extends Record<string, never> | PreloadQueryOptions<TVariables>,
+    TOptions extends
+      | Record<string, never>
+      | Omit<PreloadQueryOptions<any>, "variables">,
   > = TOptions extends any ?
     PreloadedQueryRef<
       TData,
@@ -306,19 +332,20 @@ export declare namespace PreloadQueryFunction {
         TData,
         TVariables extends OperationVariables,
         // this overload should never be manually defined, it should always be inferred
-        TOptions extends PreloadQueryOptions<NoInfer<TVariables>> &
-          VariablesOption<
-            TVariables & {
-              [K in Exclude<
-                keyof TOptions["variables"],
-                keyof TVariables
-              >]?: never;
-            }
-          >,
+        TOptions extends Omit<PreloadQueryOptions<any>, "variables"> & {
+          variables?: unknown;
+        },
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        ...[options]: {} extends TVariables ? [options?: TOptions]
-        : [options: TOptions]
+        ...[options]: {} extends TVariables ?
+          [
+            options?: TOptions &
+              PreloadQueryFunction.OptionsFor<TVariables, TOptions>,
+          ]
+        : [
+            options: TOptions &
+              PreloadQueryFunction.OptionsFor<TVariables, TOptions>,
+          ]
       ): PreloadQueryFunction.ResultForOptions<TData, TVariables, TOptions>;
     }
 

--- a/src/react/query-preloader/createQueryPreloader.ts
+++ b/src/react/query-preloader/createQueryPreloader.ts
@@ -136,26 +136,23 @@ export declare namespace PreloadQueryFunction {
 
   export type OptionsFor<
     TVariables extends OperationVariables,
-    TOptions,
+    TOptions extends { variables?: unknown },
   > = PreloadQueryOptions<NoInfer<TVariables>> & {
     variables?: Prettify<
       TVariables & {
         // variables that are not part of `TVariables`
-        [K in keyof TOptions["variables" & keyof TOptions]]: K extends (
-          keyof TVariables
-        ) ?
+        [K in keyof TOptions["variables"]]: K extends keyof TVariables ?
           TVariables[K]
         : never;
       }
     >;
-  } & ([Exclude<keyof TOptions, keyof PreloadQueryOptions<any>>] extends (
-      [never]
+  } & (Exclude<keyof TOptions, keyof PreloadQueryOptions<any>> extends (
+      infer InvalidOptionNames extends string
     ) ?
-      unknown
-    : {
-        // options that are not part of `PreloadQueryOptions`
-        [K in Exclude<keyof TOptions, keyof PreloadQueryOptions<any>>]: never;
-      });
+      [InvalidOptionNames] extends [never] ?
+        unknown
+      : { [K in InvalidOptionNames]: never }
+    : never);
 
   export type ResultForOptions<
     TData,


### PR DESCRIPTION
Fixes #13342

TypeScript playground of the reproduction: https://tsplay.dev/mAbMQW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript inference for query and mutation variables, including literal values and partial-data or error-policy results.
  * Unsupported options and invalid option values are now rejected across core and React query APIs.
  * Preserved accurate data and loading-state types when using preload, skip, and suspense features.

* **Documentation**
  * Updated public API type declarations to reflect improved option validation and variable inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->