### PR TITLE
Update return types for `refetch`, `fetchMore` and `useLazyQuery` `execute` on configured `errorPolicy`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -917,7 +917,9 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     });
     // @internal @deprecated (undocumented)
     applyOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
-    fetchMore<TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(options: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>): Promise<ApolloClient.QueryResult<TFetchData>>;
+    fetchMore<TFetchData = TData, TFetchVars extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy = "none">(options: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars> & {
+        errorPolicy?: TErrorPolicy;
+    }): Promise<ApolloClient.QueryResult<TFetchData, TErrorPolicy>>;
     // @internal @deprecated (undocumented)
     getCacheDiff({ optimistic }?: {
         optimistic?: boolean | undefined;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -375,93 +375,115 @@ export namespace useBackgroundQuery {
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
                 fetchPolicy: "no-cache";
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
-                errorPolicy: "ignore" | "all";
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-                errorPolicy: "ignore" | "all";
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
-                errorPolicy: "ignore" | "all";
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: false;
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: boolean;
+                errorPolicy?: TErrorPolicy;
             }): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
             <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): [undefined, useBackgroundQuery.Result<TData, TVariables>];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
+                errorPolicy?: TErrorPolicy;
             })): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
+                errorPolicy?: TErrorPolicy;
             })): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ] : [
+            options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ] : [
+            options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
@@ -789,13 +811,17 @@ export namespace useLazyQuery {
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming">;
+                errorPolicy?: TErrorPolicy;
+            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming", TErrorPolicy>;
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
@@ -878,17 +904,20 @@ export namespace useLoadableQuery {
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
-                errorPolicy: "ignore" | "all";
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
-                errorPolicy: "ignore" | "all";
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useLoadableQuery.Options): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming">;
+                errorPolicy?: TErrorPolicy;
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useLoadableQuery.Options & {
+                errorPolicy?: TErrorPolicy;
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming", TErrorPolicy>;
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
@@ -1168,27 +1197,41 @@ export namespace useQuery {
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
+                errorPolicy?: TErrorPolicy;
+            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TVariables, TErrorPolicy>;
             <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>, TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TVariables, TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
-            ] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+                errorPolicy?: TErrorPolicy;
+            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>, TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
             ] : [
-            options: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
-            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>>;
+            options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", TVariables, TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ] : [
+            options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>, TErrorPolicy>;
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
@@ -1553,33 +1596,51 @@ export namespace useSuspenseQuery {
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-                errorPolicy: "ignore" | "all";
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
-                errorPolicy: "ignore" | "all";
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: true;
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-            }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-            })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+                errorPolicy?: TErrorPolicy;
+            })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ] : [
+            options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ] : [
+            options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -677,14 +677,12 @@ export namespace useLazyQuery {
         export interface Result<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error?: ErrorLike;
-            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy = "none">(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars> & {
-                errorPolicy?: TErrorPolicy;
-            }) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>, TErrorPolicy>>;
+            fetchMore: FetchMoreFunction<TData, TVariables>;
             loading: boolean;
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
             previousData?: MaybeMasked<TData>;
-            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>, TErrorPolicy>>;
+            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
             startPolling: (pollInterval: number) => void;
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1099,14 +1097,12 @@ export namespace useQuery {
         export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error?: ErrorLike;
-            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy = "none">(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars> & {
-                errorPolicy?: TErrorPolicy;
-            }) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TFetchData>, TErrorPolicy>>;
+            fetchMore: FetchMoreFunction<TData, TVariables>;
             loading: boolean;
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
             previousData?: MaybeMasked_2<TData>;
-            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TData>, TErrorPolicy>>;
+            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
             startPolling: (pollInterval: number) => void;
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -677,7 +677,9 @@ export namespace useLazyQuery {
         export interface Result<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error?: ErrorLike;
-            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>>>;
+            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy = "none">(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars> & {
+                errorPolicy?: TErrorPolicy;
+            }) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>, TErrorPolicy>>;
             loading: boolean;
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
@@ -1097,7 +1099,9 @@ export namespace useQuery {
         export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error?: ErrorLike;
-            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TFetchData>>>;
+            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy = "none">(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars> & {
+                errorPolicy?: TErrorPolicy;
+            }) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TFetchData>, TErrorPolicy>>;
             loading: boolean;
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -360,15 +360,15 @@ export namespace useBackgroundQuery {
         [K in InvalidOptionNames]: never;
     } : never);
     // (undocumented)
-    export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
+    export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
         fetchMore: FetchMoreFunction<TData, TVariables>;
-        refetch: RefetchFunction<TData, TVariables>;
+        refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     }
     // (undocumented)
     export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options | SkipToken> = [
     queryRef: TOptions extends any ? TOptions extends SkipToken ? undefined : QueryRef_2<TData, TVariables, "complete" | "streaming" | ((OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"))> | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends false ? never : undefined) : never,
-    result: useBackgroundQuery.Result<TData, TVariables>
+    result: useBackgroundQuery.Result<TData, TVariables, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>
     ];
     export interface Signature extends Signatures.Evaluated {
     }
@@ -674,7 +674,7 @@ export namespace useLazyQuery {
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData, TVariables extends OperationVariables> {
+        export interface Result<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error?: ErrorLike;
             fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>>>;
@@ -682,7 +682,7 @@ export namespace useLazyQuery {
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
             previousData?: MaybeMasked<TData>;
-            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>, TErrorPolicy>>;
             startPolling: (pollInterval: number) => void;
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -741,9 +741,9 @@ export namespace useLazyQuery {
         }
     }
     // (undocumented)
-    export type ExecFunction<TData, TVariables extends OperationVariables> = (...args: {} extends TVariables ? [
+    export type ExecFunction<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...args: {} extends TVariables ? [
     options?: useLazyQuery.ExecOptions<TVariables>
-    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData>>;
+    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData, TErrorPolicy>>;
     // (undocumented)
     export type ExecOptions<TVariables extends OperationVariables = OperationVariables> = {
         context?: DefaultContext;
@@ -768,7 +768,7 @@ export namespace useLazyQuery {
         [K in InvalidOptionNames]: never;
     } : never;
     // (undocumented)
-    export type Result<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & (({
+    export type Result<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TErrorPolicy> & (({
         called: true;
         variables: TVariables;
     } & GetDataState<MaybeMasked<TData>, TStates>) | {
@@ -778,11 +778,11 @@ export namespace useLazyQuery {
         dataState: "empty";
     });
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables>> = ResultTuple<TData, TVariables, "complete" | "streaming" | "empty" | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial")>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables>> = ResultTuple<TData, TVariables, "complete" | "streaming" | "empty" | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
     // (undocumented)
-    export type ResultTuple<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
-    execute: ExecFunction<TData, TVariables>,
-    result: useLazyQuery.Result<TData, TVariables, TStates>
+    export type ResultTuple<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
+    execute: ExecFunction<TData, TVariables, TErrorPolicy>,
+    result: useLazyQuery.Result<TData, TVariables, TStates, TErrorPolicy>
     ];
     export interface Signature extends Signatures.Evaluated {
     }
@@ -839,9 +839,9 @@ export namespace useLoadableQuery {
     // (undocumented)
     export type FetchPolicy = Extract<WatchQueryFetchPolicy, "cache-first" | "network-only" | "no-cache" | "cache-and-network">;
     // (undocumented)
-    export interface Handlers<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
+    export interface Handlers<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
         fetchMore: FetchMoreFunction<TData, TVariables>;
-        refetch: RefetchFunction<TData, TVariables>;
+        refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
         // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
         reset: ResetFunction;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -866,13 +866,13 @@ export namespace useLoadableQuery {
         [K in InvalidOptionNames]: never;
     } : never;
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
     loadQuery: LoadQueryFunction<TVariables>,
     queryRef: QueryRef_2<TData, TVariables, TStates> | null,
-    handlers: Handlers<TData, TVariables>
+    handlers: Handlers<TData, TVariables, TErrorPolicy>
     ];
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options> = Result<TData, TVariables, "complete" | "streaming" | (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends ("none") ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial")>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options> = Result<TData, TVariables, "complete" | "streaming" | (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends ("none") ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
@@ -1094,7 +1094,7 @@ export namespace useQuery {
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables> {
+        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error?: ErrorLike;
             fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TFetchData>>>;
@@ -1102,7 +1102,7 @@ export namespace useQuery {
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
             previousData?: MaybeMasked_2<TData>;
-            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TData>>>;
+            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TData>, TErrorPolicy>>;
             startPolling: (pollInterval: number) => void;
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1160,9 +1160,9 @@ export namespace useQuery {
         [K in InvalidOptionNames]: never;
     } : never);
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables> = Base.Result<TData, TVariables, TReturnVariables> & GetDataState<MaybeMasked_2<TData>, TStates>;
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TReturnVariables, TErrorPolicy> & GetDataState<MaybeMasked_2<TData>, TStates>;
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never)>>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never), TVariables, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
@@ -1482,12 +1482,12 @@ export namespace useSuspenseQuery {
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
+        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error: ErrorLike | undefined;
             fetchMore: FetchMoreFunction<TData, TVariables>;
             networkStatus: NetworkStatus;
-            refetch: RefetchFunction<TData, TVariables>;
+            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
         }
     }
@@ -1543,11 +1543,11 @@ export namespace useSuspenseQuery {
         [K in InvalidOptionNames]: never;
     } : never);
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & GetDataState<MaybeMasked<TData>, TStates>;
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TErrorPolicy> & GetDataState<MaybeMasked<TData>, TStates>;
     // (undocumented)
     export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TVariables> | SkipToken> = Result<TData, TVariables, "complete" | "streaming" | (TOptions extends any ? TOptions extends SkipToken ? "empty" : (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends (false) ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial") : never) | ([TOptions] extends [SkipToken] ? DefaultOptions extends {
         returnPartialData: false;
-    } ? never : "partial" : never)>;
+    } ? never : "partial" : never), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -35,7 +35,9 @@ stringifiedVariables: string,
 ];
 
 // @public (undocumented)
-export type FetchMoreFunction<TData, TVariables extends OperationVariables> = <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TData>>>;
+export type FetchMoreFunction<TData, TVariables extends OperationVariables> = <TFetchData = TData, TFetchVars extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy = "none">(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars> & {
+    errorPolicy?: TErrorPolicy;
+}) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TFetchData>, TErrorPolicy>>;
 
 // @public (undocumented)
 type FragmentCacheKey = [

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -209,7 +209,7 @@ export namespace QueryRef {
 type QueryRefPromise<TData, TStates extends DataState<TData>["dataState"]> = DecoratedPromise<ObservableQuery.Result<MaybeMasked<TData>, TStates>>;
 
 // @public (undocumented)
-export type RefetchFunction<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<TData, TErrorPolicy>>;
+export type RefetchFunction<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TData>, TErrorPolicy>>;
 
 // @public (undocumented)
 class SuspenseCache {

--- a/.api-reports/api-report-react_internal.api.md
+++ b/.api-reports/api-report-react_internal.api.md
@@ -10,6 +10,7 @@ import type { DecoratedPromise } from '@apollo/client/utilities/internal';
 import type { DocumentNode } from 'graphql';
 import type { DocumentTypeDecoration } from '@graphql-typed-document-node/core';
 import { ErrorLike } from '@apollo/client';
+import type { ErrorPolicy } from '@apollo/client';
 import type { InternalTypes } from '@apollo/client/react';
 import type { MaybeMasked } from '@apollo/client/masking';
 import type { MaybeMasked as MaybeMasked_2 } from '@apollo/client';
@@ -206,7 +207,7 @@ export namespace QueryRef {
 type QueryRefPromise<TData, TStates extends DataState<TData>["dataState"]> = DecoratedPromise<ObservableQuery.Result<MaybeMasked<TData>, TStates>>;
 
 // @public (undocumented)
-export type RefetchFunction<TData, TVariables extends OperationVariables> = (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<TData>>;
+export type RefetchFunction<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<TData, TErrorPolicy>>;
 
 // @public (undocumented)
 class SuspenseCache {

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2220,7 +2220,9 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     });
     // @internal @deprecated (undocumented)
     applyOptions(newOptions: Partial<ObservableQuery.Options<TData, TVariables>>): void;
-    fetchMore<TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(options: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>): Promise<ApolloClient.QueryResult<TFetchData>>;
+    fetchMore<TFetchData = TData, TFetchVars extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy = "none">(options: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars> & {
+        errorPolicy?: TErrorPolicy;
+    }): Promise<ApolloClient.QueryResult<TFetchData, TErrorPolicy>>;
     // @internal @deprecated (undocumented)
     getCacheDiff({ optimistic }?: {
         optimistic?: boolean | undefined;

--- a/.changeset/twenty-spies-invite.md
+++ b/.changeset/twenty-spies-invite.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Update the return type of `refetch`, `fetchMore` and `useLazyQuery`'s `execute` function on the provided `errorPolicy`. Previously these APIs all used the default type which typed `data` as `TData | undefined` and `error` as `ErrorLike | undefined`.

--- a/integration-tests/type-tests/defaultOptions/defaults/index.ts
+++ b/integration-tests/type-tests/defaultOptions/defaults/index.ts
@@ -84,64 +84,64 @@ import { expectTypeOf } from "expect-type";
     skip: false;
   }>();
   useQuery.defaults.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.skipToken.result.toEqualTypeOf<
-    useQuery.Result<"empty", Record<string, never>>
+    useQuery.Result<"empty", undefined, Record<string, never>>
   >;
   useQuery.skipToken.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.skipToken.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
 }
 // useLazyQuery
@@ -214,84 +214,108 @@ import { expectTypeOf } from "expect-type";
     skip: false;
   }>();
   useSuspenseQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.none.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.all.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.skipToken.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
 
   useSuspenseQuery.skip._true.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skip._bool.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
 }
 // useBackgroundQuery
@@ -302,83 +326,112 @@ import { expectTypeOf } from "expect-type";
     skip: false;
   }>();
   useBackgroundQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._false
-    .toEqualTypeOf<useBackgroundQuery.Result<"complete" | "streaming">>;
+    .toEqualTypeOf<useBackgroundQuery.Result<"complete" | "streaming", "none">>;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.none.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.all.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
-  useBackgroundQuery.skipToken.result
-    .toEqualTypeOf<useBackgroundQuery.UndefinedResult>;
+  useBackgroundQuery.skipToken.result.toEqualTypeOf<
+    useBackgroundQuery.UndefinedResult<"none">
+  >;
 
   useBackgroundQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
   useBackgroundQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
 
   useBackgroundQuery.skip._true.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skip._bool.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
 }
 
@@ -448,54 +501,66 @@ import { expectTypeOf } from "expect-type";
     returnPartialData: false;
   }>();
   useLoadableQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.none.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.all.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 }

--- a/integration-tests/type-tests/defaultOptions/defaults/index.ts
+++ b/integration-tests/type-tests/defaultOptions/defaults/index.ts
@@ -151,51 +151,59 @@ import { expectTypeOf } from "expect-type";
     returnPartialData: false;
   }>();
   useLazyQuery.defaults.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.returnPartialData._true.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.returnPartialData._false.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.returnPartialData._bool.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._false.branded
-    .toEqualTypeOf<useLazyQuery.Result<"empty" | "complete" | "streaming">>;
+    .toEqualTypeOf<
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
+  >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
 }
 // useSuspenseQuery

--- a/integration-tests/type-tests/defaultOptions/shared/scenarios.ts
+++ b/integration-tests/type-tests/defaultOptions/shared/scenarios.ts
@@ -107,8 +107,9 @@ namespace useQueryCase {
   export import hook = useQuery;
   export type Result<
     TStates extends DataState<Data>["dataState"],
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
     TReturnVariables extends OperationVariables = Variables,
-  > = useQuery.Result<Data, Variables, TStates, TReturnVariables>;
+  > = useQuery.Result<Data, Variables, TStates, TReturnVariables, TErrorPolicy>;
   export const defaults = expectTypeOf(useQuery(QUERY));
   export namespace returnPartialData {
     export const _false = expectTypeOf(
@@ -281,8 +282,10 @@ namespace useLazyQueryCase {
 
 namespace useSuspenseQueryCase {
   export import hook = useSuspenseQuery;
-  export type Result<TStates extends DataState<Data>["dataState"]> =
-    useSuspenseQuery.Result<Data, Variables, TStates>;
+  export type Result<
+    TStates extends DataState<Data>["dataState"],
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = useSuspenseQuery.Result<Data, Variables, TStates, TErrorPolicy>;
 
   export namespace errorPolicy {
     export namespace defaults {
@@ -423,15 +426,15 @@ namespace useBackgroundQueryCase {
   export import hook = useBackgroundQuery;
   export type Result<
     TStates extends DataState<Data>["dataState"],
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
     AdditionalReturnValue = never,
   > = [
     QueryRef<Data, Variables, TStates> | AdditionalReturnValue,
-    useBackgroundQuery.Result<Data, Variables>,
+    useBackgroundQuery.Result<Data, Variables, TErrorPolicy>,
   ];
-  export type UndefinedResult = [
-    undefined,
-    useBackgroundQuery.Result<Data, Variables>,
-  ];
+  export type UndefinedResult<
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = [undefined, useBackgroundQuery.Result<Data, Variables, TErrorPolicy>];
 
   export namespace errorPolicy {
     export namespace defaults {
@@ -572,8 +575,10 @@ namespace useBackgroundQueryCase {
 }
 namespace useLoadableQueryCase {
   export import hook = useLoadableQuery;
-  export type Result<TStates extends DataState<Data>["dataState"]> =
-    useLoadableQuery.Result<Data, Variables, TStates>;
+  export type Result<
+    TStates extends DataState<Data>["dataState"],
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = useLoadableQuery.Result<Data, Variables, TStates, TErrorPolicy>;
 
   export namespace errorPolicy {
     export namespace defaults {

--- a/integration-tests/type-tests/defaultOptions/shared/scenarios.ts
+++ b/integration-tests/type-tests/defaultOptions/shared/scenarios.ts
@@ -1,5 +1,6 @@
 import {
   ApolloClient,
+  type ErrorPolicy,
   type OperationVariables,
   type DataState,
   type TypedDocumentNode,
@@ -195,8 +196,10 @@ namespace useQueryCase {
 
 namespace useLazyQueryCase {
   export import hook = useLazyQuery;
-  export type Result<TStates extends DataState<Data>["dataState"]> =
-    useLazyQuery.ResultTuple<Data, Variables, TStates>;
+  export type Result<
+    TStates extends DataState<Data>["dataState"],
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = useLazyQuery.ResultTuple<Data, Variables, TStates, TErrorPolicy>;
   export const defaults = expectTypeOf(useLazyQuery(QUERY));
 
   export namespace returnPartialData {

--- a/integration-tests/type-tests/defaultOptions/unions/index.ts
+++ b/integration-tests/type-tests/defaultOptions/unions/index.ts
@@ -281,51 +281,74 @@ const bool = {} as any as boolean;
     returnPartialData: boolean;
   }>();
   useLazyQuery.defaults.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useLazyQuery.returnPartialData._true.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useLazyQuery.returnPartialData._false.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useLazyQuery.returnPartialData._bool.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useLazyQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._false.branded
-    .toEqualTypeOf<useLazyQuery.Result<"empty" | "complete" | "streaming">>;
+    .toEqualTypeOf<
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
+  >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
 }
 // useSuspenseQuery

--- a/integration-tests/type-tests/defaultOptions/unions/index.ts
+++ b/integration-tests/type-tests/defaultOptions/unions/index.ts
@@ -214,64 +214,85 @@ const bool = {} as any as boolean;
     skip: false;
   }>();
   useQuery.defaults.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.skipToken.result.toEqualTypeOf<
-    useQuery.Result<"empty", Record<string, never>>
+    useQuery.Result<"empty", undefined, Record<string, never>>
   >;
   useQuery.skipToken.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.skipToken.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
 }
 // useLazyQuery
@@ -359,84 +380,141 @@ const bool = {} as any as boolean;
     skip: false;
   }>();
   useSuspenseQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"empty" | "complete" | "streaming">
+    useSuspenseQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.none.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.all.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.skipToken.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
 
   useSuspenseQuery.skip._true.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skip._bool.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
 }
 // useBackgroundQuery
@@ -447,73 +525,110 @@ const bool = {} as any as boolean;
     skip: false;
   }>();
   useBackgroundQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._false
     .toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.none.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.all.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
-  useBackgroundQuery.skipToken.result
-    .toEqualTypeOf<useBackgroundQuery.UndefinedResult>;
+  useBackgroundQuery.skipToken.result.toEqualTypeOf<
+    useBackgroundQuery.UndefinedResult<"none" | "ignore" | "all">
+  >;
 
   useBackgroundQuery.skipToken.returnPartialData._true.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
   useBackgroundQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
@@ -521,27 +636,35 @@ const bool = {} as any as boolean;
   useBackgroundQuery.skip._true.result.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
   useBackgroundQuery.skip._bool.result.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
@@ -613,54 +736,84 @@ const bool = {} as any as boolean;
     returnPartialData: boolean;
   }>();
   useLoadableQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.none.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.all.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 }

--- a/integration-tests/type-tests/defaultOptions/unionsWithOptional/index.ts
+++ b/integration-tests/type-tests/defaultOptions/unionsWithOptional/index.ts
@@ -186,64 +186,85 @@ expectTypeOf<ApolloClient.query.DefaultOptions>().toEqualTypeOf<{
     skip: false;
   }>();
   useQuery.defaults.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.skipToken.result.toEqualTypeOf<
-    useQuery.Result<"empty", Record<string, never>>
+    useQuery.Result<"empty", undefined, Record<string, never>>
   >;
   useQuery.skipToken.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useQuery.skipToken.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
 }
 // useLazyQuery
@@ -328,84 +349,135 @@ expectTypeOf<ApolloClient.query.DefaultOptions>().toEqualTypeOf<{
     skip: false;
   }>();
   useSuspenseQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"empty" | "complete" | "streaming">
+    useSuspenseQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"empty" | "complete" | "streaming">
+    useSuspenseQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.none.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.all.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.skipToken.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
 
   useSuspenseQuery.skip._true.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skip._bool.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
 }
 // useBackgroundQuery
@@ -416,95 +488,140 @@ expectTypeOf<ApolloClient.query.DefaultOptions>().toEqualTypeOf<{
     skip: false;
   }>();
   useBackgroundQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._false
     .toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.none.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.all.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
-  useBackgroundQuery.skipToken.result
-    .toEqualTypeOf<useBackgroundQuery.UndefinedResult>;
+  useBackgroundQuery.skipToken.result.toEqualTypeOf<
+    useBackgroundQuery.UndefinedResult<"none" | "ignore" | "all">
+  >;
 
   useBackgroundQuery.skipToken.returnPartialData._true.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
   useBackgroundQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
 
   useBackgroundQuery.skip._true.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all",
       undefined
     >
   >;
@@ -576,54 +693,78 @@ expectTypeOf<ApolloClient.query.DefaultOptions>().toEqualTypeOf<{
     returnPartialData: false;
   }>();
   useLoadableQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "none" | "ignore" | "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.none.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.all.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 }

--- a/integration-tests/type-tests/defaultOptions/unionsWithOptional/index.ts
+++ b/integration-tests/type-tests/defaultOptions/unionsWithOptional/index.ts
@@ -253,51 +253,71 @@ expectTypeOf<ApolloClient.query.DefaultOptions>().toEqualTypeOf<{
     returnPartialData: false;
   }>();
   useLazyQuery.defaults.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useLazyQuery.returnPartialData._true.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useLazyQuery.returnPartialData._false.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming",
+      "none" | "ignore" | "all"
+    >
   >;
   useLazyQuery.returnPartialData._bool.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "none" | "ignore" | "all"
+    >
   >;
   useLazyQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._false.branded
-    .toEqualTypeOf<useLazyQuery.Result<"empty" | "complete" | "streaming">>;
+    .toEqualTypeOf<
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
+  >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
 }
 // useSuspenseQuery

--- a/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyAll/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyAll/index.ts
@@ -102,64 +102,64 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useQuery.defaults.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.skipToken.result.toEqualTypeOf<
-    useQuery.Result<"empty", Record<string, never>>
+    useQuery.Result<"empty", undefined, Record<string, never>>
   >;
   useQuery.skipToken.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.skipToken.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
 }
 // useLazyQuery
@@ -232,84 +232,114 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useSuspenseQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.none.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.all.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.skipToken.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
 
   useSuspenseQuery.skip._true.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.skip._bool.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
 }
 // useBackgroundQuery
@@ -320,95 +350,134 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useBackgroundQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._false
     .toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.none.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.all.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
-  useBackgroundQuery.skipToken.result
-    .toEqualTypeOf<useBackgroundQuery.UndefinedResult>;
+  useBackgroundQuery.skipToken.result.toEqualTypeOf<
+    useBackgroundQuery.UndefinedResult<"all">
+  >;
 
   useBackgroundQuery.skipToken.returnPartialData._true.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "all",
       undefined
     >
   >;
   useBackgroundQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "all",
       undefined
     >
   >;
 
   useBackgroundQuery.skip._true.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "all",
       undefined
     >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "all",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "all",
       undefined
     >
   >;
@@ -480,54 +549,72 @@ declare module "@apollo/client" {
     returnPartialData: false;
   }>();
   useLoadableQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.none.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.all.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 }

--- a/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyAll/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyAll/index.ts
@@ -169,51 +169,59 @@ declare module "@apollo/client" {
     returnPartialData: false;
   }>();
   useLazyQuery.defaults.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.returnPartialData._true.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.returnPartialData._false.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.returnPartialData._bool.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._false.branded
-    .toEqualTypeOf<useLazyQuery.Result<"empty" | "complete" | "streaming">>;
+    .toEqualTypeOf<
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
+  >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
 }
 // useSuspenseQuery

--- a/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyIgnore/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyIgnore/index.ts
@@ -169,51 +169,65 @@ declare module "@apollo/client" {
     returnPartialData: false;
   }>();
   useLazyQuery.defaults.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useLazyQuery.returnPartialData._true.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.returnPartialData._false.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useLazyQuery.returnPartialData._bool.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._false.branded
-    .toEqualTypeOf<useLazyQuery.Result<"empty" | "complete" | "streaming">>;
+    .toEqualTypeOf<
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
+  >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
 }
 // useSuspenseQuery

--- a/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyIgnore/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyIgnore/index.ts
@@ -102,64 +102,64 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useQuery.defaults.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.skipToken.result.toEqualTypeOf<
-    useQuery.Result<"empty", Record<string, never>>
+    useQuery.Result<"empty", undefined, Record<string, never>>
   >;
   useQuery.skipToken.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.skipToken.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
 }
 // useLazyQuery
@@ -238,84 +238,114 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useSuspenseQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.none.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.all.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.skipToken.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.skip._true.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.skip._bool.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
 }
 // useBackgroundQuery
@@ -326,95 +356,134 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useBackgroundQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._false
     .toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.none.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.all.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
-  useBackgroundQuery.skipToken.result
-    .toEqualTypeOf<useBackgroundQuery.UndefinedResult>;
+  useBackgroundQuery.skipToken.result.toEqualTypeOf<
+    useBackgroundQuery.UndefinedResult<"ignore">
+  >;
 
   useBackgroundQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "ignore",
       undefined
     >
   >;
   useBackgroundQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "ignore",
+      undefined
+    >
   >;
   useBackgroundQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "ignore",
       undefined
     >
   >;
 
   useBackgroundQuery.skip._true.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "ignore",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "ignore",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "ignore",
       undefined
     >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty",
+      "ignore",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
+      "ignore",
       undefined
     >
   >;
@@ -486,54 +555,72 @@ declare module "@apollo/client" {
     returnPartialData: false;
   }>();
   useLoadableQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useLoadableQuery.errorPolicy.none.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.all.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 }

--- a/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyIgnore/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyIgnore/index.ts
@@ -430,7 +430,7 @@ declare module "@apollo/client" {
     useBackgroundQuery.UndefinedResult<"ignore">
   >;
 
-  useBackgroundQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
+  useBackgroundQuery.skipToken.returnPartialData._true.toEqualTypeOf<
     useBackgroundQuery.Result<
       "complete" | "streaming" | "partial" | "empty",
       "ignore",

--- a/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyNone/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyNone/index.ts
@@ -102,64 +102,64 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useQuery.defaults.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.skipToken.result.toEqualTypeOf<
-    useQuery.Result<"empty", Record<string, never>>
+    useQuery.Result<"empty", undefined, Record<string, never>>
   >;
   useQuery.skipToken.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.skipToken.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
 }
 // useLazyQuery
@@ -232,84 +232,108 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useSuspenseQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.none.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.all.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.skipToken.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
 
   useSuspenseQuery.skip._true.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skip._bool.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
 }
 // useBackgroundQuery
@@ -320,83 +344,112 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useBackgroundQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._false
-    .toEqualTypeOf<useBackgroundQuery.Result<"complete" | "streaming">>;
+    .toEqualTypeOf<useBackgroundQuery.Result<"complete" | "streaming", "none">>;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.none.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.all.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
-  useBackgroundQuery.skipToken.result
-    .toEqualTypeOf<useBackgroundQuery.UndefinedResult>;
+  useBackgroundQuery.skipToken.result.toEqualTypeOf<
+    useBackgroundQuery.UndefinedResult<"none">
+  >;
 
   useBackgroundQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
   useBackgroundQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
 
   useBackgroundQuery.skip._true.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skip._bool.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
 }
 
@@ -466,54 +519,66 @@ declare module "@apollo/client" {
     returnPartialData: false;
   }>();
   useLoadableQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.none.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.all.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 }

--- a/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyNone/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/errorPolicyNone/index.ts
@@ -169,51 +169,59 @@ declare module "@apollo/client" {
     returnPartialData: false;
   }>();
   useLazyQuery.defaults.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.returnPartialData._true.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.returnPartialData._false.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.returnPartialData._bool.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._false.branded
-    .toEqualTypeOf<useLazyQuery.Result<"empty" | "complete" | "streaming">>;
+    .toEqualTypeOf<
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
+  >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
 }
 // useSuspenseQuery

--- a/integration-tests/type-tests/defaultOptions/watchQuery/returnPartialDataTrue/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/returnPartialDataTrue/index.ts
@@ -169,51 +169,62 @@ declare module "@apollo/client" {
     returnPartialData: true;
   }>();
   useLazyQuery.defaults.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.returnPartialData._true.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.returnPartialData._false.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.returnPartialData._bool.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useLazyQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming">
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useLazyQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._false.branded
-    .toEqualTypeOf<useLazyQuery.Result<"empty" | "complete" | "streaming">>;
+    .toEqualTypeOf<
+    useLazyQuery.Result<"empty" | "complete" | "streaming", "ignore">
+  >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
   useLazyQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useLazyQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useLazyQuery.Result<
+      "empty" | "complete" | "streaming" | "partial",
+      "ignore"
+    >
   >;
 }
 // useSuspenseQuery

--- a/integration-tests/type-tests/defaultOptions/watchQuery/returnPartialDataTrue/index.ts
+++ b/integration-tests/type-tests/defaultOptions/watchQuery/returnPartialDataTrue/index.ts
@@ -102,64 +102,64 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useQuery.defaults.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.none.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.errorPolicy.all.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.all.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "all">
   >;
   useQuery.errorPolicy.ignore.result.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.errorPolicy.ignore.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "ignore">
   >;
   useQuery.skipToken.result.toEqualTypeOf<
-    useQuery.Result<"empty", Record<string, never>>
+    useQuery.Result<"empty", undefined, Record<string, never>>
   >;
   useQuery.skipToken.returnPartialData._false.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming">
+    useQuery.Result<"empty" | "complete" | "streaming", "none">
   >;
   useQuery.skipToken.returnPartialData._true.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
   useQuery.skipToken.returnPartialData._bool.branded.toEqualTypeOf<
-    useQuery.Result<"empty" | "complete" | "streaming" | "partial">
+    useQuery.Result<"empty" | "complete" | "streaming" | "partial", "none">
   >;
 }
 // useLazyQuery
@@ -235,84 +235,123 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useSuspenseQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.none.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming">
+    useSuspenseQuery.Result<"complete" | "streaming", "none">
   >;
   useSuspenseQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial">
+    useSuspenseQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useSuspenseQuery.errorPolicy.all.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useSuspenseQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useSuspenseQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useSuspenseQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
   useSuspenseQuery.skipToken.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
 
   useSuspenseQuery.skip._true.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skip._bool.result.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
   useSuspenseQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty">
+    useSuspenseQuery.Result<"complete" | "streaming" | "empty", "none">
   >;
   useSuspenseQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useSuspenseQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useSuspenseQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "none"
+    >
   >;
 }
 // useBackgroundQuery
@@ -323,83 +362,126 @@ declare module "@apollo/client" {
     skip: false;
   }>();
   useBackgroundQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._false
-    .toEqualTypeOf<useBackgroundQuery.Result<"complete" | "streaming">>;
+    .toEqualTypeOf<useBackgroundQuery.Result<"complete" | "streaming", "none">>;
   useBackgroundQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.none.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming">
+    useBackgroundQuery.Result<"complete" | "streaming", "none">
   >;
   useBackgroundQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial">
+    useBackgroundQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useBackgroundQuery.errorPolicy.all.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useBackgroundQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useBackgroundQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "empty">
+    useBackgroundQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useBackgroundQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 
-  useBackgroundQuery.skipToken.result
-    .toEqualTypeOf<useBackgroundQuery.UndefinedResult>;
+  useBackgroundQuery.skipToken.result.toEqualTypeOf<
+    useBackgroundQuery.UndefinedResult<"none">
+  >;
 
   useBackgroundQuery.skipToken.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
   useBackgroundQuery.skipToken.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skipToken.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
 
   useBackgroundQuery.skip._true.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.result.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._true.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
   useBackgroundQuery.skip._bool.returnPartialData._false.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming", undefined>
+    useBackgroundQuery.Result<"complete" | "streaming", "none", undefined>
   >;
   useBackgroundQuery.skip._bool.returnPartialData._bool.toEqualTypeOf<
-    useBackgroundQuery.Result<"complete" | "streaming" | "partial", undefined>
+    useBackgroundQuery.Result<
+      "complete" | "streaming" | "partial",
+      "none",
+      undefined
+    >
   >;
 }
 
@@ -469,54 +551,72 @@ declare module "@apollo/client" {
     returnPartialData: true;
   }>();
   useLoadableQuery.errorPolicy.defaults.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.defaults.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.none.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming">
+    useLoadableQuery.Result<"complete" | "streaming", "none">
   >;
   useLoadableQuery.errorPolicy.none.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial">
+    useLoadableQuery.Result<"complete" | "streaming" | "partial", "none">
   >;
 
   useLoadableQuery.errorPolicy.all.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "all">
   >;
   useLoadableQuery.errorPolicy.all.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "all"
+    >
   >;
 
   useLoadableQuery.errorPolicy.ignore.result.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty" | "partial">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "empty" | "partial",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._true.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._false.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "empty">
+    useLoadableQuery.Result<"complete" | "streaming" | "empty", "ignore">
   >;
   useLoadableQuery.errorPolicy.ignore.returnPartialData._bool.toEqualTypeOf<
-    useLoadableQuery.Result<"complete" | "streaming" | "partial" | "empty">
+    useLoadableQuery.Result<
+      "complete" | "streaming" | "partial" | "empty",
+      "ignore"
+    >
   >;
 }

--- a/integration-tests/type-tests/signatures/classic/useBackgroundQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useBackgroundQuery.ts
@@ -1,5 +1,6 @@
 import {
   DataValue,
+  ErrorLike,
   gql,
   OperationVariables,
   TypedDocumentNode,
@@ -2490,4 +2491,205 @@ test("requires variables with mixed TVariables", () => {
       }
     )
   );
+});
+
+test("refetch narrows the result by errorPolicy in every overload", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+  let skip!: boolean;
+  let returnPartialData!: boolean;
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      returnPartialData,
+      fetchPolicy: "no-cache",
+      errorPolicy: "ignore",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      returnPartialData: false,
+      errorPolicy: "ignore",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      returnPartialData,
+      errorPolicy: "all",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      skip,
+      returnPartialData: false,
+      errorPolicy: "none",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      skip,
+      returnPartialData,
+      errorPolicy: "none",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      returnPartialData: false,
+      errorPolicy: "none",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      returnPartialData,
+      errorPolicy: "none",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      skip,
+      errorPolicy: "none",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, skipToken);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(
+      query,
+      skip ? skipToken : { returnPartialData: false, errorPolicy: "none" }
+    );
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(
+      query,
+      skip ? skipToken : { returnPartialData, errorPolicy: "none" }
+    );
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(
+      query,
+      skip ? skipToken : { errorPolicy: "none" }
+    );
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, { fetchMore }] = useBackgroundQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const [, { fetchMore }] = useBackgroundQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { fetchMore }] = useBackgroundQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { fetchMore }] = useBackgroundQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
 });

--- a/integration-tests/type-tests/signatures/classic/useBackgroundQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useBackgroundQuery.ts
@@ -2016,7 +2016,7 @@ it("uses proper masked types for fetchMore", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
   }
 
   {
@@ -2040,7 +2040,7 @@ it("uses proper masked types for fetchMore", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData>();
   }
 });
 

--- a/integration-tests/type-tests/signatures/classic/useLazyQuery.explicit-generics.ts
+++ b/integration-tests/type-tests/signatures/classic/useLazyQuery.explicit-generics.ts
@@ -251,7 +251,7 @@ test("uses masked types when using masked document", async () => {
         },
       });
 
-      expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+      expectTypeOf(data).toEqualTypeOf<Query>();
     }
 
     {
@@ -321,7 +321,7 @@ test("uses masked types when using masked document", async () => {
         },
       });
 
-      expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+      expectTypeOf(data).toEqualTypeOf<Query>();
     }
 
     {

--- a/integration-tests/type-tests/signatures/classic/useLazyQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useLazyQuery.ts
@@ -4,6 +4,7 @@ import { expectTypeOf } from "expect-type";
 import {
   ApolloClient,
   DataValue,
+  ErrorLike,
   gql,
   TypedDocumentNode,
 } from "@apollo/client";
@@ -478,4 +479,87 @@ test("execution result has `.retain` method", () => {
 
   // retain should return the same type as the original result
   expectTypeOf(result.retain()).toEqualTypeOf(result);
+});
+
+test("refetch narrows the result by errorPolicy in every overload", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  let returnPartialData!: boolean;
+
+  {
+    const [, { refetch }] = useLazyQuery(query);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { refetch }] = useLazyQuery(query, {
+      returnPartialData: true,
+      errorPolicy: "ignore",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useLazyQuery(query, {
+      returnPartialData,
+      errorPolicy: "all",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { refetch }] = useLazyQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, { fetchMore }] = useLazyQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const [, { fetchMore }] = useLazyQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { fetchMore }] = useLazyQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { fetchMore }] = useLazyQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
 });

--- a/integration-tests/type-tests/signatures/classic/useLazyQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useLazyQuery.ts
@@ -182,7 +182,7 @@ test("uses masked types when using masked document", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 
   {
@@ -298,7 +298,7 @@ test("uses unmodified types when using TypedDocumentNode", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 
   {

--- a/integration-tests/type-tests/signatures/classic/useLoadableQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useLoadableQuery.ts
@@ -1,5 +1,6 @@
 import {
   DataValue,
+  ErrorLike,
   gql,
   OperationVariables,
   TypedDocumentNode,
@@ -914,5 +915,94 @@ it("returns correct TData type when combined options that do not affect TData", 
     if (dataState === "partial") {
       expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
     }
+  }
+});
+
+it("refetch narrows the result by errorPolicy in every overload", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query, {
+      returnPartialData: true,
+      errorPolicy: "ignore",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query, {
+      returnPartialData: true,
+      errorPolicy: "none",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+it("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, , { fetchMore }] = useLoadableQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const [, , { fetchMore }] = useLoadableQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, , { fetchMore }] = useLoadableQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, , { fetchMore }] = useLoadableQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
   }
 });

--- a/integration-tests/type-tests/signatures/classic/useQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useQuery.ts
@@ -446,11 +446,27 @@ test("refetch narrows the result by errorPolicy", async () => {
     expectTypeOf(data).toEqualTypeOf<Data | undefined>();
     expectTypeOf(error).toEqualTypeOf<undefined>();
   }
+});
+
+test("refetch narrows the result by errorPolicy in every overload", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  let skip!: boolean;
+  let returnPartialData!: boolean;
+
+  {
+    const { refetch } = useQuery(query);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
 
   {
     const { refetch } = useQuery(query, {
-      errorPolicy: "ignore",
       returnPartialData: true,
+      errorPolicy: "ignore",
     });
     const { data, error } = await refetch();
 
@@ -459,7 +475,55 @@ test("refetch narrows the result by errorPolicy", async () => {
   }
 
   {
-    let skip!: boolean;
+    const { refetch } = useQuery(query, skipToken);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(
+      query,
+      skip ? skipToken : { returnPartialData: true, errorPolicy: "ignore" }
+    );
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, {
+      returnPartialData,
+      errorPolicy: "ignore",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(
+      query,
+      skip ? skipToken : { returnPartialData, errorPolicy: "none" }
+    );
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
     const { refetch } = useQuery(
       query,
       skip ? skipToken : { errorPolicy: "none" }

--- a/integration-tests/type-tests/signatures/classic/useQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useQuery.ts
@@ -380,6 +380,29 @@ test("always returns empty data/dataState with unconditional skipToken", () => {
   expectTypeOf(variables).toEqualTypeOf<Record<string, never>>();
 });
 
+test("errorPolicy does not narrow dataState", () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const { dataState } = useQuery(query, { errorPolicy: "none" });
+
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const { dataState } = useQuery(query, { errorPolicy: "all" });
+
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+
+  {
+    const { dataState } = useQuery(query, { errorPolicy: "ignore" });
+
+    expectTypeOf(dataState).toEqualTypeOf<"empty" | "streaming" | "complete">();
+  }
+});
+
 test("refetch narrows the result by errorPolicy", async () => {
   type Data = { character: string };
   const query: TypedDocumentNode<Data, Record<string, never>> = gql``;

--- a/integration-tests/type-tests/signatures/classic/useQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useQuery.ts
@@ -1,4 +1,4 @@
-import { DataValue, gql, TypedDocumentNode } from "@apollo/client";
+import { DataValue, ErrorLike, gql, TypedDocumentNode } from "@apollo/client";
 import { skipToken, useQuery } from "@apollo/client/react";
 import { DeepPartial } from "@apollo/client/utilities";
 import { expectTypeOf } from "expect-type";
@@ -378,4 +378,123 @@ test("always returns empty data/dataState with unconditional skipToken", () => {
   expectTypeOf(data).toEqualTypeOf<undefined>();
   expectTypeOf(dataState).toEqualTypeOf<"empty">();
   expectTypeOf(variables).toEqualTypeOf<Record<string, never>>();
+});
+
+test("refetch narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const { refetch } = useQuery(query);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, {});
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, { errorPolicy: "ignore" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, {
+      errorPolicy: "ignore",
+      returnPartialData: true,
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    let skip!: boolean;
+    const { refetch } = useQuery(
+      query,
+      skip ? skipToken : { errorPolicy: "none" }
+    );
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const { fetchMore } = useQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const { fetchMore } = useQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { fetchMore } = useQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { fetchMore } = useQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    type OtherData = { other: string };
+    const otherQuery: TypedDocumentNode<
+      OtherData,
+      Record<string, never>
+    > = gql``;
+
+    const { fetchMore } = useQuery(query, {});
+    const { data } = await fetchMore({ query: otherQuery });
+
+    expectTypeOf(data).toEqualTypeOf<OtherData>();
+  }
 });

--- a/integration-tests/type-tests/signatures/classic/useSuspenseQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useSuspenseQuery.ts
@@ -2054,7 +2054,7 @@ it("uses proper masked types for fetchMore", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
   }
 
   {
@@ -2074,7 +2074,7 @@ it("uses proper masked types for fetchMore", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData>();
   }
 });
 

--- a/integration-tests/type-tests/signatures/classic/useSuspenseQuery.ts
+++ b/integration-tests/type-tests/signatures/classic/useSuspenseQuery.ts
@@ -1,4 +1,4 @@
-import { DataValue, gql, TypedDocumentNode } from "@apollo/client";
+import { DataValue, ErrorLike, gql, TypedDocumentNode } from "@apollo/client";
 import { skipToken, useSuspenseQuery } from "@apollo/client/react";
 import { DeepPartial } from "@apollo/client/utilities";
 import { expectTypeOf } from "expect-type";
@@ -2494,4 +2494,137 @@ test("requires variables with mixed TVariables", () => {
       }
     )
   );
+});
+
+test("refetch narrows the result by errorPolicy in every overload", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  let skip!: boolean;
+
+  {
+    const { refetch } = useSuspenseQuery(query);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, {
+      returnPartialData: true,
+      errorPolicy: "ignore",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, {
+      skip,
+      returnPartialData: true,
+      errorPolicy: "none",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, {
+      returnPartialData: true,
+      errorPolicy: "none",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, { skip, errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(
+      query,
+      skip ? skipToken : { returnPartialData: true, errorPolicy: "ignore" }
+    );
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(
+      query,
+      skip ? skipToken : { errorPolicy: "none" }
+    );
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const { fetchMore } = useSuspenseQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const { fetchMore } = useSuspenseQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { fetchMore } = useSuspenseQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { fetchMore } = useSuspenseQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
 });

--- a/integration-tests/type-tests/signatures/modern/useBackgroundQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useBackgroundQuery.ts
@@ -1,5 +1,6 @@
 import {
   DataValue,
+  ErrorLike,
   gql,
   OperationVariables,
   TypedDocumentNode,
@@ -1983,7 +1984,7 @@ it("uses proper masked types for refetch", async () => {
     });
     const { data } = await refetch();
 
-    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
   }
 
   {
@@ -1992,7 +1993,7 @@ it("uses proper masked types for refetch", async () => {
     });
     const { data } = await refetch();
 
-    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData>();
   }
 });
 
@@ -2490,6 +2491,45 @@ test("requires variables with mixed TVariables", () => {
       }
     )
   );
+});
+
+test("refetch narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query);
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { refetch }] = useBackgroundQuery(query, {
+      errorPolicy: "ignore",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
 });
 
 test("rejects unknown options", () => {

--- a/integration-tests/type-tests/signatures/modern/useBackgroundQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useBackgroundQuery.ts
@@ -2017,7 +2017,7 @@ it("uses proper masked types for fetchMore", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
   }
 
   {
@@ -2041,7 +2041,7 @@ it("uses proper masked types for fetchMore", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData>();
   }
 });
 
@@ -2529,6 +2529,57 @@ test("refetch narrows the result by errorPolicy", async () => {
 
     expectTypeOf(data).toEqualTypeOf<Data | undefined>();
     expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, { fetchMore }] = useBackgroundQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const [, { fetchMore }] = useBackgroundQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { fetchMore }] = useBackgroundQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { fetchMore }] = useBackgroundQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    type OtherData = { other: string };
+    const otherQuery: TypedDocumentNode<
+      OtherData,
+      Record<string, never>
+    > = gql``;
+
+    const [, { fetchMore }] = useBackgroundQuery(query, {});
+    const { data } = await fetchMore({ query: otherQuery });
+
+    expectTypeOf(data).toEqualTypeOf<OtherData>();
   }
 });
 

--- a/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
@@ -183,7 +183,7 @@ test("uses masked types when using masked document", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 
   {
@@ -299,7 +299,7 @@ test("uses unmodified types when using TypedDocumentNode", async () => {
       },
     });
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 
   {
@@ -562,6 +562,57 @@ test("refetch narrows the result by errorPolicy", async () => {
 
     expectTypeOf(data).toEqualTypeOf<Data | undefined>();
     expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, { fetchMore }] = useLazyQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const [, { fetchMore }] = useLazyQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { fetchMore }] = useLazyQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { fetchMore }] = useLazyQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    type OtherData = { other: string };
+    const otherQuery: TypedDocumentNode<
+      OtherData,
+      Record<string, never>
+    > = gql``;
+
+    const [, { fetchMore }] = useLazyQuery(query, {});
+    const { data } = await fetchMore({ query: otherQuery });
+
+    expectTypeOf(data).toEqualTypeOf<OtherData>();
   }
 });
 

--- a/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
@@ -189,7 +189,7 @@ test("uses masked types when using masked document", async () => {
   {
     const { data } = await refetch();
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 });
 
@@ -305,7 +305,7 @@ test("uses unmodified types when using TypedDocumentNode", async () => {
   {
     const { data } = await refetch();
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 });
 
@@ -524,6 +524,43 @@ test("execute function narrows the result by errorPolicy", async () => {
     const { data, error } = await execute({ variables: { type: "main" } });
 
     expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("refetch narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, { refetch }] = useLazyQuery(query, {});
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useLazyQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, { refetch }] = useLazyQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, { refetch }] = useLazyQuery(query, { errorPolicy: "ignore" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
     expectTypeOf(error).toEqualTypeOf<undefined>();
   }
 });

--- a/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useLazyQuery.ts
@@ -4,6 +4,7 @@ import { expectTypeOf } from "expect-type";
 import {
   ApolloClient,
   DataValue,
+  ErrorLike,
   gql,
   TypedDocumentNode,
 } from "@apollo/client";
@@ -168,7 +169,7 @@ test("uses masked types when using masked document", async () => {
   {
     const { data } = await execute();
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 
   {
@@ -284,7 +285,7 @@ test("uses unmodified types when using TypedDocumentNode", async () => {
   {
     const { data } = await execute();
 
-    expectTypeOf(data).toEqualTypeOf<Query | undefined>();
+    expectTypeOf(data).toEqualTypeOf<Query>();
   }
 
   {
@@ -478,6 +479,53 @@ test("execution result has `.retain` method", () => {
 
   // retain should return the same type as the original result
   expectTypeOf(result.retain()).toEqualTypeOf(result);
+});
+
+test("execute function narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [execute] = useLazyQuery(query);
+    const { data, error } = await execute();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [execute] = useLazyQuery(query, { errorPolicy: "none" });
+    const { data, error } = await execute();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [execute] = useLazyQuery(query, { errorPolicy: "all" });
+    const { data, error } = await execute();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [execute] = useLazyQuery(query, { errorPolicy: "ignore" });
+    const { data, error } = await execute();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;
+
+    const [execute] = useLazyQuery(literalVariables, { errorPolicy: "none" });
+    const { data, error } = await execute({ variables: { type: "main" } });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
 });
 
 test("rejects unknown options", () => {

--- a/integration-tests/type-tests/signatures/modern/useLoadableQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useLoadableQuery.ts
@@ -1,5 +1,6 @@
 import {
   DataValue,
+  ErrorLike,
   gql,
   OperationVariables,
   TypedDocumentNode,
@@ -915,6 +916,45 @@ it("returns correct TData type when combined options that do not affect TData", 
       expectTypeOf(data).toEqualTypeOf<DeepPartial<VariablesCaseData>>();
     }
   } */
+});
+
+it("refetch narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query, {});
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, , { refetch }] = useLoadableQuery(query, {
+      errorPolicy: "ignore",
+    });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
 });
 
 it("rejects unknown options", () => {

--- a/integration-tests/type-tests/signatures/modern/useLoadableQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useLoadableQuery.ts
@@ -957,6 +957,57 @@ it("refetch narrows the result by errorPolicy", async () => {
   }
 });
 
+it("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const [, , { fetchMore }] = useLoadableQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const [, , { fetchMore }] = useLoadableQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [, , { fetchMore }] = useLoadableQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [, , { fetchMore }] = useLoadableQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    type OtherData = { other: string };
+    const otherQuery: TypedDocumentNode<
+      OtherData,
+      Record<string, never>
+    > = gql``;
+
+    const [, , { fetchMore }] = useLoadableQuery(query, {});
+    const { data } = await fetchMore({ query: otherQuery });
+
+    expectTypeOf(data).toEqualTypeOf<OtherData>();
+  }
+});
+
 it("rejects unknown options", () => {
   type Data = { character: string };
   const query: TypedDocumentNode<Data, { type: "main" }> = gql``;

--- a/integration-tests/type-tests/signatures/modern/useQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useQuery.ts
@@ -410,6 +410,57 @@ test("refetch narrows the result by errorPolicy", async () => {
   }
 });
 
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const { fetchMore } = useQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const { fetchMore } = useQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { fetchMore } = useQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { fetchMore } = useQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    type OtherData = { other: string };
+    const otherQuery: TypedDocumentNode<
+      OtherData,
+      Record<string, never>
+    > = gql``;
+
+    const { fetchMore } = useQuery(query, {});
+    const { data } = await fetchMore({ query: otherQuery });
+
+    expectTypeOf(data).toEqualTypeOf<OtherData>();
+  }
+});
+
 test("rejects unknown options", () => {
   const literalVariables: TypedDocumentNode<
     { character: string },

--- a/integration-tests/type-tests/signatures/modern/useQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useQuery.ts
@@ -1,4 +1,4 @@
-import { DataValue, gql, TypedDocumentNode } from "@apollo/client";
+import { DataValue, ErrorLike, gql, TypedDocumentNode } from "@apollo/client";
 import { skipToken, useQuery } from "@apollo/client/react";
 import { DeepPartial } from "@apollo/client/utilities";
 import { expectTypeOf } from "expect-type";
@@ -371,6 +371,43 @@ test("requires variables with mixed TVariables", () => {
       }
     )
   );
+});
+
+test("refetch narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const { refetch } = useQuery(query, {});
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { refetch } = useQuery(query, { errorPolicy: "ignore" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
 });
 
 test("rejects unknown options", () => {

--- a/integration-tests/type-tests/signatures/modern/useSuspenseQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useSuspenseQuery.ts
@@ -1,4 +1,4 @@
-import { DataValue, gql, TypedDocumentNode } from "@apollo/client";
+import { DataValue, ErrorLike, gql, TypedDocumentNode } from "@apollo/client";
 import { skipToken, useSuspenseQuery } from "@apollo/client/react";
 import { DeepPartial } from "@apollo/client/utilities";
 import { expectTypeOf } from "expect-type";
@@ -2021,7 +2021,7 @@ it("uses proper masked types for refetch", async () => {
     const { refetch } = useSuspenseQuery(query, { variables: { id: "1" } });
     const { data } = await refetch();
 
-    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<MaskedVariablesCaseData>();
   }
 
   {
@@ -2030,7 +2030,7 @@ it("uses proper masked types for refetch", async () => {
     });
     const { data } = await refetch();
 
-    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData | undefined>();
+    expectTypeOf(data).toEqualTypeOf<UnmaskedVariablesCaseData>();
   }
 });
 
@@ -2494,6 +2494,43 @@ test("requires variables with mixed TVariables", () => {
       }
     )
   );
+});
+
+test("refetch narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const { refetch } = useSuspenseQuery(query, {});
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, { errorPolicy: "none" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, { errorPolicy: "all" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { refetch } = useSuspenseQuery(query, { errorPolicy: "ignore" });
+    const { data, error } = await refetch();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
 });
 
 test("rejects unknown options", () => {

--- a/integration-tests/type-tests/signatures/modern/useSuspenseQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/useSuspenseQuery.ts
@@ -2533,6 +2533,57 @@ test("refetch narrows the result by errorPolicy", async () => {
   }
 });
 
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const { fetchMore } = useSuspenseQuery(query, {});
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the hook
+    const { fetchMore } = useSuspenseQuery(query, { errorPolicy: "all" });
+    const { data, error } = await fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { fetchMore } = useSuspenseQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { fetchMore } = useSuspenseQuery(query, {});
+    const { data, error } = await fetchMore({ errorPolicy: "ignore" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    type OtherData = { other: string };
+    const otherQuery: TypedDocumentNode<
+      OtherData,
+      Record<string, never>
+    > = gql``;
+
+    const { fetchMore } = useSuspenseQuery(query, {});
+    const { data } = await fetchMore({ query: otherQuery });
+
+    expectTypeOf(data).toEqualTypeOf<OtherData>();
+  }
+});
+
 test("rejects unknown options", () => {
   type Data = { character: string };
   const literalVariables: TypedDocumentNode<Data, { type: "main" }> = gql``;

--- a/integration-tests/type-tests/signatures/modern/watchQuery.ts
+++ b/integration-tests/type-tests/signatures/modern/watchQuery.ts
@@ -1,0 +1,64 @@
+import {
+  ApolloClient,
+  ErrorLike,
+  gql,
+  TypedDocumentNode,
+} from "@apollo/client";
+import { expectTypeOf } from "expect-type";
+
+import { test } from "./shared.js";
+
+declare const client: ApolloClient;
+
+test("fetchMore narrows the result by errorPolicy", async () => {
+  type Data = { character: string };
+  const query: TypedDocumentNode<Data, Record<string, never>> = gql``;
+
+  {
+    const observable = client.watchQuery({ query });
+    const { data, error } = await observable.fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    // `fetchMore` does not inherit the error policy of the query
+    const observable = client.watchQuery({ query, errorPolicy: "all" });
+    const { data, error } = await observable.fetchMore({});
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const observable = client.watchQuery({ query });
+    const { data, error } = await observable.fetchMore({ errorPolicy: "all" });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const observable = client.watchQuery({ query });
+    const { data, error } = await observable.fetchMore({
+      errorPolicy: "ignore",
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    type OtherData = { other: string };
+    const otherQuery: TypedDocumentNode<
+      OtherData,
+      Record<string, never>
+    > = gql``;
+
+    const observable = client.watchQuery({ query });
+    const { data } = await observable.fetchMore({ query: otherQuery });
+
+    expectTypeOf(data).toEqualTypeOf<OtherData>();
+  }
+});

--- a/src/__tests__/ApolloClient.ts
+++ b/src/__tests__/ApolloClient.ts
@@ -3522,7 +3522,7 @@ describe("ApolloClient", () => {
         },
       });
 
-      expectTypeOf(fetchMoreResult.data).toEqualTypeOf<Query | undefined>();
+      expectTypeOf(fetchMoreResult.data).toEqualTypeOf<Query>();
 
       const refetchResult = await observableQuery.refetch();
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -823,14 +823,18 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   public fetchMore<
     TFetchData = TData,
     TFetchVars extends OperationVariables = TVariables,
+    TErrorPolicy extends ErrorPolicy = "none",
   >(
     options: ObservableQuery.FetchMoreOptions<
       TData,
       TVariables,
       TFetchData,
       TFetchVars
-    >
-  ): Promise<ApolloClient.QueryResult<TFetchData>>;
+    > & {
+      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
+      errorPolicy?: TErrorPolicy;
+    }
+  ): Promise<ApolloClient.QueryResult<TFetchData, TErrorPolicy>>;
 
   public fetchMore<
     TFetchData = TData,

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -108,6 +108,7 @@ export declare namespace useBackgroundQuery {
   export interface Result<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > {
     /** {@inheritDoc @apollo/client!ObservableQuery#subscribeToMore:member(1)} */
     subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -126,7 +127,7 @@ export declare namespace useBackgroundQuery {
      * @remarks
      * Calling this function will cause the component to re-suspend, unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
      */
-    refetch: RefetchFunction<TData, TVariables>;
+    refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
   }
 
   namespace DocumentationTypes {
@@ -198,7 +199,11 @@ export declare namespace useBackgroundQuery {
             never
           : undefined)
     : never,
-    result: useBackgroundQuery.Result<TData, TVariables>,
+    result: useBackgroundQuery.Result<
+      TData,
+      TVariables,
+      OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy
+    >,
   ];
 
   export namespace DocumentationTypes {

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -6,6 +6,7 @@ import type {
   DefaultContext,
   DocumentNode,
   ErrorPolicy,
+  ObservableQuery,
   OperationVariables,
   RefetchOn,
   RefetchWritePolicy,
@@ -901,8 +902,10 @@ function useBackgroundQuery_<
     // conditional ensures we aren't running the logic on each render.
   });
 
-  const fetchMore: FetchMoreFunction<TData, TVariables> = React.useCallback(
-    (options) => {
+  const fetchMore = React.useCallback(
+    (
+      options: ObservableQuery.FetchMoreOptions<TData, TVariables, any, any>
+    ) => {
       const promise = queryRef.fetchMore(options);
 
       setWrappedQueryRef(wrapQueryRef(queryRef));
@@ -910,7 +913,7 @@ function useBackgroundQuery_<
       return promise;
     },
     [queryRef]
-  );
+  ) as FetchMoreFunction<TData, TVariables>;
 
   const refetch: RefetchFunction<TData, TVariables> = React.useCallback(
     (variables) => {

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -317,16 +317,18 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
           /** @deprecated `returnPartialData` has no effect on `no-cache` queries */
           returnPartialData: boolean;
           fetchPolicy: "no-cache";
+          errorPolicy?: TErrorPolicy;
         }
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming">,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -334,15 +336,16 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
           returnPartialData: false;
-          errorPolicy: "ignore" | "all";
+          errorPolicy: TErrorPolicy & ("ignore" | "all");
         }
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming" | "empty">,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -350,11 +353,12 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
           returnPartialData: boolean;
-          errorPolicy: "ignore" | "all";
+          errorPolicy: TErrorPolicy & ("ignore" | "all");
         }
       ): [
         QueryRef<
@@ -362,7 +366,7 @@ export declare namespace useBackgroundQuery {
           TVariables,
           "complete" | "streaming" | "partial" | "empty"
         >,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -370,14 +374,15 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
-          errorPolicy: "ignore" | "all";
+          errorPolicy: TErrorPolicy & ("ignore" | "all");
         }
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming" | "empty">,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -385,15 +390,17 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
           skip: boolean;
           returnPartialData: false;
+          errorPolicy?: TErrorPolicy;
         }
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming"> | undefined,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -401,18 +408,20 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
           skip: boolean;
           returnPartialData: boolean;
+          errorPolicy?: TErrorPolicy;
         }
       ): [
         (
           | QueryRef<TData, TVariables, "complete" | "streaming" | "partial">
           | undefined
         ),
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -420,14 +429,16 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
           returnPartialData: false;
+          errorPolicy?: TErrorPolicy;
         }
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming">,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -435,14 +446,16 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
           returnPartialData: boolean;
+          errorPolicy?: TErrorPolicy;
         }
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming" | "partial">,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -450,14 +463,16 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
           skip: boolean;
+          errorPolicy?: TErrorPolicy;
         }
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming"> | undefined,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -475,16 +490,18 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options:
           | SkipToken
           | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
               returnPartialData: false;
+              errorPolicy?: TErrorPolicy;
             })
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming"> | undefined,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -492,19 +509,21 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options:
           | SkipToken
           | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
               returnPartialData: boolean;
+              errorPolicy?: TErrorPolicy;
             })
       ): [
         (
           | QueryRef<TData, TVariables, "complete" | "streaming" | "partial">
           | undefined
         ),
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -512,14 +531,23 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?
-          [options?: useBackgroundQuery.Options<NoInfer<TVariables>>]
-        : [options: useBackgroundQuery.Options<NoInfer<TVariables>>]
+          [
+            options?: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+              errorPolicy?: TErrorPolicy;
+            },
+          ]
+        : [
+            options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+              errorPolicy?: TErrorPolicy;
+            },
+          ]
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming">,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -527,18 +555,27 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?
           [
             options?:
               | SkipToken
-              | useBackgroundQuery.Options<NoInfer<TVariables>>,
+              | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+                  errorPolicy?: TErrorPolicy;
+                }),
           ]
-        : [options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]
+        : [
+            options:
+              | SkipToken
+              | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+                  errorPolicy?: TErrorPolicy;
+                }),
+          ]
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming"> | undefined,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery:call(1)} */
@@ -546,12 +583,17 @@ export declare namespace useBackgroundQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>
+        options:
+          | SkipToken
+          | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+              errorPolicy?: TErrorPolicy;
+            })
       ): [
         QueryRef<TData, TVariables, "complete" | "streaming"> | undefined,
-        useBackgroundQuery.Result<TData, TVariables>,
+        useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>,
       ];
 
       /** {@inheritDoc @apollo/client/react!useBackgroundQuery.DocumentationTypes.useBackgroundQuery_Deprecated:call(1)} */

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -117,14 +117,20 @@ export declare namespace useLazyQuery {
       fetchMore: <
         TFetchData = TData,
         TFetchVars extends OperationVariables = TVariables,
+        TErrorPolicy extends ErrorPolicy = "none",
       >(
         fetchMoreOptions: ObservableQuery.FetchMoreOptions<
           TData,
           TVariables,
           TFetchData,
           TFetchVars
-        >
-      ) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>>>;
+        > & {
+          /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
+          errorPolicy?: TErrorPolicy;
+        }
+      ) => Promise<
+        ApolloClient.QueryResult<MaybeMasked<TFetchData>, TErrorPolicy>
+      >;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#client:member} */
       client: ApolloClient;

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -348,15 +348,18 @@ export declare namespace useLazyQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
           returnPartialData: true;
+          errorPolicy?: TErrorPolicy;
         }
       ): useLazyQuery.ResultTuple<
         TData,
         TVariables,
-        "empty" | "complete" | "streaming" | "partial"
+        "empty" | "complete" | "streaming" | "partial",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useLazyQuery.DocumentationTypes.useLazyQuery:call(1)} */
@@ -364,15 +367,18 @@ export declare namespace useLazyQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
           returnPartialData: boolean;
+          errorPolicy?: TErrorPolicy;
         }
       ): useLazyQuery.ResultTuple<
         TData,
         TVariables,
-        "empty" | "complete" | "streaming" | "partial"
+        "empty" | "complete" | "streaming" | "partial",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useLazyQuery.DocumentationTypes.useLazyQuery:call(1)} */
@@ -380,13 +386,17 @@ export declare namespace useLazyQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options?: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
+        options?: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+          errorPolicy?: TErrorPolicy;
+        }
       ): useLazyQuery.ResultTuple<
         TData,
         TVariables,
-        "empty" | "complete" | "streaming"
+        "empty" | "complete" | "streaming",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useLazyQuery.DocumentationTypes.useLazyQuery_Deprecated:call(1)} */

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -91,7 +91,11 @@ export declare namespace useLazyQuery {
   }
 
   namespace Base {
-    export interface Result<TData, TVariables extends OperationVariables> {
+    export interface Result<
+      TData,
+      TVariables extends OperationVariables,
+      TErrorPolicy extends ErrorPolicy | undefined = undefined,
+    > {
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#startPolling:member} */
       startPolling: (pollInterval: number) => void;
 
@@ -107,7 +111,7 @@ export declare namespace useLazyQuery {
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
       refetch: (
         variables?: Partial<TVariables>
-      ) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+      ) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>, TErrorPolicy>>;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#fetchMore:member} */
       fetchMore: <
@@ -147,7 +151,8 @@ export declare namespace useLazyQuery {
     TVariables extends OperationVariables,
     TStates extends
       DataState<TData>["dataState"] = DataState<TData>["dataState"],
-  > = Base.Result<TData, TVariables> &
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = Base.Result<TData, TVariables, TErrorPolicy> &
     (
       | ({
           /**
@@ -219,7 +224,7 @@ export declare namespace useLazyQuery {
     TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = [
     execute: ExecFunction<TData, TVariables, TErrorPolicy>,
-    result: useLazyQuery.Result<TData, TVariables, TStates>,
+    result: useLazyQuery.Result<TData, TVariables, TStates, TErrorPolicy>,
   ];
 
   export type ExecFunction<

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -216,16 +216,23 @@ export declare namespace useLazyQuery {
     TVariables extends OperationVariables,
     TStates extends
       DataState<TData>["dataState"] = DataState<TData>["dataState"],
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = [
-    execute: ExecFunction<TData, TVariables>,
+    execute: ExecFunction<TData, TVariables, TErrorPolicy>,
     result: useLazyQuery.Result<TData, TVariables, TStates>,
   ];
 
-  export type ExecFunction<TData, TVariables extends OperationVariables> = (
+  export type ExecFunction<
+    TData,
+    TVariables extends OperationVariables,
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = (
     ...args: {} extends TVariables ?
       [options?: useLazyQuery.ExecOptions<TVariables>]
     : [options: useLazyQuery.ExecOptions<TVariables>]
-  ) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData>>;
+  ) => ObservableQuery.ResultPromise<
+    ApolloClient.QueryResult<TData, TErrorPolicy>
+  >;
 
   namespace DocumentationTypes {
     namespace useLazyQuery {
@@ -261,7 +268,8 @@ export declare namespace useLazyQuery {
         "returnPartialData"
       > extends false ?
         never
-      : "partial")
+      : "partial"),
+    OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy
   >;
 
   namespace DocumentationTypes {

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -39,6 +39,7 @@ import { useDeepMemo } from "./internal/useDeepMemo.js";
 import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.js";
 import { useApolloClient } from "./useApolloClient.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
+
 export declare namespace useLazyQuery {
   import _self = useLazyQuery;
   export interface Options<

--- a/src/react/hooks/useLazyQuery.ts
+++ b/src/react/hooks/useLazyQuery.ts
@@ -22,6 +22,10 @@ import type {
 } from "@apollo/client";
 import { NetworkStatus } from "@apollo/client";
 import type {
+  FetchMoreFunction,
+  RefetchFunction,
+} from "@apollo/client/react/internal";
+import type {
   DocumentationTypes as UtilityDocumentationTypes,
   NoInfer,
   OptionWithFallback,
@@ -110,28 +114,10 @@ export declare namespace useLazyQuery {
       updateQuery: (mapFn: UpdateQueryMapFn<TData, TVariables>) => void;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
-      refetch: (
-        variables?: Partial<TVariables>
-      ) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>, TErrorPolicy>>;
+      refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#fetchMore:member} */
-      fetchMore: <
-        TFetchData = TData,
-        TFetchVars extends OperationVariables = TVariables,
-        TErrorPolicy extends ErrorPolicy = "none",
-      >(
-        fetchMoreOptions: ObservableQuery.FetchMoreOptions<
-          TData,
-          TVariables,
-          TFetchData,
-          TFetchVars
-        > & {
-          /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
-          errorPolicy?: TErrorPolicy;
-        }
-      ) => Promise<
-        ApolloClient.QueryResult<MaybeMasked<TFetchData>, TErrorPolicy>
-      >;
+      fetchMore: FetchMoreFunction<TData, TVariables>;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#client:member} */
       client: ApolloClient;

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -234,16 +234,18 @@ export declare namespace useLoadableQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useLoadableQuery.Options & {
           returnPartialData: true;
-          errorPolicy: "ignore" | "all";
+          errorPolicy: TErrorPolicy & ("ignore" | "all");
         }
       ): useLoadableQuery.Result<
         TData,
         TVariables,
-        "complete" | "streaming" | "partial" | "empty"
+        "complete" | "streaming" | "partial" | "empty",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useLoadableQuery.DocumentationTypes.useLoadableQuery:call(1)} */
@@ -251,15 +253,17 @@ export declare namespace useLoadableQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useLoadableQuery.Options & {
-          errorPolicy: "ignore" | "all";
+          errorPolicy: TErrorPolicy & ("ignore" | "all");
         }
       ): useLoadableQuery.Result<
         TData,
         TVariables,
-        "complete" | "streaming" | "empty"
+        "complete" | "streaming" | "empty",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useLoadableQuery.DocumentationTypes.useLoadableQuery:call(1)} */
@@ -267,15 +271,18 @@ export declare namespace useLoadableQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useLoadableQuery.Options & {
           returnPartialData: true;
+          errorPolicy?: TErrorPolicy;
         }
       ): useLoadableQuery.Result<
         TData,
         TVariables,
-        "complete" | "streaming" | "partial"
+        "complete" | "streaming" | "partial",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useLoadableQuery.DocumentationTypes.useLoadableQuery:call(1)} */
@@ -283,10 +290,16 @@ export declare namespace useLoadableQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options?: useLoadableQuery.Options
-      ): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming">;
+        options?: useLoadableQuery.Options & { errorPolicy?: TErrorPolicy }
+      ): useLoadableQuery.Result<
+        TData,
+        TVariables,
+        "complete" | "streaming",
+        TErrorPolicy
+      >;
 
       /** {@inheritDoc @apollo/client/react!useLoadableQuery.DocumentationTypes.useLoadableQuery_Deprecated:call(1)} */
       <TData, TVariables extends OperationVariables = OperationVariables>(

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -397,8 +397,10 @@ export const useLoadableQuery: useLoadableQuery.Signature =
 
     const calledDuringRender = useRenderGuard();
 
-    const fetchMore: FetchMoreFunction<TData, TVariables> = React.useCallback(
-      (options) => {
+    const fetchMore = React.useCallback(
+      (
+        options: ObservableQuery.FetchMoreOptions<TData, TVariables, any, any>
+      ) => {
         if (!internalQueryRef) {
           throw new Error(
             "The query has not been loaded. Please load the query."
@@ -412,7 +414,7 @@ export const useLoadableQuery: useLoadableQuery.Signature =
         return promise;
       },
       [internalQueryRef]
-    );
+    ) as FetchMoreFunction<TData, TVariables>;
 
     const refetch: RefetchFunction<TData, TVariables> = React.useCallback(
       (options) => {

--- a/src/react/hooks/useLoadableQuery.ts
+++ b/src/react/hooks/useLoadableQuery.ts
@@ -56,19 +56,21 @@ export declare namespace useLoadableQuery {
     TVariables extends OperationVariables = OperationVariables,
     TStates extends
       DataState<TData>["dataState"] = DataState<TData>["dataState"],
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > = [
     loadQuery: LoadQueryFunction<TVariables>,
     queryRef: QueryRef<TData, TVariables, TStates> | null,
-    handlers: Handlers<TData, TVariables>,
+    handlers: Handlers<TData, TVariables, TErrorPolicy>,
   ];
   export interface Handlers<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
   > {
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#fetchMore:member} */
     fetchMore: FetchMoreFunction<TData, TVariables>;
     /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
-    refetch: RefetchFunction<TData, TVariables>;
+    refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
     /** {@inheritDoc @apollo/client!ObservableQuery#subscribeToMore:member(1)} */
     subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     /**
@@ -140,7 +142,8 @@ export declare namespace useLoadableQuery {
         "returnPartialData"
       > extends false ?
         never
-      : "partial")
+      : "partial"),
+    OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy
   >;
 
   export namespace DocumentationTypes {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -336,15 +336,19 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
           returnPartialData: true;
+          errorPolicy?: TErrorPolicy;
         }
       ): useQuery.Result<
         TData,
         TVariables,
-        "empty" | "complete" | "streaming" | "partial"
+        "empty" | "complete" | "streaming" | "partial",
+        TVariables,
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
@@ -362,12 +366,14 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options:
           | SkipToken
           | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
               returnPartialData: true;
+              errorPolicy?: TErrorPolicy;
             })
       ): useQuery.Result<
         TData,
@@ -381,15 +387,19 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
           returnPartialData: boolean;
+          errorPolicy?: TErrorPolicy;
         }
       ): useQuery.Result<
         TData,
         TVariables,
-        "empty" | "complete" | "streaming" | "partial"
+        "empty" | "complete" | "streaming" | "partial",
+        TVariables,
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
@@ -397,18 +407,21 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options:
           | SkipToken
           | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
               returnPartialData: boolean;
+              TErrorPolicy?: TErrorPolicy;
             })
       ): useQuery.Result<
         TData,
         TVariables,
         "empty" | "complete" | "streaming" | "partial",
-        Partial<TVariables>
+        Partial<TVariables>,
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
@@ -416,36 +429,57 @@ export declare namespace useQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?
-          [options?: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>]
-        : [options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>]
-      ): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
+          [
+            options?: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+              errorPolicy?: TErrorPolicy;
+            },
+          ]
+        : [
+            options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+              errorPolicy?: TErrorPolicy;
+            },
+          ]
+      ): useQuery.Result<
+        TData,
+        TVariables,
+        "empty" | "complete" | "streaming",
+        TVariables,
+        TErrorPolicy
+      >;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
       <
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?
           [
             options?:
               | SkipToken
-              | useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>,
+              | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                  errorPolicy?: TErrorPolicy;
+                }),
           ]
         : [
             options:
               | SkipToken
-              | useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>,
+              | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                  errorPolicy?: TErrorPolicy;
+                }),
           ]
       ): useQuery.Result<
         TData,
         TVariables,
         "empty" | "complete" | "streaming",
-        Partial<TVariables>
+        Partial<TVariables>,
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery_Deprecated:call(1)} */

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -135,6 +135,7 @@ export declare namespace useQuery {
       TData = unknown,
       TVariables extends OperationVariables = OperationVariables,
       TReturnVariables extends OperationVariables = TVariables,
+      TErrorPolicy extends ErrorPolicy | undefined = undefined,
     > {
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#client:member} */
       client: ApolloClient;
@@ -169,7 +170,7 @@ export declare namespace useQuery {
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
       refetch: (
         variables?: Partial<TVariables>
-      ) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+      ) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>, TErrorPolicy>>;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#variables:member} */
       variables: TReturnVariables;
@@ -194,7 +195,8 @@ export declare namespace useQuery {
     TStates extends
       DataState<TData>["dataState"] = DataState<TData>["dataState"],
     TReturnVariables extends OperationVariables = TVariables,
-  > = Base.Result<TData, TVariables, TReturnVariables> &
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = Base.Result<TData, TVariables, TReturnVariables, TErrorPolicy> &
     GetDataState<MaybeMasked<TData>, TStates>;
 
   export interface DefaultOptions
@@ -247,7 +249,9 @@ export declare namespace useQuery {
           > extends false ?
             never
           : "partial"
-        : never)
+        : never),
+      TVariables,
+      OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy
     >
   >;
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -379,7 +379,8 @@ export declare namespace useQuery {
         TData,
         TVariables,
         "empty" | "complete" | "streaming" | "partial",
-        Partial<TVariables>
+        Partial<TVariables>,
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useQuery.DocumentationTypes.useQuery:call(1)} */
@@ -414,7 +415,7 @@ export declare namespace useQuery {
           | SkipToken
           | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
               returnPartialData: boolean;
-              TErrorPolicy?: TErrorPolicy;
+              errorPolicy?: TErrorPolicy;
             })
       ): useQuery.Result<
         TData,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -179,14 +179,20 @@ export declare namespace useQuery {
       fetchMore: <
         TFetchData = TData,
         TFetchVars extends OperationVariables = TVariables,
+        TErrorPolicy extends ErrorPolicy = "none",
       >(
         fetchMoreOptions: ObservableQuery.FetchMoreOptions<
           TData,
           TVariables,
           TFetchData,
           TFetchVars
-        >
-      ) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>>>;
+        > & {
+          /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
+          errorPolicy?: TErrorPolicy;
+        }
+      ) => Promise<
+        ApolloClient.QueryResult<MaybeMasked<TFetchData>, TErrorPolicy>
+      >;
     }
   }
   export type Result<

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -36,6 +36,10 @@ import type { ApolloClient } from "@apollo/client";
 import { NetworkStatus } from "@apollo/client";
 import type { MaybeMasked } from "@apollo/client/masking";
 import type {
+  FetchMoreFunction,
+  RefetchFunction,
+} from "@apollo/client/react/internal";
+import type {
   DocumentationTypes as UtilityDocumentationTypes,
   LazyType,
   NoInfer,
@@ -168,31 +172,13 @@ export declare namespace useQuery {
       updateQuery: (mapFn: UpdateQueryMapFn<TData, TVariables>) => void;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#refetch:member} */
-      refetch: (
-        variables?: Partial<TVariables>
-      ) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>, TErrorPolicy>>;
+      refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#variables:member} */
       variables: TReturnVariables;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#fetchMore:member} */
-      fetchMore: <
-        TFetchData = TData,
-        TFetchVars extends OperationVariables = TVariables,
-        TErrorPolicy extends ErrorPolicy = "none",
-      >(
-        fetchMoreOptions: ObservableQuery.FetchMoreOptions<
-          TData,
-          TVariables,
-          TFetchData,
-          TFetchVars
-        > & {
-          /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
-          errorPolicy?: TErrorPolicy;
-        }
-      ) => Promise<
-        ApolloClient.QueryResult<MaybeMasked<TFetchData>, TErrorPolicy>
-      >;
+      fetchMore: FetchMoreFunction<TData, TVariables>;
     }
   }
   export type Result<

--- a/src/react/hooks/useQueryRefHandlers.ts
+++ b/src/react/hooks/useQueryRefHandlers.ts
@@ -119,8 +119,10 @@ function useQueryRefHandlers_<
     [internalQueryRef]
   );
 
-  const fetchMore: FetchMoreFunction<TData, TVariables> = React.useCallback(
-    (options) => {
+  const fetchMore = React.useCallback(
+    (
+      options: ObservableQuery.FetchMoreOptions<TData, TVariables, any, any>
+    ) => {
       const promise = internalQueryRef.fetchMore(
         options as ObservableQuery.FetchMoreOptions<any, any>
       );
@@ -130,7 +132,7 @@ function useQueryRefHandlers_<
       return promise;
     },
     [internalQueryRef]
-  );
+  ) as FetchMoreFunction<TData, TVariables>;
 
   return {
     refetch,

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -117,6 +117,7 @@ export declare namespace useSuspenseQuery {
     export interface Result<
       TData = unknown,
       TVariables extends OperationVariables = OperationVariables,
+      TErrorPolicy extends ErrorPolicy | undefined = undefined,
     > {
       /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#client:member} */
       client: ApolloClient;
@@ -141,7 +142,7 @@ export declare namespace useSuspenseQuery {
        * @remarks
        * Calling this function will cause the component to re-suspend, unless the call site is wrapped in [`startTransition`](https://react.dev/reference/react/startTransition).
        */
-      refetch: RefetchFunction<TData, TVariables>;
+      refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#subscribeToMore:member} */
       subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -152,7 +153,8 @@ export declare namespace useSuspenseQuery {
     TVariables extends OperationVariables = OperationVariables,
     TStates extends
       DataState<TData>["dataState"] = DataState<TData>["dataState"],
-  > = Base.Result<TData, TVariables> &
+    TErrorPolicy extends ErrorPolicy | undefined = undefined,
+  > = Base.Result<TData, TVariables, TErrorPolicy> &
     GetDataState<MaybeMasked<TData>, TStates>;
 
   export interface DefaultOptions
@@ -223,7 +225,8 @@ export declare namespace useSuspenseQuery {
         DefaultOptions extends { returnPartialData: false } ?
           never
         : "partial"
-      : never)
+      : never),
+    OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy
   >;
 
   export namespace DocumentationTypes {

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -322,16 +322,18 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
           returnPartialData: true;
-          errorPolicy: "ignore" | "all";
+          errorPolicy: TErrorPolicy & ("ignore" | "all");
         }
       ): useSuspenseQuery.Result<
         TData,
         TVariables,
-        "complete" | "streaming" | "partial" | "empty"
+        "complete" | "streaming" | "partial" | "empty",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
@@ -339,15 +341,17 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
-          errorPolicy: "ignore" | "all";
+          errorPolicy: TErrorPolicy & ("ignore" | "all");
         }
       ): useSuspenseQuery.Result<
         TData,
         TVariables,
-        "complete" | "streaming" | "empty"
+        "complete" | "streaming" | "empty",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
@@ -355,16 +359,19 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
           skip: boolean;
           returnPartialData: true;
+          errorPolicy?: TErrorPolicy;
         }
       ): useSuspenseQuery.Result<
         TData,
         TVariables,
-        "complete" | "empty" | "streaming" | "partial"
+        "complete" | "empty" | "streaming" | "partial",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
@@ -372,15 +379,18 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
           returnPartialData: true;
+          errorPolicy?: TErrorPolicy;
         }
       ): useSuspenseQuery.Result<
         TData,
         TVariables,
-        "partial" | "streaming" | "complete"
+        "partial" | "streaming" | "complete",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
@@ -388,15 +398,18 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
           skip: boolean;
+          errorPolicy?: TErrorPolicy;
         }
       ): useSuspenseQuery.Result<
         TData,
         TVariables,
-        "complete" | "streaming" | "empty"
+        "complete" | "streaming" | "empty",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
@@ -404,17 +417,20 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         options:
           | SkipToken
           | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
               returnPartialData: true;
+              errorPolicy?: TErrorPolicy;
             })
       ): useSuspenseQuery.Result<
         TData,
         TVariables,
-        "empty" | "streaming" | "complete" | "partial"
+        "empty" | "streaming" | "complete" | "partial",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
@@ -422,27 +438,25 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
         ...[options]: {} extends TVariables ?
-          [options?: useSuspenseQuery.Options<NoInfer<TVariables>>]
-        : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]
-      ): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
-
-      /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
-      <
-        TData,
-        TVariables extends OperationVariables,
-        _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
-      >(
-        query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        ...[options]: {} extends TVariables ?
-          [options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
-        : [options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]
+          [
+            options?: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+              errorPolicy?: TErrorPolicy;
+            },
+          ]
+        : [
+            options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+              errorPolicy?: TErrorPolicy;
+            },
+          ]
       ): useSuspenseQuery.Result<
         TData,
         TVariables,
-        "complete" | "streaming" | "empty"
+        "complete" | "streaming",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
@@ -450,13 +464,49 @@ export declare namespace useSuspenseQuery {
         TData,
         TVariables extends OperationVariables,
         _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
       >(
         query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-        options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>
+        ...[options]: {} extends TVariables ?
+          [
+            options?:
+              | SkipToken
+              | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                  errorPolicy?: TErrorPolicy;
+                }),
+          ]
+        : [
+            options:
+              | SkipToken
+              | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                  errorPolicy?: TErrorPolicy;
+                }),
+          ]
       ): useSuspenseQuery.Result<
         TData,
         TVariables,
-        "complete" | "streaming" | "empty"
+        "complete" | "streaming" | "empty",
+        TErrorPolicy
+      >;
+
+      /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery:call(1)} */
+      <
+        TData,
+        TVariables extends OperationVariables,
+        _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred",
+        TErrorPolicy extends ErrorPolicy | undefined = undefined,
+      >(
+        query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+        options:
+          | SkipToken
+          | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+              errorPolicy?: TErrorPolicy;
+            })
+      ): useSuspenseQuery.Result<
+        TData,
+        TVariables,
+        "complete" | "streaming" | "empty",
+        TErrorPolicy
       >;
 
       /** {@inheritDoc @apollo/client/react!useSuspenseQuery.DocumentationTypes.useSuspenseQuery_Deprecated:call(1)} */

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -743,10 +743,10 @@ function useSuspenseQuery_<
 
   const result = fetchPolicy === "standby" ? skipResult : __use(promise);
 
-  const fetchMore = React.useCallback<
-    FetchMoreFunction<unknown, OperationVariables>
-  >(
-    (options) => {
+  const fetchMore = React.useCallback(
+    (
+      options: ObservableQuery.FetchMoreOptions<unknown, OperationVariables>
+    ) => {
       const promise = queryRef.fetchMore(options);
       setPromise([queryRef.key, queryRef.promise]);
 

--- a/src/react/internal/cache/QueryReference.ts
+++ b/src/react/internal/cache/QueryReference.ts
@@ -10,6 +10,7 @@ import { filter } from "rxjs";
 import type {
   ApolloClient,
   DataState,
+  ErrorPolicy,
   ObservableQuery,
   OperationVariables,
 } from "@apollo/client";
@@ -366,7 +367,9 @@ export class InternalQueryReference<
   }
 
   fetchMore(options: ObservableQuery.FetchMoreOptions<TData, any, any, any>) {
-    return this.initiateFetch(this.observable.fetchMore<TData>(options));
+    return this.initiateFetch(
+      this.observable.fetchMore<TData, any, ErrorPolicy>(options)
+    );
   }
 
   private dispose() {

--- a/src/react/internal/types.ts
+++ b/src/react/internal/types.ts
@@ -17,11 +17,15 @@ export type RefetchFunction<
 export type FetchMoreFunction<TData, TVariables extends OperationVariables> = <
   TFetchData = TData,
   TFetchVars extends OperationVariables = TVariables,
+  TErrorPolicy extends ErrorPolicy = "none",
 >(
   fetchMoreOptions: ObservableQuery.FetchMoreOptions<
     TData,
     TVariables,
     TFetchData,
     TFetchVars
-  >
-) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+  > & {
+    /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#errorPolicy:member} */
+    errorPolicy?: TErrorPolicy;
+  }
+) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>, TErrorPolicy>>;

--- a/src/react/internal/types.ts
+++ b/src/react/internal/types.ts
@@ -1,13 +1,18 @@
 import type {
   ApolloClient,
+  ErrorPolicy,
   MaybeMasked,
   ObservableQuery,
   OperationVariables,
 } from "@apollo/client";
 
-export type RefetchFunction<TData, TVariables extends OperationVariables> = (
+export type RefetchFunction<
+  TData,
+  TVariables extends OperationVariables,
+  TErrorPolicy extends ErrorPolicy | undefined = undefined,
+> = (
   variables?: Partial<TVariables>
-) => Promise<ApolloClient.QueryResult<TData>>;
+) => Promise<ApolloClient.QueryResult<TData, TErrorPolicy>>;
 
 export type FetchMoreFunction<TData, TVariables extends OperationVariables> = <
   TFetchData = TData,

--- a/src/react/internal/types.ts
+++ b/src/react/internal/types.ts
@@ -12,7 +12,7 @@ export type RefetchFunction<
   TErrorPolicy extends ErrorPolicy | undefined = undefined,
 > = (
   variables?: Partial<TVariables>
-) => Promise<ApolloClient.QueryResult<TData, TErrorPolicy>>;
+) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>, TErrorPolicy>>;
 
 export type FetchMoreFunction<TData, TVariables extends OperationVariables> = <
   TFetchData = TData,


### PR DESCRIPTION
Fixes #13371

`refetch`, `fetchMore`, and the `execute` function returned by `useLazyQuery` all used the `ApolloClient.QueryResult` type which accepts an `ErrorPolicy` so that the `data` and `error` properties are configured to the right values. Unfortunately all the React hooks never passed through the configured `errorPolicy` so the return types from these functions didn't reflect accurate runtime values. These APIs are now all updated to base the return type off the configured `errorPolicy` (including any configured default from `defaultOptions`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query results now accurately reflect the selected error policy in TypeScript.
  * `fetchMore` supports an optional error-policy override, with policy-aware data and error types.
  * `refetch` and lazy-query execution results now provide improved data and error narrowing.

* **Bug Fixes**
  * Corrected result typings so successfully fetched data is recognized as defined.
  * Improved consistency across query hooks, including skipped and partial-data scenarios.

* **Tests**
  * Expanded type coverage for error policies across query, refetch, and fetch-more operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->