### PR TITLE
Fix `client.mutate` return type when `optimisticResponse` is provided

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -245,7 +245,9 @@ export namespace ApolloClient {
             [K in InvalidOptionNames]: never;
         } : never);
         // (undocumented)
-        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | Omit<MutateOptions<any, any, TCache>, "variables">> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+        export type ResultForOptions<TData, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<{
+            errorPolicy: TErrorPolicy;
+        }, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
         }
         // (undocumented)
@@ -266,9 +268,10 @@ export namespace ApolloClient {
             export interface Modern {
                 <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Omit<ApolloClient.MutateOptions<NoInfer<TData>, any, TCache>, "variables"> & {
                     variables?: unknown;
-                }>(options: TOptions & ApolloClient.mutate.OptionsFor<TData, TVariables, TCache, TOptions> & {
+                }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: TOptions & ApolloClient.mutate.OptionsFor<TData, TVariables, TCache, TOptions> & {
                     mutation: TypedDocumentNode<TData, TVariables>;
-                }): Promise<ApolloClient.mutate.ResultForOptions<TData, TVariables, TCache, TOptions>>;
+                    errorPolicy?: TErrorPolicy;
+                }): Promise<ApolloClient.mutate.ResultForOptions<TData, TErrorPolicy>>;
             }
         }
     }
@@ -1394,7 +1397,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:669:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:667:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1028,11 +1028,9 @@ export namespace useMutation {
     // Warning: (ae-forgotten-export) The symbol "ExtractConfiguredVariables" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, never> | Options<TData, TVariables, TCache>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, ExtractConfiguredVariables<TOptions, TVariables>>, TCache, [
-    TErrorPolicy
-    ] extends [undefined] ? DefaultOptions extends {
-        errorPolicy: infer D;
-    } ? D : undefined : TErrorPolicy>>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, never> | Options<TData, TVariables, TCache>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, ExtractConfiguredVariables<TOptions, TVariables>>, TCache, OptionWithFallback<{
+        errorPolicy: TErrorPolicy;
+    }, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
     export type ResultStateMap<TData = unknown> = {
         none: {
             data: MaybeMasked<TData> | null | undefined;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -288,7 +288,9 @@ export namespace ApolloClient {
         // Warning: (ae-forgotten-export) The symbol "OptionWithFallback" needs to be exported by the entry point index.d.ts
         //
         // (undocumented)
-        export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, unknown> | Omit<MutateOptions<any, any, TCache>, "variables">> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+        export type ResultForOptions<TData, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<MutateResult<MaybeMasked<TData>, OptionWithFallback<{
+            errorPolicy: TErrorPolicy;
+        }, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
         export interface Signature extends Signatures.Evaluated {
         }
         // (undocumented)
@@ -311,9 +313,10 @@ export namespace ApolloClient {
             export interface Modern {
                 <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Omit<ApolloClient.MutateOptions<NoInfer<TData>, any, TCache>, "variables"> & {
                     variables?: unknown;
-                }>(options: TOptions & ApolloClient.mutate.OptionsFor<TData, TVariables, TCache, TOptions> & {
+                }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(options: TOptions & ApolloClient.mutate.OptionsFor<TData, TVariables, TCache, TOptions> & {
                     mutation: TypedDocumentNode<TData, TVariables>;
-                }): Promise<ApolloClient.mutate.ResultForOptions<TData, TVariables, TCache, TOptions>>;
+                    errorPolicy?: TErrorPolicy;
+                }): Promise<ApolloClient.mutate.ResultForOptions<TData, TErrorPolicy>>;
             }
         }
     }
@@ -3096,7 +3099,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:669:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:667:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/empty-snails-provide.md
+++ b/.changeset/empty-snails-provide.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix accidental widening of the `client.mutate` return type when `optimisticResponse` was present.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 48044,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 42315,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35982,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29489
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 47945,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 42291,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35993,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29497
 }

--- a/integration-tests/type-tests/signatures/modern/mutate.ts
+++ b/integration-tests/type-tests/signatures/modern/mutate.ts
@@ -173,6 +173,108 @@ test("constant variable types do not widen errorPolicy", async () => {
   }
 });
 
+test("optimisticResponse does not widen the result", async () => {
+  interface Data {
+    updateThing: {
+      __typename: "Payload";
+      inner: { __typename: "Inner"; data: Record<string, unknown> };
+    };
+  }
+
+  const mutation: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  {
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { id: "1" },
+      optimisticResponse: {
+        updateThing: {
+          __typename: "Payload",
+          inner: { __typename: "Inner", data: { x: 1 } },
+        },
+      },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { id: "1" },
+      errorPolicy: "all",
+      optimisticResponse: {
+        updateThing: {
+          __typename: "Payload",
+          inner: { __typename: "Inner", data: { x: 1 } },
+        },
+      },
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const { data, error } = await client.mutate({
+      mutation,
+      variables: { id: "1" },
+      optimisticResponse: () => ({
+        updateThing: {
+          __typename: "Payload" as const,
+          inner: { __typename: "Inner" as const, data: { x: 1 } },
+        },
+      }),
+    });
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("rejects an invalid optimisticResponse", () => {
+  interface Data {
+    thing: { __typename: "Thing"; name: string };
+  }
+
+  const mutation: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  client.mutate({
+    mutation,
+    variables: { id: "1" },
+    optimisticResponse: { thing: { __typename: "Thing", name: "a" } },
+  });
+
+  client.mutate({
+    mutation,
+    variables: { id: "1" },
+    // @ts-expect-error invalid __typename
+    optimisticResponse: { thing: { __typename: "Nope", name: "a" } },
+  });
+
+  client.mutate({
+    mutation,
+    variables: { id: "1" },
+    // @ts-expect-error missing field
+    optimisticResponse: { thing: { __typename: "Thing" } },
+  });
+
+  client.mutate({
+    mutation,
+    variables: { id: "1" },
+    // @ts-expect-error excess field
+    optimisticResponse: { thing: { __typename: "Thing", name: "a", id: 1 } },
+  });
+
+  client.mutate({
+    mutation,
+    variables: { id: "1" },
+    // @ts-expect-error not an object
+    optimisticResponse: 1,
+  });
+});
+
 test("passes through generic variables", () => {
   function wrapper<TData, TVariables extends OperationVariables>(
     mutation: TypedDocumentNode<TData, TVariables>,

--- a/integration-tests/type-tests/signatures/modern/useMutation.ts
+++ b/integration-tests/type-tests/signatures/modern/useMutation.ts
@@ -1,5 +1,10 @@
 import { useMutation } from "@apollo/client/react";
-import { ApolloClient, gql, TypedDocumentNode } from "@apollo/client";
+import {
+  ApolloClient,
+  ErrorLike,
+  gql,
+  TypedDocumentNode,
+} from "@apollo/client";
 import { expectTypeOf } from "expect-type";
 
 import { test } from "./shared.js";
@@ -1523,4 +1528,104 @@ test("constant variable types do not widen errorPolicy", () => {
       Promise<ApolloClient.MutateResult<Data, "all">>
     >();
   }
+});
+
+test("optimisticResponse does not widen the result", async () => {
+  interface Data {
+    updateThing: {
+      __typename: "Payload";
+      inner: { __typename: "Inner"; data: Record<string, unknown> };
+    };
+  }
+
+  const mutation: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  {
+    const [mutate] = useMutation(mutation, {
+      variables: { id: "1" },
+      optimisticResponse: {
+        updateThing: {
+          __typename: "Payload",
+          inner: { __typename: "Inner", data: { x: 1 } },
+        },
+      },
+    });
+
+    const { data, error } = await mutate();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+
+  {
+    const [mutate] = useMutation(mutation, {
+      variables: { id: "1" },
+      errorPolicy: "all",
+      optimisticResponse: {
+        updateThing: {
+          __typename: "Payload",
+          inner: { __typename: "Inner", data: { x: 1 } },
+        },
+      },
+    });
+
+    const { data, error } = await mutate();
+
+    expectTypeOf(data).toEqualTypeOf<Data | undefined>();
+    expectTypeOf(error).toEqualTypeOf<ErrorLike | undefined>();
+  }
+
+  {
+    const [mutate] = useMutation(mutation, {
+      variables: { id: "1" },
+      optimisticResponse: () => ({
+        updateThing: {
+          __typename: "Payload" as const,
+          inner: { __typename: "Inner" as const, data: { x: 1 } },
+        },
+      }),
+    });
+
+    const { data, error } = await mutate();
+
+    expectTypeOf(data).toEqualTypeOf<Data>();
+    expectTypeOf(error).toEqualTypeOf<undefined>();
+  }
+});
+
+test("rejects an invalid optimisticResponse", () => {
+  interface Data {
+    thing: { __typename: "Thing"; name: string };
+  }
+
+  const mutation: TypedDocumentNode<Data, { id: string }> = gql``;
+
+  useMutation(mutation, {
+    variables: { id: "1" },
+    optimisticResponse: { thing: { __typename: "Thing", name: "a" } },
+  });
+
+  useMutation(mutation, {
+    variables: { id: "1" },
+    // @ts-expect-error invalid __typename
+    optimisticResponse: { thing: { __typename: "Nope", name: "a" } },
+  });
+
+  useMutation(mutation, {
+    variables: { id: "1" },
+    // @ts-expect-error missing field
+    optimisticResponse: { thing: { __typename: "Thing" } },
+  });
+
+  useMutation(mutation, {
+    variables: { id: "1" },
+    // @ts-expect-error excess field
+    optimisticResponse: { thing: { __typename: "Thing", name: "a", id: 1 } },
+  });
+
+  useMutation(mutation, {
+    variables: { id: "1" },
+    // @ts-expect-error not an object
+    optimisticResponse: 1,
+  });
 });

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -269,15 +269,15 @@ export declare namespace ApolloClient {
 
     export type ResultForOptions<
       TData,
-      TVariables extends OperationVariables,
-      TCache extends ApolloCache,
-      TOptions extends
-        | Record<string, unknown>
-        | Omit<MutateOptions<any, any, TCache>, "variables">,
+      TErrorPolicy extends ErrorPolicy | undefined = undefined,
     > = LazyType<
       MutateResult<
         MaybeMasked<TData>,
-        OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> &
+        OptionWithFallback<
+          { errorPolicy: TErrorPolicy },
+          DefaultOptions,
+          "errorPolicy"
+        > &
           ErrorPolicy
       >
     >;
@@ -325,6 +325,7 @@ export declare namespace ApolloClient {
             ApolloClient.MutateOptions<NoInfer<TData>, any, TCache>,
             "variables"
           > & { variables?: unknown },
+          TErrorPolicy extends ErrorPolicy | undefined = undefined,
         >(
           options: TOptions &
             ApolloClient.mutate.OptionsFor<
@@ -332,15 +333,12 @@ export declare namespace ApolloClient {
               TVariables,
               TCache,
               TOptions
-            > & { mutation: TypedDocumentNode<TData, TVariables> }
-        ): Promise<
-          ApolloClient.mutate.ResultForOptions<
-            TData,
-            TVariables,
-            TCache,
-            TOptions
-          >
-        >;
+            > & {
+              mutation: TypedDocumentNode<TData, TVariables>;
+              /** {@inheritDoc @apollo/client!MutationOptionsDocumentation#errorPolicy:member} */
+              errorPolicy?: TErrorPolicy;
+            }
+        ): Promise<ApolloClient.mutate.ResultForOptions<TData, TErrorPolicy>>;
       }
 
       export type Evaluated =

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -23,6 +23,7 @@ import type { IgnoreModifier } from "@apollo/client/cache";
 import type {
   LazyType,
   NoInfer,
+  OptionWithFallback,
   Prettify,
   SignatureStyle,
 } from "@apollo/client/utilities/internal";
@@ -279,11 +280,12 @@ export declare namespace useMutation {
         ExtractConfiguredVariables<TOptions, TVariables>
       >,
       TCache,
-      [TErrorPolicy] extends [undefined] ?
-        DefaultOptions extends { errorPolicy: infer D } ?
-          D
-        : undefined
-      : TErrorPolicy
+      OptionWithFallback<
+        { errorPolicy: TErrorPolicy },
+        DefaultOptions,
+        "errorPolicy"
+      > &
+        ErrorPolicy
     >
   >;
 


### PR DESCRIPTION
Fixes #13285

`client.mutate` suffered from a similar problem as #13382 where constant types in `TData` caused the type to widen when `optimisticResponse` was provided. `TData` is much more vulnerable to this since `__typename` is usually typed as a constant value instead of `string`, so this happened often. This applies a similar fix as #13382 which captures `errorPolicy` from options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed TypeScript result inference for `client.mutate` when using `optimisticResponse`, preventing unintended widening of mutation result types.
  - Improved mutation result typing across supported error policies, including default and `"all"` policies.
  - Added stricter validation for optimistic responses, including object shape, fields, and `__typename` values.

- **Improvements**
  - Mutation options now provide more accurate type inference for `errorPolicy` and returned data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->