### PR TITLE
feat: support skipToken in useSubscription

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1243,8 +1243,10 @@ export type UseReadQueryResult<TData = unknown> = useReadQuery.Result<TData>;
 
 // @public
 export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, ...[options]: {} extends (TVariables) ? [
-options?: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
-] : [options: useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useSubscription.Result<TData>;
+options?: SkipToken | useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+] : [
+options: SkipToken | useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+]): useSubscription.Result<TData>;
 
 // @public (undocumented)
 export namespace useSubscription {

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -4,9 +4,9 @@
 
 ```ts
 
-import type { ApolloCache } from '@apollo/client';
-import type { ApolloCache as ApolloCache_2 } from '@apollo/client/cache';
+import type { ApolloCache } from '@apollo/client/cache';
 import type { ApolloClient } from '@apollo/client';
+import type { Cache as Cache_2 } from '@apollo/client/cache';
 import type { DataState } from '@apollo/client';
 import type { DataValue } from '@apollo/client';
 import type { DefaultContext } from '@apollo/client';
@@ -30,7 +30,6 @@ import type { MutationFetchPolicy } from '@apollo/client';
 import type { MutationQueryReducersMap } from '@apollo/client';
 import type { MutationUpdaterFunction } from '@apollo/client';
 import { NetworkStatus } from '@apollo/client';
-import type { NoInfer as NoInfer_2 } from '@apollo/client/utilities/internal';
 import type { NormalizedExecutionResult } from '@apollo/client';
 import type { ObservableQuery } from '@apollo/client';
 import type { OnQueryUpdated } from '@apollo/client';
@@ -97,7 +96,7 @@ export function getApolloContext(): ReactTypes.Context<ApolloContextValue>;
 
 // @internal @deprecated (undocumented)
 export namespace InternalTypes {
-    export type { HookWrappers };
+    export export type { HookWrappers };
 }
 
 // @public @deprecated (undocumented)
@@ -130,16 +129,16 @@ type MakeRequiredVariablesOptional<TVariables extends OperationVariables, TConfi
 } & Omit<TVariables, keyof TConfiguredVariables>>;
 
 // @public @deprecated (undocumented)
-export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
+export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
-export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.Options<TData, TVariables, TCache>;
+export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.Options<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
 export type MutationResult<TData = unknown> = useMutation.Result<TData>;
 
 // @public @deprecated (undocumented)
-export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.ResultTuple<TData, TVariables, TCache>;
+export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.ResultTuple<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
 export type OnDataOptions<TData = unknown> = useSubscription.OnDataOptions<TData>;
@@ -169,7 +168,19 @@ export namespace PreloadQueryFunction {
         }
     }
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | PreloadQueryOptions<TVariables>> = TOptions extends any ? PreloadedQueryRef_2<TData, TVariables, ResultForOptions.States<TOptions, DefaultOptions>> : never;
+    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
+        variables?: unknown;
+    }> = PreloadQueryOptions<NoInfer<TVariables>> & {
+        variables?: Prettify<TVariables & {
+            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
+        }>;
+    } & (Exclude<keyof TOptions, keyof PreloadQueryOptions<any>> extends (infer InvalidOptionNames extends string) ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never);
+    // (undocumented)
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Omit<PreloadQueryOptions<any>, "variables">> = TOptions extends any ? PreloadedQueryRef_2<TData, TVariables, ResultForOptions.States<TOptions, DefaultOptions>> : never;
     // (undocumented)
     export namespace ResultForOptions {
         // (undocumented)
@@ -179,44 +190,48 @@ export namespace PreloadQueryFunction {
     export namespace Signatures {
         // (undocumented)
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
                 returnPartialData: true;
                 errorPolicy: "ignore" | "all";
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
                 returnPartialData: true;
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: PreloadQueryOptions<NoInfer_2<TVariables>>
-            ] : [options: PreloadQueryOptions<NoInfer_2<TVariables>>]): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: PreloadQueryOptions<NoInfer<TVariables>>
+            ] : [options: PreloadQueryOptions<NoInfer<TVariables>>]): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
                 returnPartialData: true;
                 errorPolicy: "ignore" | "all";
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
                 returnPartialData: true;
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: PreloadQueryOptions<NoInfer_2<TVariables>>
-            ] : [options: PreloadQueryOptions<NoInfer_2<TVariables>>]): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: PreloadQueryOptions<NoInfer<TVariables>>
+            ] : [options: PreloadQueryOptions<NoInfer<TVariables>>]): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): PreloadQueryFunction.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends PreloadQueryOptions<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): PreloadQueryFunction.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends Omit<PreloadQueryOptions<any>, "variables"> & {
+                variables?: unknown;
+            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: TOptions & PreloadQueryFunction.OptionsFor<TVariables, TOptions>
+            ] : [
+            options: TOptions & PreloadQueryFunction.OptionsFor<TVariables, TOptions>
+            ]): PreloadQueryFunction.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -283,6 +298,7 @@ export namespace useBackgroundQuery {
             returnPartialData?: boolean;
             // @deprecated
             skip?: boolean;
+            variables?: unknown;
         }
     }
     // (undocumented)
@@ -295,7 +311,8 @@ export namespace useBackgroundQuery {
         // (undocumented)
         export namespace useBackgroundQuery {
             // (undocumented)
-            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options {
+                variables?: TVariables;
             }
         }
     }
@@ -331,111 +348,145 @@ export namespace useBackgroundQuery {
     // (undocumented)
     export type Options<TVariables extends OperationVariables = OperationVariables> = Base.Options & VariablesOption<TVariables>;
     // (undocumented)
-    export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
+    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
+        variables?: unknown;
+    }> = useBackgroundQuery.Options<NoInfer<TVariables>> & {
+        variables?: Prettify<TVariables & {
+            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
+        }>;
+    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useBackgroundQuery.Options<any>> extends infer InvalidOptionNames extends string ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never);
+    // (undocumented)
+    export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
         fetchMore: FetchMoreFunction<TData, TVariables>;
-        refetch: RefetchFunction<TData, TVariables>;
+        refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     }
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TVariables> | SkipToken> = [
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options | SkipToken> = [
     queryRef: TOptions extends any ? TOptions extends SkipToken ? undefined : QueryRef_2<TData, TVariables, "complete" | "streaming" | ((OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"))> | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends false ? never : undefined) : never,
-    result: useBackgroundQuery.Result<TData, TVariables>
+    result: useBackgroundQuery.Result<TData, TVariables, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>
     ];
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: boolean;
                 fetchPolicy: "no-cache";
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: false;
-                errorPolicy: "ignore" | "all";
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: boolean;
-                errorPolicy: "ignore" | "all";
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
-                errorPolicy: "ignore" | "all";
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 skip: boolean;
                 returnPartialData: false;
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 skip: boolean;
                 returnPartialData: boolean;
+                errorPolicy?: TErrorPolicy;
             }): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: false;
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: boolean;
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 skip: boolean;
+                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
             <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): [undefined, useBackgroundQuery.Result<TData, TVariables>];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: false;
+                errorPolicy?: TErrorPolicy;
             })): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: boolean;
+                errorPolicy?: TErrorPolicy;
             })): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ] : [
+            options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ] : [
+            options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables>
+            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: boolean;
                 fetchPolicy: "no-cache";
             }): [
@@ -443,7 +494,7 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: false;
                 errorPolicy: "ignore" | "all";
             }): [
@@ -451,7 +502,7 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: boolean;
                 errorPolicy: "ignore" | "all";
             }): [
@@ -459,14 +510,14 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 skip: boolean;
                 returnPartialData: false;
             }): [
@@ -474,7 +525,7 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 skip: boolean;
                 returnPartialData: boolean;
             }): [
@@ -482,21 +533,21 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: false;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: boolean;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 skip: boolean;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
@@ -505,35 +556,35 @@ export namespace useBackgroundQuery {
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): [undefined, useBackgroundQuery.Result<TData, TVariables>];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: false;
             })): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: boolean;
             })): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: useBackgroundQuery.Options<NoInfer<TVariables>>
+            ] : [options: useBackgroundQuery.Options<NoInfer<TVariables>>]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>
+            ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>): [
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
@@ -542,13 +593,17 @@ export namespace useBackgroundQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useBackgroundQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>
+            ] : [
+            options: TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>
+            ]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>) | SkipToken
+            ] : [
+            options: (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>) | SkipToken
+            ]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
         }
     }
 }
@@ -605,9 +660,9 @@ export namespace useFragment {
     }
     // (undocumented)
     export namespace DocumentationTypes {
-        export function useFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ fragment, from, fragmentName, variables, optimistic, client, }: useFragment.Options<TData, TVariables>): useFragment.Result<TData>;
+        export function useFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: useFragment.Options<TData, TVariables>): useFragment.Result<TData>;
     }
-    export type FromOptionValue<TData> = ApolloCache_2.FromOptionValue<TData>;
+    export type FromOptionValue<TData> = ApolloCache.FromOptionValue<TData>;
     // (undocumented)
     export interface Options<TData, TVariables extends OperationVariables> {
         client?: ApolloClient;
@@ -615,7 +670,7 @@ export namespace useFragment {
         fragmentName?: string;
         from: useFragment.FromOptionValue<TData> | Array<useFragment.FromOptionValue<TData> | null> | null;
         optimistic?: boolean;
-        variables?: NoInfer_2<TVariables>;
+        variables?: NoInfer<TVariables>;
     }
     // (undocumented)
     export type Result<TData> = ({
@@ -641,15 +696,15 @@ export namespace useLazyQuery {
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData, TVariables extends OperationVariables> {
+        export interface Result<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error?: ErrorLike;
-            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>>>;
+            fetchMore: FetchMoreFunction<TData, TVariables>;
             loading: boolean;
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
             previousData?: MaybeMasked<TData>;
-            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
+            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
             startPolling: (pollInterval: number) => void;
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -692,7 +747,7 @@ export namespace useLazyQuery {
     export namespace DocumentationTypes {
         // (undocumented)
         export namespace useLazyQuery {
-            export type { ResultTuple };
+            export export type { ResultTuple };
         }
     }
     // (undocumented)
@@ -708,9 +763,9 @@ export namespace useLazyQuery {
         }
     }
     // (undocumented)
-    export type ExecFunction<TData, TVariables extends OperationVariables> = (...args: {} extends TVariables ? [
+    export type ExecFunction<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...args: {} extends TVariables ? [
     options?: useLazyQuery.ExecOptions<TVariables>
-    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData>>;
+    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData, TErrorPolicy>>;
     // (undocumented)
     export type ExecOptions<TVariables extends OperationVariables = OperationVariables> = {
         context?: DefaultContext;
@@ -729,7 +784,13 @@ export namespace useLazyQuery {
         skipPollAttempt?: () => boolean;
     }
     // (undocumented)
-    export type Result<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & (({
+    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useLazyQuery.Options<any, any>> extends (infer InvalidOptionNames extends string) ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never;
+    // (undocumented)
+    export type Result<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TErrorPolicy> & (({
         called: true;
         variables: TVariables;
     } & GetDataState<MaybeMasked<TData>, TStates>) | {
@@ -739,44 +800,44 @@ export namespace useLazyQuery {
         dataState: "empty";
     });
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables>> = ResultTuple<TData, TVariables, "complete" | "streaming" | "empty" | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial")>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables>> = ResultTuple<TData, TVariables, "complete" | "streaming" | "empty" | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
     // (undocumented)
-    export type ResultTuple<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
-    execute: ExecFunction<TData, TVariables>,
-    result: useLazyQuery.Result<TData, TVariables, TStates>
+    export type ResultTuple<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
+    execute: ExecFunction<TData, TVariables, TErrorPolicy>,
+    result: useLazyQuery.Result<TData, TVariables, TStates, TErrorPolicy>
     ];
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                returnPartialData: true;
+                errorPolicy?: TErrorPolicy;
+            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                returnPartialData: boolean;
+                errorPolicy?: TErrorPolicy;
+            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming", TErrorPolicy>;
+            // @deprecated (undocumented)
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: true;
             }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
-                returnPartialData: boolean;
-            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
-                returnPartialData: true;
-            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: boolean;
             }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>>): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode | TypedDocumentNode<TData, TVariables>): useLazyQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
-                variables?: {
-                    [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-                };
-            }>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: TOptions): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>>>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: TOptions & useLazyQuery.OptionsFor<TOptions>): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -804,9 +865,9 @@ export namespace useLoadableQuery {
     // (undocumented)
     export type FetchPolicy = Extract<WatchQueryFetchPolicy, "cache-first" | "network-only" | "no-cache" | "cache-and-network">;
     // (undocumented)
-    export interface Handlers<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
+    export interface Handlers<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
         fetchMore: FetchMoreFunction<TData, TVariables>;
-        refetch: RefetchFunction<TData, TVariables>;
+        refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
         // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
         reset: ResetFunction;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -825,29 +886,38 @@ export namespace useLoadableQuery {
         returnPartialData?: boolean;
     }
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
+    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useLoadableQuery.Options> extends (infer InvalidOptionNames extends string) ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never;
+    // (undocumented)
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
     loadQuery: LoadQueryFunction<TVariables>,
     queryRef: QueryRef_2<TData, TVariables, TStates> | null,
-    handlers: Handlers<TData, TVariables>
+    handlers: Handlers<TData, TVariables, TErrorPolicy>
     ];
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options> = Result<TData, TVariables, "complete" | "streaming" | (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends ("none") ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial")>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options> = Result<TData, TVariables, "complete" | "streaming" | (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends ("none") ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
-                errorPolicy: "ignore" | "all";
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
-                errorPolicy: "ignore" | "all";
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useLoadableQuery.Options): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming">;
+                errorPolicy?: TErrorPolicy;
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useLoadableQuery.Options & {
+                errorPolicy?: TErrorPolicy;
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming", TErrorPolicy>;
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
@@ -868,7 +938,7 @@ export namespace useLoadableQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>): useLoadableQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useLoadableQuery.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: TOptions): useLoadableQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends useLoadableQuery.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: TOptions & useLoadableQuery.OptionsFor<TOptions>): useLoadableQuery.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -913,7 +983,7 @@ export namespace useMutation {
         }
     }
     // (undocumented)
-    export type MutationFunction<TData, TVariables extends OperationVariables, TCache extends ApolloCache = ApolloCache, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...[options]: {} extends TVariables ? [
+    export type MutationFunction<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...input: {} extends TVariables ? [
     options?: MutationFunctionOptions<TData, TVariables, TCache> & {
         variables?: TVariables;
     }
@@ -923,11 +993,11 @@ export namespace useMutation {
     }
     ]) => Promise<ApolloClient.MutateResult<MaybeMasked<TData>, TErrorPolicy>>;
     // (undocumented)
-    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = Options<TData, TVariables, TCache> & {
+    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation> = Options<TData, TVariables, TCache> & {
         context?: DefaultContext | ((hookContext: DefaultContext | undefined) => DefaultContext);
     };
     // (undocumented)
-    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
+    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
         awaitRefetchQueries?: boolean;
         client?: ApolloClient;
         context?: DefaultContext;
@@ -938,25 +1008,29 @@ export namespace useMutation {
         onCompleted?: (data: MaybeMasked<TData>, clientOptions?: Options<TData, TVariables, TCache>) => void;
         onError?: (error: ErrorLike, clientOptions?: Options<TData, TVariables, TCache>) => void;
         onQueryUpdated?: OnQueryUpdated<any>;
-        optimisticResponse?: Unmasked<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
+        optimisticResponse?: Unmasked<NoInfer<TData>> | ((vars: TVariables, input: {
             IGNORE: IgnoreModifier;
-        }) => Unmasked<NoInfer_2<TData>> | IgnoreModifier);
+        }) => Unmasked<NoInfer<TData>> | IgnoreModifier);
         refetchQueries?: ((result: NormalizedExecutionResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
         update?: MutationUpdaterFunction<TData, TVariables, TCache>;
         updateQueries?: MutationQueryReducersMap<TData>;
         variables?: Partial<TVariables> & TConfiguredVariables;
     }
     // (undocumented)
+    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useMutation.Options<any, any, any, any>> extends infer InvalidOptionNames extends string ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never;
+    // (undocumented)
     export type Result<TData = unknown, TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result & ResultStateMap<TData>[`${TErrorPolicy}`];
     // Warning: (ae-forgotten-export) The symbol "MakeRequiredVariablesOptional" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ExtractConfiguredVariables" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, never> | Options<TData, TVariables, TCache>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, ExtractConfiguredVariables<TOptions, TVariables>>, TCache, [
-    TErrorPolicy
-    ] extends [undefined] ? DefaultOptions extends {
-        errorPolicy: infer D;
-    } ? D : undefined : TErrorPolicy>>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation, TOptions extends Record<string, never> | Options<TData, TVariables, TCache>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, ExtractConfiguredVariables<TOptions, TVariables>>, TCache, OptionWithFallback<{
+        errorPolicy: TErrorPolicy;
+    }, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
     export type ResultStateMap<TData = unknown> = {
         none: {
             data: MaybeMasked<TData> | null | undefined;
@@ -976,7 +1050,7 @@ export namespace useMutation {
         };
     };
     // (undocumented)
-    export type ResultTuple<TData, TVariables extends OperationVariables, TCache extends ApolloCache = ApolloCache, TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
+    export type ResultTuple<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
     mutate: MutationFunction<TData, TVariables, TCache, TErrorPolicy>,
     result: Result<TData, TErrorPolicy>
     ];
@@ -988,13 +1062,13 @@ export namespace useMutation {
         // (undocumented)
         export interface Classic {
             // (undocumented)
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, ApolloCache, {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer<TData>, NoInfer<TVariables>, Cache_2.Implementation, {
                 [K in keyof TConfiguredVariables]: K extends keyof TVariables ? TConfiguredVariables[K] : never;
             }> & {
                 errorPolicy?: TErrorPolicy;
-            }): useMutation.ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>, ApolloCache, TErrorPolicy>;
+            }): useMutation.ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>, Cache_2.Implementation, TErrorPolicy>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TCache, {
+            <TData, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer<TData>, NoInfer<TVariables>, TCache, {
                 [K in keyof TConfiguredVariables]: K extends keyof TVariables ? TConfiguredVariables[K] : never;
             }> & (TErrorPolicy extends undefined ? {} : {
                 errorPolicy: TErrorPolicy;
@@ -1005,15 +1079,15 @@ export namespace useMutation {
         // (undocumented)
         export interface Modern {
             // (undocumented)
-            <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends never>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>): useMutation.ResultForOptions<TData, TVariables, TCache, Record<string, never>>;
+            <TData, TVariables extends OperationVariables, TOptions extends never>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>): useMutation.ResultForOptions<TData, TVariables, Cache_2.Implementation, Record<string, never>>;
             // (undocumented)
-            <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TCache> & {
+            <TData, TVariables extends OperationVariables, TOptions extends useMutation.Options<NoInfer<TData>, NoInfer<TVariables>, Cache_2.Implementation> & {
                 variables?: {
                     [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
                 };
-            }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: TOptions & {
+            }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: TOptions & useMutation.OptionsFor<TOptions> & {
                 errorPolicy?: TErrorPolicy;
-            }): useMutation.ResultForOptions<TData, TVariables, TCache, TOptions, TErrorPolicy>;
+            }): useMutation.ResultForOptions<TData, TVariables, Cache_2.Implementation, TOptions, TErrorPolicy>;
         }
     }
 }
@@ -1041,20 +1115,21 @@ export namespace useQuery {
             skip?: boolean;
             skipPollAttempt?: () => boolean;
             ssr?: boolean;
+            variables?: unknown;
         }
     }
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables> {
+        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error?: ErrorLike;
-            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TFetchData>>>;
+            fetchMore: FetchMoreFunction<TData, TVariables>;
             loading: boolean;
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
             previousData?: MaybeMasked_2<TData>;
-            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TData>>>;
+            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
             startPolling: (pollInterval: number) => void;
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1072,7 +1147,8 @@ export namespace useQuery {
         // (undocumented)
         export namespace useQuery {
             // (undocumented)
-            export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> extends Base.Options<TData, TVariables>, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> extends Base.Options<TData, TVariables> {
+                variables?: TVariables;
             }
         }
     }
@@ -1100,62 +1176,88 @@ export namespace useQuery {
     // (undocumented)
     export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<TVariables>;
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables> = Base.Result<TData, TVariables, TReturnVariables> & GetDataState<MaybeMasked_2<TData>, TStates>;
+    export type OptionsFor<TData, TVariables extends OperationVariables, TOptions extends {
+        variables?: unknown;
+    }> = useQuery.Options<TData, NoInfer<TVariables>> & {
+        variables?: Prettify<TVariables & {
+            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
+        }>;
+    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useQuery.Options<TData, TVariables>> extends infer InvalidOptionNames extends string ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never);
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never)>>;
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TReturnVariables, TErrorPolicy> & GetDataState<MaybeMasked_2<TData>, TStates>;
+    // (undocumented)
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never), TVariables, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: true;
-            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
+                errorPolicy?: TErrorPolicy;
+            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TVariables, TErrorPolicy>;
             <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: true;
-            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>, TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: boolean;
-            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TVariables, TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: boolean;
-            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
-            ] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+                errorPolicy?: TErrorPolicy;
+            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>, TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
             ] : [
-            options: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
-            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>>;
+            options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", TVariables, TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ] : [
+            options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>, TErrorPolicy>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: true;
             }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: true;
             })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: boolean;
             }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
                 returnPartialData: boolean;
             })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
-            ] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
+            ] : [options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: SkipToken | useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
             ] : [
-            options: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+            options: SkipToken | useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
             ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>>;
             // (undocumented)
             ssrDisabledResult: ObservableQuery.Result<any>;
@@ -1164,20 +1266,20 @@ export namespace useQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: [
             TVariables
-            ] extends [never] ? [options: never] : {} extends TVariables ? [options?: TOptions] : [
-            options: TOptions
+            ] extends [never] ? [options: never] : {} extends TVariables ? [
+            options?: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>
+            ] : [
+            options: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends SkipToken>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: [
             TVariables
-            ] extends [never] ? [options: never] : {} extends TVariables ? [options?: TOptions | SkipToken] : [
-            options: TOptions | SkipToken
+            ] extends [never] ? [options: never] : {} extends TVariables ? [
+            options?: (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>) | SkipToken
+            ] : [
+            options: (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>) | SkipToken
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
             // (undocumented)
             ssrDisabledResult: ObservableQuery.Result<any>;
@@ -1242,10 +1344,10 @@ export namespace useReadQuery {
 export type UseReadQueryResult<TData = unknown> = useReadQuery.Result<TData>;
 
 // @public
-export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, ...[options]: {} extends (TVariables) ? [
-options?: SkipToken | useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, ...input: {} extends (TVariables) ? [
+options?: SkipToken | useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>
 ] : [
-options: SkipToken | useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+options: SkipToken | useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>
 ]): useSubscription.Result<TData>;
 
 // @public (undocumented)
@@ -1386,9 +1488,9 @@ export namespace useSuspenseFragment {
     export namespace DocumentationTypes {
         export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: useSuspenseFragment.Options<TData, TVariables>): useSuspenseFragment.Result<TData>;
     }
-    export type FromOptionValue<TData> = ApolloCache_2.FromOptionValue<TData>;
+    export type FromOptionValue<TData> = ApolloCache.FromOptionValue<TData>;
     // (undocumented)
-    export type Options<TData, TVariables extends OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<NoInfer_2<TVariables>>;
+    export type Options<TData, TVariables extends OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<NoInfer<TVariables>>;
     // (undocumented)
     export interface Result<TData> {
         // (undocumented)
@@ -1418,17 +1520,18 @@ export namespace useSuspenseQuery {
             returnPartialData?: boolean;
             // @deprecated
             skip?: boolean;
+            variables?: unknown;
         }
     }
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
+        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
             client: ApolloClient;
             error: ErrorLike | undefined;
             fetchMore: FetchMoreFunction<TData, TVariables>;
             networkStatus: NetworkStatus;
-            refetch: RefetchFunction<TData, TVariables>;
+            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
         }
     }
@@ -1442,7 +1545,8 @@ export namespace useSuspenseQuery {
         // (undocumented)
         export namespace useSuspenseQuery {
             // (undocumented)
-            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options<TVariables>, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options<TVariables> {
+                variables?: TVariables;
             }
         }
     }
@@ -1472,91 +1576,125 @@ export namespace useSuspenseQuery {
     // (undocumented)
     export type Options<TVariables extends OperationVariables = OperationVariables> = Base.Options<TVariables> & VariablesOption<TVariables>;
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & GetDataState<MaybeMasked<TData>, TStates>;
+    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
+        variables?: unknown;
+    }> = useSuspenseQuery.Options<NoInfer<TVariables>> & {
+        variables?: Prettify<TVariables & {
+            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
+        }>;
+    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useSuspenseQuery.Options<any>> extends infer InvalidOptionNames extends string ? [
+    InvalidOptionNames
+    ] extends [never] ? unknown : {
+        [K in InvalidOptionNames]: never;
+    } : never);
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TVariables> | SkipToken> = Result<TData, TVariables, "complete" | "streaming" | (TOptions extends any ? TOptions extends SkipToken ? "empty" : (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends (false) ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial") : never) | ([TOptions] extends [SkipToken] ? DefaultOptions extends {
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TErrorPolicy> & GetDataState<MaybeMasked<TData>, TStates>;
+    // (undocumented)
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TVariables> | SkipToken> = Result<TData, TVariables, "complete" | "streaming" | (TOptions extends any ? TOptions extends SkipToken ? "empty" : (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends (false) ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial") : never) | ([TOptions] extends [SkipToken] ? DefaultOptions extends {
         returnPartialData: false;
-    } ? never : "partial" : never)>;
+    } ? never : "partial" : never), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                returnPartialData: true;
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                skip: boolean;
+                returnPartialData: true;
+                errorPolicy?: TErrorPolicy;
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                returnPartialData: true;
+                errorPolicy?: TErrorPolicy;
+            }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                skip: boolean;
+                errorPolicy?: TErrorPolicy;
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                returnPartialData: true;
+                errorPolicy?: TErrorPolicy;
+            })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ] : [
+            options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            }
+            ]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ] : [
+            options: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })
+            ]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy?: TErrorPolicy;
+            })): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            // @deprecated (undocumented)
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: true;
                 errorPolicy: "ignore" | "all";
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
-                errorPolicy: "ignore" | "all";
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
-                skip: boolean;
-                returnPartialData: true;
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
-                returnPartialData: true;
-            }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
-                skip: boolean;
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
-                returnPartialData: true;
-            })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
-                returnPartialData: true;
-                errorPolicy: "ignore" | "all";
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
                 skip: boolean;
                 returnPartialData: true;
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: true;
             }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
                 skip: boolean;
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
                 returnPartialData: true;
             })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: useSuspenseQuery.Options<NoInfer<TVariables>>
+            ] : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
-            options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>
-            ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>
+            ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useSuspenseQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>
+            ] : [
+            options: TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>
+            ]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
-                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
-            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
+            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
+            options?: (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>) | SkipToken
+            ] : [
+            options: (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>) | SkipToken
+            ]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
         }
     }
 }

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -4,9 +4,9 @@
 
 ```ts
 
-import type { ApolloCache } from '@apollo/client/cache';
+import type { ApolloCache } from '@apollo/client';
+import type { ApolloCache as ApolloCache_2 } from '@apollo/client/cache';
 import type { ApolloClient } from '@apollo/client';
-import type { Cache as Cache_2 } from '@apollo/client/cache';
 import type { DataState } from '@apollo/client';
 import type { DataValue } from '@apollo/client';
 import type { DefaultContext } from '@apollo/client';
@@ -30,6 +30,7 @@ import type { MutationFetchPolicy } from '@apollo/client';
 import type { MutationQueryReducersMap } from '@apollo/client';
 import type { MutationUpdaterFunction } from '@apollo/client';
 import { NetworkStatus } from '@apollo/client';
+import type { NoInfer as NoInfer_2 } from '@apollo/client/utilities/internal';
 import type { NormalizedExecutionResult } from '@apollo/client';
 import type { ObservableQuery } from '@apollo/client';
 import type { OnQueryUpdated } from '@apollo/client';
@@ -96,7 +97,7 @@ export function getApolloContext(): ReactTypes.Context<ApolloContextValue>;
 
 // @internal @deprecated (undocumented)
 export namespace InternalTypes {
-    export export type { HookWrappers };
+    export type { HookWrappers };
 }
 
 // @public @deprecated (undocumented)
@@ -129,16 +130,16 @@ type MakeRequiredVariablesOptional<TVariables extends OperationVariables, TConfi
 } & Omit<TVariables, keyof TConfiguredVariables>>;
 
 // @public @deprecated (undocumented)
-export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
+export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.MutationFunctionOptions<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
-export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.Options<TData, TVariables, TCache>;
+export type MutationHookOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.Options<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
 export type MutationResult<TData = unknown> = useMutation.Result<TData>;
 
 // @public @deprecated (undocumented)
-export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext, TCache extends Cache_2.Implementation = Cache_2.Implementation> = useMutation.ResultTuple<TData, TVariables, TCache>;
+export type MutationTuple<TData, TVariables extends OperationVariables, _TContext = DefaultContext, TCache extends ApolloCache = ApolloCache> = useMutation.ResultTuple<TData, TVariables, TCache>;
 
 // @public @deprecated (undocumented)
 export type OnDataOptions<TData = unknown> = useSubscription.OnDataOptions<TData>;
@@ -168,19 +169,7 @@ export namespace PreloadQueryFunction {
         }
     }
     // (undocumented)
-    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
-        variables?: unknown;
-    }> = PreloadQueryOptions<NoInfer<TVariables>> & {
-        variables?: Prettify<TVariables & {
-            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
-        }>;
-    } & (Exclude<keyof TOptions, keyof PreloadQueryOptions<any>> extends (infer InvalidOptionNames extends string) ? [
-    InvalidOptionNames
-    ] extends [never] ? unknown : {
-        [K in InvalidOptionNames]: never;
-    } : never);
-    // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Omit<PreloadQueryOptions<any>, "variables">> = TOptions extends any ? PreloadedQueryRef_2<TData, TVariables, ResultForOptions.States<TOptions, DefaultOptions>> : never;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | PreloadQueryOptions<TVariables>> = TOptions extends any ? PreloadedQueryRef_2<TData, TVariables, ResultForOptions.States<TOptions, DefaultOptions>> : never;
     // (undocumented)
     export namespace ResultForOptions {
         // (undocumented)
@@ -190,48 +179,44 @@ export namespace PreloadQueryFunction {
     export namespace Signatures {
         // (undocumented)
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
                 errorPolicy: "ignore" | "all";
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: PreloadQueryOptions<NoInfer<TVariables>>
-            ] : [options: PreloadQueryOptions<NoInfer<TVariables>>]): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: PreloadQueryOptions<NoInfer_2<TVariables>>
+            ] : [options: PreloadQueryOptions<NoInfer_2<TVariables>>]): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
                 errorPolicy: "ignore" | "all";
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: PreloadQueryOptions<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             }): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: PreloadQueryOptions<NoInfer<TVariables>>
-            ] : [options: PreloadQueryOptions<NoInfer<TVariables>>]): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: PreloadQueryOptions<NoInfer_2<TVariables>>
+            ] : [options: PreloadQueryOptions<NoInfer_2<TVariables>>]): PreloadedQueryRef_2<TData, TVariables, "complete" | "streaming">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): PreloadQueryFunction.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Omit<PreloadQueryOptions<any>, "variables"> & {
-                variables?: unknown;
-            }>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: TOptions & PreloadQueryFunction.OptionsFor<TVariables, TOptions>
-            ] : [
-            options: TOptions & PreloadQueryFunction.OptionsFor<TVariables, TOptions>
-            ]): PreloadQueryFunction.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends PreloadQueryOptions<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
+                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
+            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): PreloadQueryFunction.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -298,7 +283,6 @@ export namespace useBackgroundQuery {
             returnPartialData?: boolean;
             // @deprecated
             skip?: boolean;
-            variables?: unknown;
         }
     }
     // (undocumented)
@@ -311,8 +295,7 @@ export namespace useBackgroundQuery {
         // (undocumented)
         export namespace useBackgroundQuery {
             // (undocumented)
-            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options {
-                variables?: TVariables;
+            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options, DocumentationTypes.VariableOptions<TVariables> {
             }
         }
     }
@@ -348,145 +331,111 @@ export namespace useBackgroundQuery {
     // (undocumented)
     export type Options<TVariables extends OperationVariables = OperationVariables> = Base.Options & VariablesOption<TVariables>;
     // (undocumented)
-    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
-        variables?: unknown;
-    }> = useBackgroundQuery.Options<NoInfer<TVariables>> & {
-        variables?: Prettify<TVariables & {
-            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
-        }>;
-    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useBackgroundQuery.Options<any>> extends infer InvalidOptionNames extends string ? [
-    InvalidOptionNames
-    ] extends [never] ? unknown : {
-        [K in InvalidOptionNames]: never;
-    } : never);
-    // (undocumented)
-    export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
+    export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
         fetchMore: FetchMoreFunction<TData, TVariables>;
-        refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
+        refetch: RefetchFunction<TData, TVariables>;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
     }
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options | SkipToken> = [
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TVariables> | SkipToken> = [
     queryRef: TOptions extends any ? TOptions extends SkipToken ? undefined : QueryRef_2<TData, TVariables, "complete" | "streaming" | ((OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"))> | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends false ? never : undefined) : never,
-    result: useBackgroundQuery.Result<TData, TVariables, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>
+    result: useBackgroundQuery.Result<TData, TVariables>
     ];
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
                 fetchPolicy: "no-cache";
-                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
-                errorPolicy: TErrorPolicy & ("ignore" | "all");
+                errorPolicy: "ignore" | "all";
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-                errorPolicy: TErrorPolicy & ("ignore" | "all");
+                errorPolicy: "ignore" | "all";
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy: TErrorPolicy & ("ignore" | "all");
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy: "ignore" | "all";
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: false;
-                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: boolean;
-                errorPolicy?: TErrorPolicy;
             }): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
-                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
-                errorPolicy?: TErrorPolicy;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
             <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): [undefined, useBackgroundQuery.Result<TData, TVariables>];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
-                errorPolicy?: TErrorPolicy;
             })): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-                errorPolicy?: TErrorPolicy;
             })): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: useBackgroundQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            }
-            ] : [
-            options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            }
-            ]): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>
+            ] : [options: useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            })
-            ] : [
-            options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            })
-            ]): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>
+            ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            })): [
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
-            useBackgroundQuery.Result<TData, TVariables, TErrorPolicy>
+            useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
                 fetchPolicy: "no-cache";
             }): [
@@ -494,7 +443,7 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
                 errorPolicy: "ignore" | "all";
             }): [
@@ -502,7 +451,7 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
                 errorPolicy: "ignore" | "all";
             }): [
@@ -510,14 +459,14 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "empty">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: false;
             }): [
@@ -525,7 +474,7 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: boolean;
             }): [
@@ -533,21 +482,21 @@ export namespace useBackgroundQuery {
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
             }): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
@@ -556,35 +505,35 @@ export namespace useBackgroundQuery {
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): [undefined, useBackgroundQuery.Result<TData, TVariables>];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: false;
             })): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useBackgroundQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             })): [
             (QueryRef_2<TData, TVariables, "complete" | "streaming" | "partial"> | undefined),
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: useBackgroundQuery.Options<NoInfer<TVariables>>
-            ] : [options: useBackgroundQuery.Options<NoInfer<TVariables>>]): [
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useBackgroundQuery.Options<NoInfer_2<TVariables>>
+            ] : [options: useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming">,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>
-            ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>]): [
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>
+            ] : [options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>]): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer<TVariables>>): [
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useBackgroundQuery.Options<NoInfer_2<TVariables>>): [
             QueryRef_2<TData, TVariables, "complete" | "streaming"> | undefined,
             useBackgroundQuery.Result<TData, TVariables>
             ];
@@ -593,17 +542,13 @@ export namespace useBackgroundQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useBackgroundQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>
-            ] : [
-            options: TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>
-            ]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
+                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
+            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useBackgroundQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>) | SkipToken
-            ] : [
-            options: (TOptions & useBackgroundQuery.OptionsFor<TVariables, TOptions>) | SkipToken
-            ]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
+            <TData, TVariables extends OperationVariables, TOptions extends useBackgroundQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
+                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
+            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useBackgroundQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
         }
     }
 }
@@ -660,9 +605,9 @@ export namespace useFragment {
     }
     // (undocumented)
     export namespace DocumentationTypes {
-        export function useFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: useFragment.Options<TData, TVariables>): useFragment.Result<TData>;
+        export function useFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ fragment, from, fragmentName, variables, optimistic, client, }: useFragment.Options<TData, TVariables>): useFragment.Result<TData>;
     }
-    export type FromOptionValue<TData> = ApolloCache.FromOptionValue<TData>;
+    export type FromOptionValue<TData> = ApolloCache_2.FromOptionValue<TData>;
     // (undocumented)
     export interface Options<TData, TVariables extends OperationVariables> {
         client?: ApolloClient;
@@ -670,7 +615,7 @@ export namespace useFragment {
         fragmentName?: string;
         from: useFragment.FromOptionValue<TData> | Array<useFragment.FromOptionValue<TData> | null> | null;
         optimistic?: boolean;
-        variables?: NoInfer<TVariables>;
+        variables?: NoInfer_2<TVariables>;
     }
     // (undocumented)
     export type Result<TData> = ({
@@ -696,15 +641,15 @@ export namespace useLazyQuery {
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
+        export interface Result<TData, TVariables extends OperationVariables> {
             client: ApolloClient;
             error?: ErrorLike;
-            fetchMore: FetchMoreFunction<TData, TVariables>;
+            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked<TFetchData>>>;
             loading: boolean;
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
             previousData?: MaybeMasked<TData>;
-            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
+            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked<TData>>>;
             startPolling: (pollInterval: number) => void;
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -747,7 +692,7 @@ export namespace useLazyQuery {
     export namespace DocumentationTypes {
         // (undocumented)
         export namespace useLazyQuery {
-            export export type { ResultTuple };
+            export type { ResultTuple };
         }
     }
     // (undocumented)
@@ -763,9 +708,9 @@ export namespace useLazyQuery {
         }
     }
     // (undocumented)
-    export type ExecFunction<TData, TVariables extends OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...args: {} extends TVariables ? [
+    export type ExecFunction<TData, TVariables extends OperationVariables> = (...args: {} extends TVariables ? [
     options?: useLazyQuery.ExecOptions<TVariables>
-    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData, TErrorPolicy>>;
+    ] : [options: useLazyQuery.ExecOptions<TVariables>]) => ObservableQuery.ResultPromise<ApolloClient.QueryResult<TData>>;
     // (undocumented)
     export type ExecOptions<TVariables extends OperationVariables = OperationVariables> = {
         context?: DefaultContext;
@@ -784,13 +729,7 @@ export namespace useLazyQuery {
         skipPollAttempt?: () => boolean;
     }
     // (undocumented)
-    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useLazyQuery.Options<any, any>> extends (infer InvalidOptionNames extends string) ? [
-    InvalidOptionNames
-    ] extends [never] ? unknown : {
-        [K in InvalidOptionNames]: never;
-    } : never;
-    // (undocumented)
-    export type Result<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TErrorPolicy> & (({
+    export type Result<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & (({
         called: true;
         variables: TVariables;
     } & GetDataState<MaybeMasked<TData>, TStates>) | {
@@ -800,44 +739,44 @@ export namespace useLazyQuery {
         dataState: "empty";
     });
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables>> = ResultTuple<TData, TVariables, "complete" | "streaming" | "empty" | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables>> = ResultTuple<TData, TVariables, "complete" | "streaming" | "empty" | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial")>;
     // (undocumented)
-    export type ResultTuple<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
-    execute: ExecFunction<TData, TVariables, TErrorPolicy>,
-    result: useLazyQuery.Result<TData, TVariables, TStates, TErrorPolicy>
+    export type ResultTuple<TData, TVariables extends OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
+    execute: ExecFunction<TData, TVariables>,
+    result: useLazyQuery.Result<TData, TVariables, TStates>
     ];
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-                errorPolicy?: TErrorPolicy;
-            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-                errorPolicy?: TErrorPolicy;
-            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming", TErrorPolicy>;
+            }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             }): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>>): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>): useLazyQuery.ResultTuple<TData, TVariables, "empty" | "complete" | "streaming">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode | TypedDocumentNode<TData, TVariables>): useLazyQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useLazyQuery.Options<NoInfer<TData>, NoInfer<TVariables>>>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: TOptions & useLazyQuery.OptionsFor<TOptions>): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends useLazyQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
+                variables?: {
+                    [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
+                };
+            }>(query: DocumentNode | TypedDocumentNode<TData, TVariables>, options?: TOptions): useLazyQuery.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -865,9 +804,9 @@ export namespace useLoadableQuery {
     // (undocumented)
     export type FetchPolicy = Extract<WatchQueryFetchPolicy, "cache-first" | "network-only" | "no-cache" | "cache-and-network">;
     // (undocumented)
-    export interface Handlers<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
+    export interface Handlers<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
         fetchMore: FetchMoreFunction<TData, TVariables>;
-        refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
+        refetch: RefetchFunction<TData, TVariables>;
         // Warning: (ae-forgotten-export) The symbol "ResetFunction" needs to be exported by the entry point index.d.ts
         reset: ResetFunction;
         subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -886,38 +825,29 @@ export namespace useLoadableQuery {
         returnPartialData?: boolean;
     }
     // (undocumented)
-    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useLoadableQuery.Options> extends (infer InvalidOptionNames extends string) ? [
-    InvalidOptionNames
-    ] extends [never] ? unknown : {
-        [K in InvalidOptionNames]: never;
-    } : never;
-    // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = [
     loadQuery: LoadQueryFunction<TVariables>,
     queryRef: QueryRef_2<TData, TVariables, TStates> | null,
-    handlers: Handlers<TData, TVariables, TErrorPolicy>
+    handlers: Handlers<TData, TVariables>
     ];
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options> = Result<TData, TVariables, "complete" | "streaming" | (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends ("none") ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial"), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options> = Result<TData, TVariables, "complete" | "streaming" | (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends ("none") ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial")>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
-                errorPolicy: TErrorPolicy & ("ignore" | "all");
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
-                errorPolicy: TErrorPolicy & ("ignore" | "all");
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+                errorPolicy: "ignore" | "all";
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
+                errorPolicy: "ignore" | "all";
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
-                errorPolicy?: TErrorPolicy;
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useLoadableQuery.Options & {
-                errorPolicy?: TErrorPolicy;
-            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming", TErrorPolicy>;
+            }): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming" | "partial">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options?: useLoadableQuery.Options): useLoadableQuery.Result<TData, TVariables, "complete" | "streaming">;
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useLoadableQuery.Options & {
                 returnPartialData: true;
@@ -938,7 +868,7 @@ export namespace useLoadableQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>): useLoadableQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends useLoadableQuery.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: TOptions & useLoadableQuery.OptionsFor<TOptions>): useLoadableQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends useLoadableQuery.Options>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: TOptions): useLoadableQuery.ResultForOptions<TData, TVariables, TOptions>;
         }
     }
 }
@@ -983,7 +913,7 @@ export namespace useMutation {
         }
     }
     // (undocumented)
-    export type MutationFunction<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...input: {} extends TVariables ? [
+    export type MutationFunction<TData, TVariables extends OperationVariables, TCache extends ApolloCache = ApolloCache, TErrorPolicy extends ErrorPolicy | undefined = undefined> = (...[options]: {} extends TVariables ? [
     options?: MutationFunctionOptions<TData, TVariables, TCache> & {
         variables?: TVariables;
     }
@@ -993,11 +923,11 @@ export namespace useMutation {
     }
     ]) => Promise<ApolloClient.MutateResult<MaybeMasked<TData>, TErrorPolicy>>;
     // (undocumented)
-    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation> = Options<TData, TVariables, TCache> & {
+    export type MutationFunctionOptions<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache> = Options<TData, TVariables, TCache> & {
         context?: DefaultContext | ((hookContext: DefaultContext | undefined) => DefaultContext);
     };
     // (undocumented)
-    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
+    export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TConfiguredVariables extends Partial<TVariables> = Partial<TVariables>> {
         awaitRefetchQueries?: boolean;
         client?: ApolloClient;
         context?: DefaultContext;
@@ -1008,29 +938,25 @@ export namespace useMutation {
         onCompleted?: (data: MaybeMasked<TData>, clientOptions?: Options<TData, TVariables, TCache>) => void;
         onError?: (error: ErrorLike, clientOptions?: Options<TData, TVariables, TCache>) => void;
         onQueryUpdated?: OnQueryUpdated<any>;
-        optimisticResponse?: Unmasked<NoInfer<TData>> | ((vars: TVariables, input: {
+        optimisticResponse?: Unmasked<NoInfer_2<TData>> | ((vars: TVariables, { IGNORE }: {
             IGNORE: IgnoreModifier;
-        }) => Unmasked<NoInfer<TData>> | IgnoreModifier);
+        }) => Unmasked<NoInfer_2<TData>> | IgnoreModifier);
         refetchQueries?: ((result: NormalizedExecutionResult<Unmasked<TData>>) => InternalRefetchQueriesInclude) | InternalRefetchQueriesInclude;
         update?: MutationUpdaterFunction<TData, TVariables, TCache>;
         updateQueries?: MutationQueryReducersMap<TData>;
         variables?: Partial<TVariables> & TConfiguredVariables;
     }
     // (undocumented)
-    export type OptionsFor<TOptions> = Exclude<keyof TOptions, keyof useMutation.Options<any, any, any, any>> extends infer InvalidOptionNames extends string ? [
-    InvalidOptionNames
-    ] extends [never] ? unknown : {
-        [K in InvalidOptionNames]: never;
-    } : never;
-    // (undocumented)
     export type Result<TData = unknown, TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result & ResultStateMap<TData>[`${TErrorPolicy}`];
     // Warning: (ae-forgotten-export) The symbol "MakeRequiredVariablesOptional" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ExtractConfiguredVariables" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation, TOptions extends Record<string, never> | Options<TData, TVariables, TCache>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, ExtractConfiguredVariables<TOptions, TVariables>>, TCache, OptionWithFallback<{
-        errorPolicy: TErrorPolicy;
-    }, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends Record<string, never> | Options<TData, TVariables, TCache>, TErrorPolicy extends ErrorPolicy | undefined = undefined> = LazyType<ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, ExtractConfiguredVariables<TOptions, TVariables>>, TCache, [
+    TErrorPolicy
+    ] extends [undefined] ? DefaultOptions extends {
+        errorPolicy: infer D;
+    } ? D : undefined : TErrorPolicy>>;
     export type ResultStateMap<TData = unknown> = {
         none: {
             data: MaybeMasked<TData> | null | undefined;
@@ -1050,7 +976,7 @@ export namespace useMutation {
         };
     };
     // (undocumented)
-    export type ResultTuple<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
+    export type ResultTuple<TData, TVariables extends OperationVariables, TCache extends ApolloCache = ApolloCache, TErrorPolicy extends ErrorPolicy | undefined = undefined> = [
     mutate: MutationFunction<TData, TVariables, TCache, TErrorPolicy>,
     result: Result<TData, TErrorPolicy>
     ];
@@ -1062,13 +988,13 @@ export namespace useMutation {
         // (undocumented)
         export interface Classic {
             // (undocumented)
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer<TData>, NoInfer<TVariables>, Cache_2.Implementation, {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, ApolloCache, {
                 [K in keyof TConfiguredVariables]: K extends keyof TVariables ? TConfiguredVariables[K] : never;
             }> & {
                 errorPolicy?: TErrorPolicy;
-            }): useMutation.ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>, Cache_2.Implementation, TErrorPolicy>;
+            }): useMutation.ResultTuple<TData, MakeRequiredVariablesOptional<TVariables, TConfiguredVariables>, ApolloCache, TErrorPolicy>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables, TCache extends Cache_2.Implementation = Cache_2.Implementation, TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer<TData>, NoInfer<TVariables>, TCache, {
+            <TData, TVariables extends OperationVariables = OperationVariables, TCache extends ApolloCache = ApolloCache, TConfiguredVariables extends Partial<TVariables> = {}, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TCache, {
                 [K in keyof TConfiguredVariables]: K extends keyof TVariables ? TConfiguredVariables[K] : never;
             }> & (TErrorPolicy extends undefined ? {} : {
                 errorPolicy: TErrorPolicy;
@@ -1079,15 +1005,15 @@ export namespace useMutation {
         // (undocumented)
         export interface Modern {
             // (undocumented)
-            <TData, TVariables extends OperationVariables, TOptions extends never>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>): useMutation.ResultForOptions<TData, TVariables, Cache_2.Implementation, Record<string, never>>;
+            <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends never>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>): useMutation.ResultForOptions<TData, TVariables, TCache, Record<string, never>>;
             // (undocumented)
-            <TData, TVariables extends OperationVariables, TOptions extends useMutation.Options<NoInfer<TData>, NoInfer<TVariables>, Cache_2.Implementation> & {
+            <TData, TVariables extends OperationVariables, TCache extends ApolloCache, TOptions extends useMutation.Options<NoInfer_2<TData>, NoInfer_2<TVariables>, TCache> & {
                 variables?: {
                     [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
                 };
-            }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: TOptions & useMutation.OptionsFor<TOptions> & {
+            }, TErrorPolicy extends ErrorPolicy | undefined = undefined>(mutation: DocumentNode_2 | TypedDocumentNode<TData, TVariables>, options?: TOptions & {
                 errorPolicy?: TErrorPolicy;
-            }): useMutation.ResultForOptions<TData, TVariables, Cache_2.Implementation, TOptions, TErrorPolicy>;
+            }): useMutation.ResultForOptions<TData, TVariables, TCache, TOptions, TErrorPolicy>;
         }
     }
 }
@@ -1115,21 +1041,20 @@ export namespace useQuery {
             skip?: boolean;
             skipPollAttempt?: () => boolean;
             ssr?: boolean;
-            variables?: unknown;
         }
     }
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
+        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TReturnVariables extends OperationVariables = TVariables> {
             client: ApolloClient;
             error?: ErrorLike;
-            fetchMore: FetchMoreFunction<TData, TVariables>;
+            fetchMore: <TFetchData = TData, TFetchVars extends OperationVariables = TVariables>(fetchMoreOptions: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TFetchData>>>;
             loading: boolean;
             networkStatus: NetworkStatus;
             observable: ObservableQuery<TData, TVariables>;
             previousData?: MaybeMasked_2<TData>;
-            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
+            refetch: (variables?: Partial<TVariables>) => Promise<ApolloClient.QueryResult<MaybeMasked_2<TData>>>;
             startPolling: (pollInterval: number) => void;
             stopPolling: () => void;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
@@ -1147,8 +1072,7 @@ export namespace useQuery {
         // (undocumented)
         export namespace useQuery {
             // (undocumented)
-            export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> extends Base.Options<TData, TVariables> {
-                variables?: TVariables;
+            export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> extends Base.Options<TData, TVariables>, DocumentationTypes.VariableOptions<TVariables> {
             }
         }
     }
@@ -1176,88 +1100,62 @@ export namespace useQuery {
     // (undocumented)
     export type Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<TVariables>;
     // (undocumented)
-    export type OptionsFor<TData, TVariables extends OperationVariables, TOptions extends {
-        variables?: unknown;
-    }> = useQuery.Options<TData, NoInfer<TVariables>> & {
-        variables?: Prettify<TVariables & {
-            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
-        }>;
-    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useQuery.Options<TData, TVariables>> extends infer InvalidOptionNames extends string ? [
-    InvalidOptionNames
-    ] extends [never] ? unknown : {
-        [K in InvalidOptionNames]: never;
-    } : never);
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables> = Base.Result<TData, TVariables, TReturnVariables> & GetDataState<MaybeMasked_2<TData>, TStates>;
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TReturnVariables extends OperationVariables = TVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TReturnVariables, TErrorPolicy> & GetDataState<MaybeMasked_2<TData>, TStates>;
-    // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never), TVariables, OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>>;
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TData, TVariables> | SkipToken> = LazyType<Result<TData, TVariables, "complete" | "streaming" | "empty" | (TOptions extends any ? TOptions extends SkipToken ? never : OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial" : never)>>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-                errorPolicy?: TErrorPolicy;
-            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TVariables, TErrorPolicy>;
+            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
             <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-                errorPolicy?: TErrorPolicy;
-            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>, TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-                errorPolicy?: TErrorPolicy;
-            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", TVariables, TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
-                errorPolicy?: TErrorPolicy;
-            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>, TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            }
+            })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+            ] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
             ] : [
-            options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            }
-            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", TVariables, TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            })
-            ] : [
-            options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            })
-            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>, TErrorPolicy>;
+            options: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+            ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
             <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             }): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer<TData>, NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>> & {
                 returnPartialData: boolean;
             })): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming" | "partial", Partial<TVariables>>;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
-            ] : [options: useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+            ] : [options: useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: SkipToken | useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
             ] : [
-            options: SkipToken | useQuery.Options<NoInfer<TData>, NoInfer<TVariables>>
+            options: SkipToken | useQuery.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
             ]): useQuery.Result<TData, TVariables, "empty" | "complete" | "streaming", Partial<TVariables>>;
             // (undocumented)
             ssrDisabledResult: ObservableQuery.Result<any>;
@@ -1266,20 +1164,20 @@ export namespace useQuery {
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: [
+            <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
+                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
+            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
             TVariables
-            ] extends [never] ? [options: never] : {} extends TVariables ? [
-            options?: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>
-            ] : [
-            options: TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>
+            ] extends [never] ? [options: never] : {} extends TVariables ? [options?: TOptions] : [
+            options: TOptions
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends SkipToken>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken): useQuery.Result<TData, TVariables, "empty", Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<TData, NoInfer<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: [
+            <TData, TVariables extends OperationVariables, TOptions extends useQuery.Options<TData, NoInfer_2<TVariables>> & VariablesOption<TVariables & {
+                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
+            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: [
             TVariables
-            ] extends [never] ? [options: never] : {} extends TVariables ? [
-            options?: (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>) | SkipToken
-            ] : [
-            options: (TOptions & useQuery.OptionsFor<TData, TVariables, TOptions>) | SkipToken
+            ] extends [never] ? [options: never] : {} extends TVariables ? [options?: TOptions | SkipToken] : [
+            options: TOptions | SkipToken
             ]): useQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
             // (undocumented)
             ssrDisabledResult: ObservableQuery.Result<any>;
@@ -1344,9 +1242,11 @@ export namespace useReadQuery {
 export type UseReadQueryResult<TData = unknown> = useReadQuery.Result<TData>;
 
 // @public
-export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, ...input: {} extends (TVariables) ? [
-options?: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>
-] : [options: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]): useSubscription.Result<TData>;
+export function useSubscription<TData = unknown, TVariables extends OperationVariables = OperationVariables>(subscription: DocumentNode | TypedDocumentNode<TData, TVariables>, ...[options]: {} extends (TVariables) ? [
+options?: SkipToken | useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+] : [
+options: SkipToken | useSubscription.Options<NoInfer_2<TData>, NoInfer_2<TVariables>>
+]): useSubscription.Result<TData>;
 
 // @public (undocumented)
 export namespace useSubscription {
@@ -1486,9 +1386,9 @@ export namespace useSuspenseFragment {
     export namespace DocumentationTypes {
         export function useSuspenseFragment<TData, TVariables extends OperationVariables = OperationVariables>(options: useSuspenseFragment.Options<TData, TVariables>): useSuspenseFragment.Result<TData>;
     }
-    export type FromOptionValue<TData> = ApolloCache.FromOptionValue<TData>;
+    export type FromOptionValue<TData> = ApolloCache_2.FromOptionValue<TData>;
     // (undocumented)
-    export type Options<TData, TVariables extends OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<NoInfer<TVariables>>;
+    export type Options<TData, TVariables extends OperationVariables> = Base.Options<TData, TVariables> & VariablesOption<NoInfer_2<TVariables>>;
     // (undocumented)
     export interface Result<TData> {
         // (undocumented)
@@ -1518,18 +1418,17 @@ export namespace useSuspenseQuery {
             returnPartialData?: boolean;
             // @deprecated
             skip?: boolean;
-            variables?: unknown;
         }
     }
     // (undocumented)
     export namespace Base {
         // (undocumented)
-        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TErrorPolicy extends ErrorPolicy | undefined = undefined> {
+        export interface Result<TData = unknown, TVariables extends OperationVariables = OperationVariables> {
             client: ApolloClient;
             error: ErrorLike | undefined;
             fetchMore: FetchMoreFunction<TData, TVariables>;
             networkStatus: NetworkStatus;
-            refetch: RefetchFunction<TData, TVariables, TErrorPolicy>;
+            refetch: RefetchFunction<TData, TVariables>;
             subscribeToMore: SubscribeToMoreFunction<TData, TVariables>;
         }
     }
@@ -1543,8 +1442,7 @@ export namespace useSuspenseQuery {
         // (undocumented)
         export namespace useSuspenseQuery {
             // (undocumented)
-            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options<TVariables> {
-                variables?: TVariables;
+            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options<TVariables>, DocumentationTypes.VariableOptions<TVariables> {
             }
         }
     }
@@ -1574,125 +1472,91 @@ export namespace useSuspenseQuery {
     // (undocumented)
     export type Options<TVariables extends OperationVariables = OperationVariables> = Base.Options<TVariables> & VariablesOption<TVariables>;
     // (undocumented)
-    export type OptionsFor<TVariables extends OperationVariables, TOptions extends {
-        variables?: unknown;
-    }> = useSuspenseQuery.Options<NoInfer<TVariables>> & {
-        variables?: Prettify<TVariables & {
-            [K in keyof TOptions["variables"]]: K extends keyof TVariables ? TVariables[K] : never;
-        }>;
-    } & (Exclude<keyof Exclude<TOptions, SkipToken>, keyof useSuspenseQuery.Options<any>> extends infer InvalidOptionNames extends string ? [
-    InvalidOptionNames
-    ] extends [never] ? unknown : {
-        [K in InvalidOptionNames]: never;
-    } : never);
+    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"]> = Base.Result<TData, TVariables> & GetDataState<MaybeMasked<TData>, TStates>;
     // (undocumented)
-    export type Result<TData = unknown, TVariables extends OperationVariables = OperationVariables, TStates extends DataState<TData>["dataState"] = DataState<TData>["dataState"], TErrorPolicy extends ErrorPolicy | undefined = undefined> = Base.Result<TData, TVariables, TErrorPolicy> & GetDataState<MaybeMasked<TData>, TStates>;
-    // (undocumented)
-    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Base.Options<TVariables> | SkipToken> = Result<TData, TVariables, "complete" | "streaming" | (TOptions extends any ? TOptions extends SkipToken ? "empty" : (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends (false) ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial") : never) | ([TOptions] extends [SkipToken] ? DefaultOptions extends {
+    export type ResultForOptions<TData, TVariables extends OperationVariables, TOptions extends Record<string, never> | Options<TVariables> | SkipToken> = Result<TData, TVariables, "complete" | "streaming" | (TOptions extends any ? TOptions extends SkipToken ? "empty" : (OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> extends "none" ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "skip"> extends (false) ? never : "empty") | (OptionWithFallback<TOptions, DefaultOptions, "returnPartialData"> extends false ? never : "partial") : never) | ([TOptions] extends [SkipToken] ? DefaultOptions extends {
         returnPartialData: false;
-    } ? never : "partial" : never), OptionWithFallback<TOptions, DefaultOptions, "errorPolicy"> & ErrorPolicy>;
+    } ? never : "partial" : never)>;
     export interface Signature extends Signatures.Evaluated {
     }
     // (undocumented)
     export namespace Signatures {
         export interface Classic {
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-                errorPolicy: TErrorPolicy & ("ignore" | "all");
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy: TErrorPolicy & ("ignore" | "all");
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+                errorPolicy: "ignore" | "all";
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
+                errorPolicy: "ignore" | "all";
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: true;
-                errorPolicy?: TErrorPolicy;
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-                errorPolicy?: TErrorPolicy;
-            }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
-                errorPolicy?: TErrorPolicy;
-            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
-                errorPolicy?: TErrorPolicy;
-            })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: useSuspenseQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            }
-            ] : [
-            options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            }
-            ]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            })
-            ] : [
-            options: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            })
-            ]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
-            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred", TErrorPolicy extends ErrorPolicy | undefined = undefined>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
-                errorPolicy?: TErrorPolicy;
-            })): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty", TErrorPolicy>;
+            })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>
+            ] : [options: useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>
+            ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+            <TData, TVariables extends OperationVariables, _INFERENCE_ONLY_DO_NOT_SPECIFY extends "inferred">(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
                 errorPolicy: "ignore" | "all";
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "partial" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 errorPolicy: "ignore" | "all";
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
                 returnPartialData: true;
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "empty" | "streaming" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             }): useSuspenseQuery.Result<TData, TVariables, "partial" | "streaming" | "complete">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 skip: boolean;
             }): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer<TVariables>> & {
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | (useSuspenseQuery.Options<NoInfer_2<TVariables>> & {
                 returnPartialData: true;
             })): useSuspenseQuery.Result<TData, TVariables, "empty" | "streaming" | "complete" | "partial">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: useSuspenseQuery.Options<NoInfer<TVariables>>
-            ] : [options: useSuspenseQuery.Options<NoInfer<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: useSuspenseQuery.Options<NoInfer_2<TVariables>>
+            ] : [options: useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>
-            ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [
+            options?: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>
+            ] : [options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>]): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
             // @deprecated (undocumented)
-            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer<TVariables>>): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
+            <TData, TVariables extends OperationVariables = OperationVariables>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, options: SkipToken | useSuspenseQuery.Options<NoInfer_2<TVariables>>): useSuspenseQuery.Result<TData, TVariables, "complete" | "streaming" | "empty">;
         }
         // (undocumented)
         export type Evaluated = SignatureStyle extends "classic" ? Classic : Modern;
         export interface Modern {
             <TData, TVariables extends OperationVariables, Options extends never>(query: {} extends TVariables ? DocumentNode_2 | TypedDocumentNode_2<TData, TVariables> : never): useSuspenseQuery.ResultForOptions<TData, TVariables, Record<string, never>>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>
-            ] : [
-            options: TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>
-            ]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
+            <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
+                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
+            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions] : [options: TOptions]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions>;
             <TData, TVariables extends OperationVariables, TOptions extends never>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, skipToken: SkipToken): useSuspenseQuery.ResultForOptions<TData, TVariables, SkipToken>;
-            <TData, TVariables extends OperationVariables, TOptions extends Base.Options<NoInfer<TVariables>>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...input: {} extends TVariables ? [
-            options?: (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>) | SkipToken
-            ] : [
-            options: (TOptions & useSuspenseQuery.OptionsFor<TVariables, TOptions>) | SkipToken
-            ]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
+            <TData, TVariables extends OperationVariables, TOptions extends useSuspenseQuery.Options<NoInfer_2<TVariables>> & VariablesOption<TVariables & {
+                [K in Exclude<keyof TOptions["variables"], keyof TVariables>]?: never;
+            }>>(query: DocumentNode_2 | TypedDocumentNode_2<TData, TVariables>, ...[options]: {} extends TVariables ? [options?: TOptions | SkipToken] : [options: TOptions | SkipToken]): useSuspenseQuery.ResultForOptions<TData, TVariables, TOptions | SkipToken>;
         }
     }
 }

--- a/.changeset/nice-donuts-subscribe.md
+++ b/.changeset/nice-donuts-subscribe.md
@@ -1,0 +1,16 @@
+---
+"@apollo/client": minor
+---
+
+Support `skipToken` with `useSubscription` to provide a more type-safe way to skip subscription execution with required variables.
+
+```ts
+import { skipToken, useSubscription } from "@apollo/client/react";
+
+// Use `skipToken` in place of `skip: true` for better type safety
+// for required variables
+const { data } = useSubscription(
+  SUBSCRIPTION,
+  id ? { variables: { id } } : skipToken
+);
+```

--- a/docs/source/api/react/skipToken.mdx
+++ b/docs/source/api/react/skipToken.mdx
@@ -7,11 +7,11 @@ description: Apollo Client API reference
 
 ## `skipToken`
 
-`skipToken` provides a type-safe mechanism to skip query execution. It is currently supported with `useQuery`, `useSuspenseQuery`, `useBackgroundQuery` and `useSubscription`.
+`skipToken` provides a type-safe mechanism to skip query execution. Use it with `useQuery`, `useSuspenseQuery`, `useBackgroundQuery`, and `useSubscription`.
 
-For the query hooks, when you pass a `skipToken` instead of the `options` object, the hook will not cause any requests or suspenseful behavior and keeps the last `data` available. It is typically used conditionally to start query execution when the input data is available.
+For the query hooks, passing `skipToken` instead of the `options` object prevents the hook from making requests or triggering suspenseful behavior while keeping the last `data` available. Use it conditionally to start query execution when the input data is available.
 
-For `useSubscription`, passing `skipToken` prevents the subscription from being set up. The hook returns an idle result with `data: undefined` instead of keeping prior subscription data, since a skipped subscription never establishes a connection to receive results. It is typically used conditionally to start the subscription when the input data is available.
+For `useSubscription`, passing `skipToken` prevents the subscription from being set up. The hook returns an idle result with `data: undefined` instead of keeping prior subscription data, because a skipped subscription never establishes a connection to receive results. Use it conditionally to start the subscription when the input data is available.
 
 ```js title="Recommended usage of skipToken with useQuery"
 import { skipToken, useQuery } from "@apollo/client/react";
@@ -42,7 +42,7 @@ const { data } = useSubscription(query, id ? { variables: { id } } : skipToken);
 
 ### Why do we recommend `skipToken` over `{ skip: true }`?
 
-Imagine this very common scenario for `skip`: You want to skip your query if a certain required variable is not set. You might be tempted to write something like this:
+Imagine this very common scenario for `skip`: you want to skip your query if a certain required variable is not set. You might be tempted to write something like this:
 
 ```ts
 const { data } = useSuspenseQuery(query, {
@@ -78,7 +78,7 @@ const { data } = useSuspenseQuery(query, {
 
 Both of these solutions hide a potential bug. If your `skip` logic becomes more complex, you might accidentally introduce a bug that causes your query to execute, even when `id` is still `undefined`. In that case, TypeScript cannot warn you about it.
 
-Instead we recommend using `skipToken`. It provides type safety without the need for an obscure default value:
+Instead, we recommend using `skipToken`. It provides type safety without the need for an obscure default value:
 
 ```ts
 const { data } = useSuspenseQuery(
@@ -87,4 +87,4 @@ const { data } = useSuspenseQuery(
 );
 ```
 
-Here it becomes apparent for TypeScript that there is a direct connection between skipping and the `variables` option - and it will work without unsafe workarounds.
+Here it becomes apparent for TypeScript that there is a direct connection between skipping and the `variables` option, and it works without unsafe workarounds.

--- a/docs/source/api/react/skipToken.mdx
+++ b/docs/source/api/react/skipToken.mdx
@@ -8,7 +8,10 @@ description: Apollo Client API reference
 ## `skipToken`
 
 `skipToken` provides a type-safe mechanism to skip query execution. It is currently supported with `useQuery`, `useSuspenseQuery`, `useBackgroundQuery` and `useSubscription`.
-When you pass a `skipToken` to one of the supported hooks instead of the `options` object, the hook will not cause any requests or suspenseful behavior and keeps the last `data` available. It is typically used conditionally to start query execution when the input data is available.
+
+For the query hooks, when you pass a `skipToken` instead of the `options` object, the hook will not cause any requests or suspenseful behavior and keeps the last `data` available. It is typically used conditionally to start query execution when the input data is available.
+
+For `useSubscription`, passing `skipToken` prevents the subscription from being set up. The hook returns an idle result with `data: undefined` instead of keeping prior subscription data, since a skipped subscription never establishes a connection to receive results. It is typically used conditionally to start the subscription when the input data is available.
 
 ```js title="Recommended usage of skipToken with useQuery"
 import { skipToken, useQuery } from "@apollo/client/react";

--- a/docs/source/api/react/skipToken.mdx
+++ b/docs/source/api/react/skipToken.mdx
@@ -7,7 +7,7 @@ description: Apollo Client API reference
 
 ## `skipToken`
 
-`skipToken` provides a type-safe mechanism to skip query execution. It is currently supported with `useQuery`, `useSuspenseQuery` and `useBackgroundQuery`.
+`skipToken` provides a type-safe mechanism to skip query execution. It is currently supported with `useQuery`, `useSuspenseQuery`, `useBackgroundQuery` and `useSubscription`.
 When you pass a `skipToken` to one of the supported hooks instead of the `options` object, the hook will not cause any requests or suspenseful behavior and keeps the last `data` available. It is typically used conditionally to start query execution when the input data is available.
 
 ```js title="Recommended usage of skipToken with useQuery"
@@ -30,6 +30,11 @@ const [queryRef] = useBackgroundQuery(
   query,
   id ? { variables: { id } } : skipToken
 );
+```
+
+```js title="Recommended usage of skipToken with useSubscription"
+import { skipToken, useSubscription } from "@apollo/client/react";
+const { data } = useSubscription(query, id ? { variables: { id } } : skipToken);
 ```
 
 ### Why do we recommend `skipToken` over `{ skip: true }`?

--- a/docs/source/api/react/skipToken.mdx
+++ b/docs/source/api/react/skipToken.mdx
@@ -11,7 +11,7 @@ description: Apollo Client API reference
 
 For the query hooks, passing `skipToken` instead of the `options` object prevents the hook from making requests or triggering suspenseful behavior while keeping the last `data` available. Use it conditionally to start query execution when the input data is available.
 
-For `useSubscription`, passing `skipToken` prevents the subscription from being set up. The hook returns an idle result with `data: undefined` instead of keeping prior subscription data, because a skipped subscription never establishes a connection to receive results. Use it conditionally to start the subscription when the input data is available.
+For `useSubscription`, passing `skipToken` prevents the subscription from executing. The hook returns an idle result with `data: undefined` instead of keeping prior subscription data, because a skipped subscription never establishes a connection to receive results. Use it conditionally to start the subscription when the input data is available.
 
 ```js title="Recommended usage of skipToken with useQuery"
 import { skipToken, useQuery } from "@apollo/client/react";

--- a/package-lock.json
+++ b/package-lock.json
@@ -6931,9 +6931,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6948,9 +6945,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6965,9 +6959,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6982,9 +6973,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6999,9 +6987,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7016,9 +7001,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7033,9 +7015,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7050,9 +7029,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7067,9 +7043,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7084,9 +7057,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -6931,6 +6931,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6945,6 +6948,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6959,6 +6965,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6973,6 +6982,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6987,6 +6999,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7001,6 +7016,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7015,6 +7033,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7029,6 +7050,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7043,6 +7067,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7057,6 +7084,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -17,7 +17,11 @@ import {
   CombinedGraphQLErrors,
   CombinedProtocolErrors,
 } from "@apollo/client/errors";
-import { ApolloProvider, useSubscription } from "@apollo/client/react";
+import {
+  ApolloProvider,
+  skipToken,
+  useSubscription,
+} from "@apollo/client/react";
 import { MockSubscriptionLink } from "@apollo/client/testing";
 import {
   mockMultipartSubscriptionStream,
@@ -423,6 +427,62 @@ describe("useSubscription Hook", () => {
       await renderHookToSnapshotStream(
         ({ variables }) =>
           useSubscription(subscription, { variables, skip: true, onData }),
+        {
+          initialProps: {
+            variables: {
+              foo: "bar",
+            },
+          },
+          wrapper: ({ children }) => (
+            <ApolloProvider client={client}>{children}</ApolloProvider>
+          ),
+        }
+      );
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      loading: false,
+    });
+
+    await rerender({ variables: { foo: "bar2" } });
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      loading: false,
+    });
+
+    await expect(takeSnapshot).not.toRerender();
+
+    expect(onSetup).toHaveBeenCalledTimes(0);
+    expect(onData).toHaveBeenCalledTimes(0);
+    unmount();
+  });
+
+  it("should never execute a subscription when skipToken is passed", async () => {
+    const subscription = gql`
+      subscription {
+        car {
+          make
+        }
+      }
+    `;
+
+    const onSetup = jest.fn();
+    const link = new MockSubscriptionLink();
+    link.onSetup(onSetup);
+    const client = new ApolloClient({
+      link,
+      cache: new Cache(),
+    });
+
+    const onData = jest.fn();
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot, unmount, rerender } =
+      await renderHookToSnapshotStream(
+        ({ variables }) => useSubscription(subscription, skipToken),
         {
           initialProps: {
             variables: {
@@ -3770,5 +3830,19 @@ describe.skip("Type Tests", () => {
         foo: "bar",
       },
     });
+  });
+
+  test("accepts skipToken when TVariables includes required variables", () => {
+    const subscription: TypedDocumentNode<
+      { character: string },
+      { id: string }
+    > = gql``;
+
+    useSubscription(subscription, skipToken);
+    useSubscription(subscription, {
+      variables: { id: "1" },
+    });
+    // @ts-expect-error skipToken does not replace the required options object
+    useSubscription(subscription);
   });
 });

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -644,7 +644,7 @@ describe("useSubscription Hook", () => {
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
         initialProps: {
-          options: skipToken as typeof skipToken | { skip: boolean },
+          options: skipToken as typeof skipToken | undefined,
         },
       }
     );
@@ -657,7 +657,7 @@ describe("useSubscription Hook", () => {
     });
 
     // Flip to active
-    await rerender({ options: { skip: false } });
+    await rerender({ options: undefined });
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: undefined,
@@ -683,7 +683,7 @@ describe("useSubscription Hook", () => {
     });
 
     // Flip to active again
-    await rerender({ options: { skip: false } });
+    await rerender({ options: undefined });
 
     await expect(takeSnapshot()).resolves.toStrictEqualTyped({
       data: undefined,

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -643,7 +643,9 @@ describe("useSubscription Hook", () => {
         wrapper: ({ children }) => (
           <ApolloProvider client={client}>{children}</ApolloProvider>
         ),
-        initialProps: { options: skipToken as typeof skipToken | { skip: boolean } },
+        initialProps: {
+          options: skipToken as typeof skipToken | { skip: boolean },
+        },
       }
     );
 
@@ -3972,10 +3974,7 @@ describe.skip("Type Tests", () => {
   });
 
   test("accepts skipToken when variables type is never", () => {
-    const subscription: TypedDocumentNode<
-      { greeting: string },
-      never
-    > = gql``;
+    const subscription: TypedDocumentNode<{ greeting: string }, never> = gql``;
 
     useSubscription(subscription, skipToken);
     // @ts-expect-error

--- a/src/react/hooks/__tests__/useSubscription.test.tsx
+++ b/src/react/hooks/__tests__/useSubscription.test.tsx
@@ -612,6 +612,94 @@ describe("useSubscription Hook", () => {
     await expect(takeSnapshot).not.toRerender();
   });
 
+  it("should flip flop skipToken from true to false to true to false", async () => {
+    const subscription = gql`
+      subscription {
+        car {
+          make
+        }
+      }
+    `;
+
+    const results = [
+      {
+        result: { data: { car: { make: "Pagani" } } },
+      },
+      {
+        result: { data: { car: { make: "Scoop" } } },
+      },
+    ];
+
+    const link = new MockSubscriptionLink();
+    const client = new ApolloClient({
+      link,
+      cache: new Cache(),
+    });
+
+    using _disabledAct = disableActEnvironment();
+    const { takeSnapshot, rerender } = await renderHookToSnapshotStream(
+      ({ options }) => useSubscription(subscription, options),
+      {
+        wrapper: ({ children }) => (
+          <ApolloProvider client={client}>{children}</ApolloProvider>
+        ),
+        initialProps: { options: skipToken as typeof skipToken | { skip: boolean } },
+      }
+    );
+
+    // Start with skipToken (skipped)
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      loading: false,
+    });
+
+    // Flip to active
+    await rerender({ options: { skip: false } });
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+    });
+
+    link.simulateResult(results[0]);
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: results[0].result.data,
+      error: undefined,
+      loading: false,
+    });
+
+    // Flop back to skipToken
+    await rerender({ options: skipToken });
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      loading: false,
+    });
+
+    // Flip to active again
+    await rerender({ options: { skip: false } });
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: undefined,
+      error: undefined,
+      loading: true,
+    });
+
+    link.simulateResult(results[1]);
+
+    await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+      data: results[1].result.data,
+      error: undefined,
+      loading: false,
+    });
+
+    await expect(takeSnapshot).not.toRerender();
+  });
+
   it("should share context set in options", async () => {
     const subscription = gql`
       subscription {
@@ -3844,5 +3932,55 @@ describe.skip("Type Tests", () => {
     });
     // @ts-expect-error skipToken does not replace the required options object
     useSubscription(subscription);
+  });
+
+  test("accepts skipToken when variables are optional (2nd arg not required)", () => {
+    const subscription: TypedDocumentNode<
+      { posts: string[] },
+      { limit?: number }
+    > = gql``;
+
+    useSubscription(subscription, skipToken);
+    useSubscription(subscription);
+    useSubscription(subscription, { variables: { limit: 10 } });
+  });
+
+  test("accepts skipToken with mixed required + optional variables", () => {
+    const subscription: TypedDocumentNode<
+      { character: string },
+      { id: string; language?: string }
+    > = gql``;
+
+    useSubscription(subscription, skipToken);
+    useSubscription(subscription, { variables: { id: "1" } });
+    useSubscription(subscription, {
+      variables: { id: "1", language: "en" },
+    });
+    // @ts-expect-error missing required variable
+    useSubscription(subscription);
+  });
+
+  test("accepts skipToken with empty variables (Record<string, never>)", () => {
+    const subscription: TypedDocumentNode<
+      { greeting: string },
+      Record<string, never>
+    > = gql``;
+
+    useSubscription(subscription, skipToken);
+    useSubscription(subscription);
+    useSubscription(subscription, { variables: {} });
+  });
+
+  test("accepts skipToken when variables type is never", () => {
+    const subscription: TypedDocumentNode<
+      { greeting: string },
+      never
+    > = gql``;
+
+    useSubscription(subscription, skipToken);
+    // @ts-expect-error
+    useSubscription(subscription);
+    // @ts-expect-error
+    useSubscription(subscription, {});
   });
 });

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -23,6 +23,8 @@ import { useDeepMemo } from "./internal/useDeepMemo.js";
 import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.js";
 import { useApolloClient } from "./useApolloClient.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
+import { skipToken } from "./constants.js";
+import type { SkipToken } from "./constants.js";
 
 export declare namespace useSubscription {
   import _self = useSubscription;
@@ -221,21 +223,40 @@ export function useSubscription<
   ...[options = {} as useSubscription.Options<TData, TVariables>]: {} extends (
     TVariables
   ) ?
-    [options?: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]
-  : [options: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]
+    [
+      options?:
+        | SkipToken
+        | useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>,
+    ]
+  : [
+      options:
+        | SkipToken
+        | useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>,
+    ]
 ): useSubscription.Result<TData> {
-  const client = useApolloClient(options.client);
+  const client = useApolloClient(
+    typeof options === "object" ? options.client : undefined
+  );
+
+  const normalizedOptions: useSubscription.Options<TData, TVariables> =
+    typeof options === "object" ? options : (
+      ({ skip: true } as useSubscription.Options<TData, TVariables>)
+    );
+
+  const skip = options === skipToken ? true : normalizedOptions.skip;
 
   const {
-    skip,
     fetchPolicy,
     errorPolicy,
     shouldResubscribe,
     context,
     extensions,
     ignoreResults,
-  } = options;
-  const variables = useDeepMemo(() => options.variables, [options.variables]);
+  } = normalizedOptions;
+  const variables = useDeepMemo(
+    () => normalizedOptions.variables,
+    [normalizedOptions.variables]
+  );
 
   const recreate = () =>
     createSubscription(
@@ -248,9 +269,7 @@ export function useSubscription<
       extensions
     );
 
-  let [observable, setObservable] = React.useState(
-    options.skip ? null : recreate
-  );
+  let [observable, setObservable] = React.useState(skip ? null : recreate);
 
   const recreateRef = React.useRef(recreate);
   useIsomorphicLayoutEffect(() => {
@@ -269,15 +288,15 @@ export function useSubscription<
       errorPolicy !== observable.__.errorPolicy ||
       !equal(variables, observable.__.variables)) &&
       (typeof shouldResubscribe === "function" ?
-        !!shouldResubscribe(options!)
+        !!shouldResubscribe(normalizedOptions)
       : shouldResubscribe) !== false)
   ) {
     setObservable((observable = recreate()));
   }
 
-  const optionsRef = React.useRef(options);
+  const optionsRef = React.useRef(normalizedOptions);
   React.useEffect(() => {
-    optionsRef.current = options;
+    optionsRef.current = normalizedOptions;
   });
 
   const fallbackLoading = !skip && !ignoreResults;

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -20,6 +20,8 @@ import { useDeepMemo } from "./internal/useDeepMemo.js";
 import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.js";
 import { useApolloClient } from "./useApolloClient.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
+import { skipToken } from "./constants.js";
+import type { SkipToken } from "./constants.js";
 
 export declare namespace useSubscription {
   import _self = useSubscription;
@@ -218,21 +220,40 @@ export function useSubscription<
   ...[options = {} as useSubscription.Options<TData, TVariables>]: {} extends (
     TVariables
   ) ?
-    [options?: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]
-  : [options: useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>]
+    [
+      options?:
+        | SkipToken
+        | useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>,
+    ]
+  : [
+      options:
+        | SkipToken
+        | useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>,
+    ]
 ): useSubscription.Result<TData> {
-  const client = useApolloClient(options.client);
+  const client = useApolloClient(
+    typeof options === "object" ? options.client : undefined
+  );
+
+  const normalizedOptions: useSubscription.Options<TData, TVariables> =
+    typeof options === "object" ? options : (
+      ({ skip: true } as useSubscription.Options<TData, TVariables>)
+    );
+
+  const skip = options === skipToken ? true : normalizedOptions.skip;
 
   const {
-    skip,
     fetchPolicy,
     errorPolicy,
     shouldResubscribe,
     context,
     extensions,
     ignoreResults,
-  } = options;
-  const variables = useDeepMemo(() => options.variables, [options.variables]);
+  } = normalizedOptions;
+  const variables = useDeepMemo(
+    () => normalizedOptions.variables,
+    [normalizedOptions.variables]
+  );
 
   const recreate = () =>
     createSubscription(
@@ -245,9 +266,7 @@ export function useSubscription<
       extensions
     );
 
-  let [observable, setObservable] = React.useState(
-    options.skip ? null : recreate
-  );
+  let [observable, setObservable] = React.useState(skip ? null : recreate);
 
   const recreateRef = React.useRef(recreate);
   useIsomorphicLayoutEffect(() => {
@@ -266,15 +285,15 @@ export function useSubscription<
       errorPolicy !== observable.__.errorPolicy ||
       !equal(variables, observable.__.variables)) &&
       (typeof shouldResubscribe === "function" ?
-        !!shouldResubscribe(options!)
+        !!shouldResubscribe(normalizedOptions)
       : shouldResubscribe) !== false)
   ) {
     setObservable((observable = recreate()));
   }
 
-  const optionsRef = React.useRef(options);
+  const optionsRef = React.useRef(normalizedOptions);
   React.useEffect(() => {
-    optionsRef.current = options;
+    optionsRef.current = normalizedOptions;
   });
 
   const fallbackLoading = !skip && !ignoreResults;

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -238,8 +238,8 @@ export function useSubscription<
 
   const client = useApolloClient(options.client);
 
-  const { skip } = options;
   const {
+    skip,
     fetchPolicy,
     errorPolicy,
     shouldResubscribe,

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -16,12 +16,12 @@ import type { DocumentationTypes as UtilityDocumentationTypes } from "@apollo/cl
 import type { VariablesOption } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
+import type { SkipToken } from "./constants.js";
+import { skipToken } from "./constants.js";
 import { useDeepMemo } from "./internal/useDeepMemo.js";
 import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.js";
 import { useApolloClient } from "./useApolloClient.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
-import { skipToken } from "./constants.js";
-import type { SkipToken } from "./constants.js";
 
 export declare namespace useSubscription {
   import _self = useSubscription;

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -247,10 +247,7 @@ export function useSubscription<
     extensions,
     ignoreResults,
   } = options;
-  const variables = useDeepMemo(
-    () => options.variables,
-    [options.variables]
-  );
+  const variables = useDeepMemo(() => options.variables, [options.variables]);
 
   const recreate = () =>
     createSubscription(

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -217,7 +217,7 @@ export function useSubscription<
   TVariables extends OperationVariables = OperationVariables,
 >(
   subscription: DocumentNode | TypedDocumentNode<TData, TVariables>,
-  ...[options = {} as useSubscription.Options<TData, TVariables>]: {} extends (
+  ...[_options = {} as useSubscription.Options<TData, TVariables>]: {} extends (
     TVariables
   ) ?
     [
@@ -231,17 +231,14 @@ export function useSubscription<
         | useSubscription.Options<NoInfer<TData>, NoInfer<TVariables>>,
     ]
 ): useSubscription.Result<TData> {
-  const client = useApolloClient(
-    typeof options === "object" ? options.client : undefined
-  );
-
-  const normalizedOptions: useSubscription.Options<TData, TVariables> =
-    typeof options === "object" ? options : (
+  const options =
+    _options === skipToken ?
       ({ skip: true } as useSubscription.Options<TData, TVariables>)
-    );
+    : _options;
 
-  const skip = options === skipToken ? true : normalizedOptions.skip;
+  const client = useApolloClient(options.client);
 
+  const { skip } = options;
   const {
     fetchPolicy,
     errorPolicy,
@@ -249,10 +246,10 @@ export function useSubscription<
     context,
     extensions,
     ignoreResults,
-  } = normalizedOptions;
+  } = options;
   const variables = useDeepMemo(
-    () => normalizedOptions.variables,
-    [normalizedOptions.variables]
+    () => options.variables,
+    [options.variables]
   );
 
   const recreate = () =>
@@ -285,15 +282,15 @@ export function useSubscription<
       errorPolicy !== observable.__.errorPolicy ||
       !equal(variables, observable.__.variables)) &&
       (typeof shouldResubscribe === "function" ?
-        !!shouldResubscribe(normalizedOptions)
+        !!shouldResubscribe(options)
       : shouldResubscribe) !== false)
   ) {
     setObservable((observable = recreate()));
   }
 
-  const optionsRef = React.useRef(normalizedOptions);
+  const optionsRef = React.useRef(options);
   React.useEffect(() => {
-    optionsRef.current = normalizedOptions;
+    optionsRef.current = options;
   });
 
   const fallbackLoading = !skip && !ignoreResults;

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -19,12 +19,12 @@ import type {
 } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
+import type { SkipToken } from "./constants.js";
+import { skipToken } from "./constants.js";
 import { useDeepMemo } from "./internal/useDeepMemo.js";
 import { useIsomorphicLayoutEffect } from "./internal/useIsomorphicLayoutEffect.js";
 import { useApolloClient } from "./useApolloClient.js";
 import { useSyncExternalStore } from "./useSyncExternalStore.js";
-import { skipToken } from "./constants.js";
-import type { SkipToken } from "./constants.js";
 
 export declare namespace useSubscription {
   import _self = useSubscription;


### PR DESCRIPTION
### Checklist:
- [x] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests

Closes #13147

## Summary

`useSubscription` now accepts `skipToken` as the options argument, matching the existing behavior of `useQuery`, `useSuspenseQuery`, and `useBackgroundQuery`. This gives a type-safe way to skip subscriptions that have required variables:

```ts
const { data } = useSubscription(
  SUBSCRIPTION,
  id ? { variables: { id } } : skipToken
);
```

Previously this was a type error since `skipToken` did not satisfy the required `variables` shape, and the `skip: true` workaround also failed for the same reason.

## Changes

- Accept `SkipToken` in the `useSubscription` options parameter type, keeping required-variable validation intact for the non-skip path.
- Treat `skipToken` as `skip: true` at runtime, so no subscription is created and results stay idle.
- Added a changeset and a runtime test confirming `skipToken` never sets up the subscription link.
- Updated the `skipToken` docs page to list `useSubscription` as a supported hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using `skipToken` with `useSubscription` to conditionally skip subscription execution while maintaining type safety for required variables.
  * Added documentation and usage examples for the new behavior.

* **Bug Fixes**
  * Prevented subscription setup, callbacks, and rerenders when execution is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->