### PR TITLE
Warn when rereading a partial cache result after a write

### DIFF
--- a/.changeset/warn-partial-cache-reread.md
+++ b/.changeset/warn-partial-cache-reread.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Add a development-only warning when a network result is written to the cache but reading the query back from the cache returns a partial result. This usually points at a `merge` or `read` function that did not repair missing fields in the cache, which prevents Apollo Client from applying the cache result to the data received by the network.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 47945,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 42291,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 35993,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29497
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 48259,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 42316,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 36284,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 29529
 }

--- a/src/__tests__/__snapshots__/client.ts.snap
+++ b/src/__tests__/__snapshots__/client.ts.snap
@@ -64,3 +64,59 @@ exports[`client should warn if server returns wrong data 1`] = `
   ],
 }
 `;
+
+exports[`client should warn if server returns wrong data 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "The network result for query %s was written to the cache, but reading it back returned a partial result.
+
+A \`read\` or \`merge\` function left missing fields after this write. Because the cache result is incomplete, Apollo Client cannot apply it to the network result. The raw network result was returned instead, and doesn't include any transformed values returned from \`read\` functions.
+
+To address this problem (which is not a bug in Apollo Client), check the \`read\` and \`merge\` functions for the fields in this query. A \`read\` or \`merge\` function that leaves missing fields leaves the cache unable to fulfill the query's data requirements.
+
+  missing fields: %o
+  network result: %o
+  cache result: %o
+
+For more information, please refer to the documentation:
+
+  * Customizing cache field behavior: https://go.apollo.dev/c/cache-field-behavior
+",
+      "(anonymous)",
+      Object {
+        "todos": Object {
+          "0": Object {
+            "description": "Can't find field 'description' on Todo:1 object",
+          },
+        },
+      },
+      Object {
+        "todos": Array [
+          Object {
+            "__typename": "Todo",
+            "id": "1",
+            "name": "Todo 1",
+            "price": 100,
+          },
+        ],
+      },
+      Object {
+        "todos": Array [
+          Object {
+            "__typename": "Todo",
+            "id": "1",
+            "name": "Todo 1",
+          },
+        ],
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -3018,7 +3018,7 @@ describe("client", () => {
   });
 
   it("should warn if server returns wrong data", async () => {
-    using _consoleSpies = spyOnConsole.takeSnapshots("error");
+    using _consoleSpies = spyOnConsole.takeSnapshots("error", "warn");
     const query = gql`
       query {
         todos {

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -7,6 +7,7 @@ import type { Incremental } from "@apollo/client/incremental";
 import type { ApolloLink } from "@apollo/client/link";
 import type { Unmasked } from "@apollo/client/masking";
 import type { DeepPartial } from "@apollo/client/utilities";
+import { __DEV__ } from "@apollo/client/utilities/environment";
 import type { ExtensionsWithStreamInfo } from "@apollo/client/utilities/internal";
 import {
   getOperationName,
@@ -242,6 +243,8 @@ export class QueryInfo<
     }
 
     if (shouldWriteResult(result, errorPolicy)) {
+      let written = false;
+
       // Using a transaction here so we have a chance to read the result
       // back from the cache before the watch callback fires as a result
       // of writeQuery, so we can store the new diff quietly and ignore
@@ -267,6 +270,8 @@ export class QueryInfo<
               overwrite: cacheWriteBehavior === CacheWriteBehavior.OVERWRITE,
               extensions: result.extensions,
             });
+
+            written = true;
 
             this.lastWrite = {
               result,
@@ -325,6 +330,14 @@ export class QueryInfo<
           // we have other ways of notifying for this result.
           if (diff.complete) {
             result = { ...result, data: diff.result };
+          } else if (
+            __DEV__ &&
+            written &&
+            // A result that is still streaming is expected to read back
+            // incomplete until the remaining chunks arrive.
+            !this.hasNext
+          ) {
+            warnAboutPartialCacheResult(query, result.data, diff);
           }
         },
       });
@@ -616,6 +629,33 @@ export class QueryInfo<
       this.queryManager.broadcastQueries();
     }
   }
+}
+
+function warnAboutPartialCacheResult(
+  query: DocumentNode,
+  networkResult: unknown,
+  diff: Cache.DiffResult<unknown>
+) {
+  invariant.warn(
+    `The network result for query %s was written to the cache, but reading it back returned a partial result.
+
+A \`read\` or \`merge\` function left missing fields after this write. Because the cache result is incomplete, Apollo Client cannot apply it to the network result. The raw network result was returned instead, and doesn't include any transformed values returned from \`read\` functions.
+
+To address this problem (which is not a bug in Apollo Client), check the \`read\` and \`merge\` functions for the fields in this query. A \`read\` or \`merge\` function that leaves missing fields leaves the cache unable to fulfill the query's data requirements.
+
+  missing fields: %o
+  network result: %o
+  cache result: %o
+
+For more information, please refer to the documentation:
+
+  * Customizing cache field behavior: https://go.apollo.dev/c/cache-field-behavior
+`,
+    getOperationName(query, "(anonymous)"),
+    diff.missing?.missing,
+    networkResult,
+    diff.result
+  );
 }
 
 function shouldWriteResult<T>(

--- a/src/core/__tests__/incompleteCacheReadWarning.test.ts
+++ b/src/core/__tests__/incompleteCacheReadWarning.test.ts
@@ -1,0 +1,554 @@
+import { ApolloClient, gql, InMemoryCache } from "@apollo/client";
+import { Defer20220824Handler } from "@apollo/client/incremental";
+import { MockLink } from "@apollo/client/testing";
+import {
+  mockDefer20220824,
+  ObservableStream,
+  spyOnConsole,
+  wait,
+} from "@apollo/client/testing/internal";
+import { offsetLimitPagination } from "@apollo/client/utilities";
+
+test("warns when a written network result reads back from the cache as partial", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    query UserQuery {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            user: {
+              merge: (_, incoming) => ({
+                __typename: incoming.__typename,
+                name: incoming.name,
+              }),
+            },
+          },
+        },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+        },
+      },
+    ]),
+  });
+
+  await client.query({ query });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    expect.stringContaining("partial result"),
+    "UserQuery",
+    { user: { age: expect.stringContaining("Can't find field 'age'") } },
+    { user: { __typename: "User", name: "Alice", age: 30 } },
+    { user: { __typename: "User", name: "Alice" } }
+  );
+});
+
+test("warns for a watched query when the cache read is partial after the write", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    query UserQuery {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            user: {
+              merge: (_, incoming) => ({
+                __typename: incoming.__typename,
+                name: incoming.name,
+              }),
+            },
+          },
+        },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+  });
+
+  using stream = new ObservableStream(client.watchQuery({ query }));
+
+  // loading
+  await stream.takeNext();
+  // result
+  await stream.takeNext();
+
+  expect(console.warn).toHaveBeenCalledWith(
+    expect.stringContaining("partial result"),
+    "UserQuery",
+    { user: { age: expect.stringContaining("Can't find field 'age'") } },
+    { user: { __typename: "User", name: "Alice", age: 30 } },
+    { user: { __typename: "User", name: "Alice" } }
+  );
+});
+
+test("warns when a `read` function makes the cache result partial", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    query UserQuery {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        User: { fields: { age: { read: () => undefined } } },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+        },
+      },
+    ]),
+  });
+
+  await client.query({ query });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    expect.stringContaining("partial result"),
+    "UserQuery",
+    { user: { age: expect.any(String) } },
+    { user: { __typename: "User", name: "Alice", age: 30 } },
+    { user: { __typename: "User", name: "Alice" } }
+  );
+});
+
+test("does not warn when the cache read is complete", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    query UserQuery {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+        },
+      },
+    ]),
+  });
+
+  await client.query({ query });
+
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
+test("does not warn for an anonymous query when the cache read is complete", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+        },
+      },
+    ]),
+  });
+
+  await client.query({ query });
+
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
+test("names an anonymous query as `(anonymous)` in the warning", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            user: {
+              merge: (_, incoming) => ({
+                __typename: incoming.__typename,
+                name: incoming.name,
+              }),
+            },
+          },
+        },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+        },
+      },
+    ]),
+  });
+
+  await client.query({ query });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    expect.stringContaining("partial result"),
+    "(anonymous)",
+    expect.anything(),
+    expect.anything(),
+    expect.anything()
+  );
+});
+
+test("does not warn with `fetchPolicy: 'no-cache'`", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    query UserQuery {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            user: {
+              merge: (_, incoming) => ({
+                __typename: incoming.__typename,
+                name: incoming.name,
+              }),
+            },
+          },
+        },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+        },
+      },
+    ]),
+  });
+
+  await client.query({ query, fetchPolicy: "no-cache" });
+
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
+test("does not warn when the result is not written because of GraphQL errors", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    query UserQuery {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            user: {
+              merge: (_, incoming) => ({
+                __typename: incoming.__typename,
+                name: incoming.name,
+              }),
+            },
+          },
+        },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+          errors: [{ message: "Oops" }],
+        },
+      },
+    ]),
+  });
+
+  await expect(client.query({ query, errorPolicy: "none" })).rejects.toThrow();
+
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
+test("does not warn while a deferred result is still streaming", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    query DeferredQuery {
+      person(id: 1) {
+        id
+        name
+        ... @defer {
+          homeworld
+        }
+      }
+    }
+  `;
+
+  const defer = mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: defer.httpLink,
+    incrementalHandler: new Defer20220824Handler(),
+  });
+
+  using stream = new ObservableStream(client.watchQuery({ query }));
+
+  await stream.takeNext();
+
+  defer.enqueueInitialChunk({
+    data: { person: { __typename: "Person", id: "1", name: "Luke" } },
+    hasNext: true,
+  });
+
+  await stream.takeNext();
+
+  expect(console.warn).not.toHaveBeenCalled();
+
+  defer.enqueueSubsequentChunk({
+    incremental: [{ path: ["person"], data: { homeworld: "Tatooine" } }],
+    hasNext: false,
+  });
+
+  await stream.takeNext();
+
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
+test("does not warn again when the cache write is skipped because the identical result was already written", async () => {
+  using _ = spyOnConsole("warn");
+
+  const query = gql`
+    query UserQuery {
+      user {
+        name
+        age
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            user: {
+              merge: (_, incoming) => ({
+                __typename: incoming.__typename,
+                name: incoming.name,
+              }),
+            },
+          },
+        },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query },
+        result: {
+          data: { user: { __typename: "User", name: "Alice", age: 30 } },
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+  });
+
+  const observable = client.watchQuery({ query, pollInterval: 10 });
+  using stream = new ObservableStream(observable);
+
+  await stream.takeNext();
+  await stream.takeNext();
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+
+  // Each poll returns the identical result, so the cache write is skipped and
+  // the warning must not repeat.
+  await wait(60);
+  observable.stopPolling();
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+});
+
+// https://github.com/apollographql/apollo-client/issues/9293
+test("warns when a pagination `merge` function concatenates a partial item into the list", async () => {
+  // The `cache.writeQuery` below writes a `Person` without `createdAt`, which
+  // logs a "Missing field" error we are not interested in here.
+  using _ = spyOnConsole("warn", "error");
+
+  const query = gql`
+    query PeopleQuery {
+      people {
+        id
+        name
+        createdAt
+      }
+    }
+  `;
+
+  const mutation = gql`
+    mutation AddPerson($name: String!) {
+      addPerson(name: $name) {
+        id
+        name
+      }
+    }
+  `;
+
+  const people = [
+    {
+      __typename: "Person",
+      id: "1",
+      name: "John Smith",
+      createdAt: "2020-01-01",
+    },
+    {
+      __typename: "Person",
+      id: "2",
+      name: "Sara Smith",
+      createdAt: "2020-01-02",
+    },
+  ];
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: { fields: { people: offsetLimitPagination() } },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query },
+        result: { data: { people } },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+      {
+        request: { query: mutation, variables: { name: "Budd Deey" } },
+        result: {
+          data: {
+            addPerson: { __typename: "Person", id: "3", name: "Budd Deey" },
+          },
+        },
+      },
+    ]),
+  });
+
+  const observable = client.watchQuery({ query });
+  using stream = new ObservableStream(observable);
+
+  await stream.takeNext();
+  await stream.takeNext();
+
+  expect(console.warn).not.toHaveBeenCalled();
+
+  await client.mutate({
+    mutation,
+    variables: { name: "Budd Deey" },
+    update: (cache, { data }) => {
+      cache.writeQuery({
+        query,
+        data: { people: [(data as any).addPerson] },
+      });
+    },
+  });
+
+  await observable.refetch();
+  await wait(50);
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    expect.stringContaining("partial result"),
+    "PeopleQuery",
+    {
+      people: {
+        2: {
+          createdAt: expect.stringContaining("Can't find field 'createdAt'"),
+        },
+      },
+    },
+    // The network result Apollo Client hands to the application, which holds
+    // the raw `createdAt` strings instead of anything a `read` function or a
+    // custom scalar would have parsed.
+    { people },
+    {
+      people: [
+        ...people,
+        { __typename: "Person", id: "3", name: "Budd Deey" },
+        ...people,
+      ],
+    }
+  );
+});

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -6560,6 +6560,10 @@ describe("useQuery Hook", () => {
   });
 
   it("delivers the full network response when a merge function returns an incomplete result", async () => {
+    // Silence expected warning about partial cache result because of merge
+    // function
+    using _ = spyOnConsole("warn");
+
     const query = gql`
       query {
         author {
@@ -6657,9 +6661,35 @@ describe("useQuery Hook", () => {
     }
 
     await expect(takeSnapshot).not.toRerender();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("partial result"),
+      "(anonymous)",
+      {
+        author: {
+          post: {
+            id: expect.stringContaining("Can't find field 'id'"),
+            title: expect.stringContaining("Can't find field 'title'"),
+          },
+        },
+      },
+      {
+        author: {
+          __typename: "Author",
+          id: 1,
+          name: "Author Lee",
+          post: { __typename: "Post", id: 1, title: "Title" },
+        },
+      },
+      { author: { __typename: "Author", id: 1, name: "Author Lee", post: {} } }
+    );
   });
 
   it("triggers a network request and rerenders with the new result when a mutation causes a partial cache update due to an incomplete merge function result", async () => {
+    // Silence expected warning about partial cache result because of merge
+    // function
+    using _ = spyOnConsole("warn");
+
     const query = gql`
       query {
         author {
@@ -9058,7 +9088,7 @@ describe("useQuery Hook", () => {
 
   describe("Missing Fields", () => {
     it("should log debug messages about MissingFieldErrors from the cache", async () => {
-      using consoleSpy = spyOnConsole("error");
+      using consoleSpy = spyOnConsole("error", "warn");
 
       const carQuery: DocumentNode = gql`
         query cars($id: Int) {


### PR DESCRIPTION
Closes #9293

Adds a development only warning when a partial result is reread from the cache after a cache write. This can happen if a mutation or manual cache write adds a partial result to the cache that causes a different query to refetch, but that refetch doesn't repair the partial result. There is nothing Apollo Client can do that would be 100% correct to fix this problem, but not telling the user something might be wrong is also bad and can lead to a frustrating time debugging the source of the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a development-only warning when cache data is incomplete after network results are written.
  * Warning details include the affected query, missing fields, and the network and cache results.
  * Warnings are suppressed for expected cases such as no-cache queries, GraphQL errors, deferred responses, and duplicate polling results.

* **Tests**
  * Expanded coverage for incomplete cache reads, pagination, watched queries, and custom field reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->