### PR TITLE
fix: remove boundary=graphql from subscription accept header

### DIFF
--- a/.changeset/tidy-schools-drop.md
+++ b/.changeset/tidy-schools-drop.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Remove the `boundary=graphql` parameter from the `accept` header sent with multipart subscription requests. The `boundary` parameter describes a multipart body and belongs on the server's response `Content-Type`, not on the client's request `accept` header. Dropping it aligns with Apollo's multipart-protocol docs and improves interop with stricter GraphQL routers that reject the parameter. The `accept` header is now `multipart/mixed;subscriptionSpec=1.0,...`.

--- a/src/link/http/BaseHttpLink.ts
+++ b/src/link/http/BaseHttpLink.ts
@@ -295,7 +295,7 @@ export class BaseHttpLink extends ApolloLink {
       const http = { ...context.http };
       if (isSubscriptionOperation(operation.query)) {
         http.accept = [
-          "multipart/mixed;boundary=graphql;subscriptionSpec=1.0",
+          "multipart/mixed;subscriptionSpec=1.0",
           ...(http.accept || []),
         ];
       }

--- a/src/link/http/__tests__/HttpLink.ts
+++ b/src/link/http/__tests__/HttpLink.ts
@@ -1936,7 +1936,7 @@ describe("HttpLink", () => {
           expect.objectContaining({
             headers: {
               accept:
-                "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,multipart/mixed;deferSpec=20220824,application/graphql-response+json,application/json;q=0.9",
+                "multipart/mixed;subscriptionSpec=1.0,multipart/mixed;deferSpec=20220824,application/graphql-response+json,application/json;q=0.9",
               "content-type": "application/json",
             },
           })
@@ -2031,7 +2031,7 @@ describe("HttpLink", () => {
             headers: {
               "content-type": "application/json",
               accept:
-                "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/graphql-response+json,application/json;q=0.9",
+                "multipart/mixed;subscriptionSpec=1.0,application/graphql-response+json,application/json;q=0.9",
             },
           })
         );

--- a/src/utilities/subscriptions/relay/index.ts
+++ b/src/utilities/subscriptions/relay/index.ts
@@ -79,8 +79,7 @@ function generateOptionsForMultipartSubscription(
     headers: {
       ...(headers || {}),
       ...fallbackHttpConfig.headers,
-      accept:
-        "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
+      accept: "multipart/mixed;subscriptionSpec=1.0,application/json",
     },
   };
   return options;


### PR DESCRIPTION
### Checklist:
- [✅] If this PR contains changes to the library itself (not necessary for e.g. docs updates), please include a changeset (see [CONTRIBUTING.md](https://github.com/apollographql/apollo-client/blob/main/CONTRIBUTING.md#changesets))
- [] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [✅] Make sure all of the significant new logic is covered by tests

## Summary

Removes the `boundary=graphql` parameter from the `accept` header Apollo Client
sends with multipart subscription requests. The subscription `accept` header
changes from:

    multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json

to:

    multipart/mixed;subscriptionSpec=1.0,application/json


## Why

`boundary` is used to denote how data is meant to be split, and should not be on an accept header. Using Apollo Client with strict routers, e.g. Hive Router, will cause the request to be rejected(whether they should be rejected or not is debatable, it's a bit too strict for accept headers imo). 

Apollo's own [documentation](https://www.apollographql.com/docs/graphos/routing/operations/subscriptions/multipart-protocol#:~:text=The%20only%20difference%20is%20that%20the%20request%20should%20include%20the%20following%20Accept%20header%3A) makes reference to the minimally correct Accept header to use when querying

    Accept: multipart/mixed;subscriptionSpec="1.0", application/json

The defer handler does not seem to include it either. This leads me to believe that it's an oversight and should be removed. 


## Note

I'm not sure if to raise this as a patch or major, given there're potentially servers which might reject requests that don't include this `boundary` which could be construed as a breaking change. 

Strawberry shipped [this fix](https://github.com/strawberry-graphql/strawberry/pull/4002) to loosen their accept header validation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated multipart subscription requests to use the standardized `multipart/mixed` format without the deprecated `boundary=graphql` parameter.
  - Improved compatibility for standard, deferred, and Relay subscription requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->