### PR TITLE
More predictably prune cache-first and cache-and-network values to more closely follow the delivered network values

### DIFF
--- a/.changeset/silent-berries-help.md
+++ b/.changeset/silent-berries-help.md
@@ -1,0 +1,51 @@
+---
+"@apollo/client": minor
+---
+
+Change when `@defer` fragments and `@stream` fields are pruned for `cache-first` and `cache-and-network` fetch policies to better match the network when the initial value contained a partial result:
+
+- `cache-first`: prune undelivered `@defer` fragments or `@stream` items when the result is fetched from the network due to a partial result
+- `cache-and-network`: prune undelivered `@defer` fragments or `@stream` items if the initial cache value was partial. If the first value emitted from the cache is complete, the results will not be pruned.
+
+This makes the emitted results more predictable by following what the network has delivered and avoids some ambiguity in other edge cases.
+
+For example, with a `cache-first` fetch policy where all `@defer` fields are written to the cache, but a non-deferred field is partial, the values emitted from the client previously looked like the following:
+
+```graphql
+query {
+  user {
+    id
+    name
+    ... @defer {
+      email
+    }
+  }
+}
+```
+
+```ts
+// data written to the cache is missing name
+{ user: { id: 1, email: "user.cache@example.com" }}
+
+// 1. empty because the result is partial
+{ data: undefined, dataState: "empty", ... }
+// 2. returns all data because the cache contains a value for email
+{ data: { user: 1, name: "User", email: "user.cache@example.com" }, dataState: "complete" }
+// 3. email updated from the server
+{ data: { user: 1, name: "User", email: "user.network@example.com" }, dataState: "complete" }
+```
+
+Here the result is confusing because the initial value returned from the query was `undefined`, yet a complete result was returned after the initial chunk from the network returned (which did not contain `email`).
+
+The cache values are now pruned if the network hasn't delivered them yet:
+
+```ts
+// 1. empty because the result is partial
+{ data: undefined, dataState: "empty" }
+// 2. email hasn't been delivered by the network so it gets pruned
+{ data: { user: 1, name: "User" }, dataState: "streaming" }
+// 3. full result returned after the network streams the email field
+{ data: { user: 1, name: "User", email: "user.network@example.com" }, dataState: "complete" }
+```
+
+This is especially helpful in situations where `@defer` boundaries that are never delivered due to errors prevent an awkward situation where the client would otherwise have to choose whether to serve the stale cache result from the cache, or prune the undelivered fragment on the final chunk.

--- a/.size-limits.json
+++ b/.size-limits.json
@@ -1,6 +1,6 @@
 {
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 51378,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 45439,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 38760,
-  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 31837
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (CJS)": 51925,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production) (CJS)": 46000,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\"": 39003,
+  "import { ApolloClient, InMemoryCache, HttpLink } from \"@apollo/client\" (production)": 32118
 }

--- a/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
+++ b/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
@@ -2988,6 +2988,136 @@ test("truncates a complete stream array to the stream position when truncation i
   });
 });
 
+test('returns dataState "complete" when truncating a stream item with an empty @defer boundary', () => {
+  const cache = new InMemoryCache();
+  const query = gql`
+    query {
+      friendList @stream(initialCount: 1) {
+        id
+        name
+        ... on Friend @defer {
+          email
+          phone
+        }
+      }
+    }
+  `;
+  const streamInfo = makeStreamInfoTrie();
+  streamInfo.lookupArray(["friendList"]).state.truncate = true;
+  streamInfo.lookupArray(["friendList"]).state.streamPosition = 1;
+
+  cache.writeQuery({
+    query,
+    data: {
+      friendList: [
+        {
+          __typename: "Friend",
+          id: "1",
+          name: "Luke",
+          email: "luke@example.com",
+          phone: "555-0101",
+        },
+        {
+          __typename: "Friend",
+          id: "2",
+          name: "Han",
+        },
+      ],
+    },
+  });
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: true,
+      returnPartialData: false,
+      [handleIncrementalSymbol]: { streamInfo },
+    })
+  ).toStrictEqualTyped({
+    result: {
+      friendList: [
+        {
+          __typename: "Friend",
+          id: "1",
+          name: "Luke",
+          email: "luke@example.com",
+          phone: "555-0101",
+        },
+      ],
+    },
+    dataState: "complete",
+    complete: true,
+    missing: undefined,
+  });
+});
+
+test('returns dataState "complete" when truncating a stream item with a partial @defer boundary', () => {
+  const cache = new InMemoryCache();
+  const query = gql`
+    query {
+      friendList @stream(initialCount: 1) {
+        id
+        name
+        ... on Friend @defer {
+          email
+          phone
+        }
+      }
+    }
+  `;
+  const streamInfo = makeStreamInfoTrie();
+  streamInfo.lookupArray(["friendList"]).state.truncate = true;
+  streamInfo.lookupArray(["friendList"]).state.streamPosition = 1;
+
+  {
+    using _ = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        friendList: [
+          {
+            __typename: "Friend",
+            id: "1",
+            name: "Luke",
+            email: "luke@example.com",
+            phone: "555-0101",
+          },
+          {
+            __typename: "Friend",
+            id: "2",
+            name: "Han",
+            email: "han@example.com",
+          },
+        ],
+      },
+    });
+  }
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: true,
+      returnPartialData: false,
+      [handleIncrementalSymbol]: { streamInfo },
+    })
+  ).toStrictEqualTyped({
+    result: {
+      friendList: [
+        {
+          __typename: "Friend",
+          id: "1",
+          name: "Luke",
+          email: "luke@example.com",
+          phone: "555-0101",
+        },
+      ],
+    },
+    dataState: "complete",
+    complete: true,
+    missing: undefined,
+  });
+});
+
 test("invalidates a pruned stream array when the stream position changes", () => {
   const cache = new InMemoryCache();
   const query = gql`

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -103,6 +103,11 @@ type ExecResult<R = any> = {
   missing?: MissingTree;
 };
 
+type PruneResult<R = any> = {
+  result: R;
+  dataState: DataState;
+};
+
 type ExecSelectionSetOptions = {
   selectionSet: SelectionSetNode;
   objectOrReference: StoreObject | Reference;
@@ -168,11 +173,11 @@ export class StoreReader {
 
   private prunePartialStreamArray: OptimisticWrapperFunction<
     [PruneArrayOptions],
-    any[]
+    PruneResult
   >;
   private prunePartialBoundaries: OptimisticWrapperFunction<
     [PruneSelectionSetOptions],
-    Record<string, any>
+    PruneResult
   >;
 
   private config: {
@@ -371,7 +376,7 @@ export class StoreReader {
         context,
         path: [],
       });
-      const changed = execResult.result !== pruned;
+      const changed = execResult.result !== pruned.result;
       // It's possible that pruning didn't actually change the result which can
       // happen if a defer boundary is misclassified as "deferPartial" instead
       // of "streaming" (sibling defer boundaries with overlapping selection
@@ -381,21 +386,12 @@ export class StoreReader {
       // we want to keep the original execResult which contains the partial
       // data.
       if (!changed || !returnPartialData) {
-        const { dataState } = execResult;
-
         // Omit `missing` property since pruning puts it in a state that doesn't
         // report missing fields.
         execResult = {
-          result: pruned,
+          result: pruned.result,
           partialBoundaries: execResult.partialBoundaries,
-          dataState:
-            dataState === "deferPartial" ? "streaming"
-            : dataState === "streamPartial" ? "complete"
-              // A cached @defer boundary the network hasn't delivered was
-              // pruned from an otherwise complete result, so we're still
-              // streaming.
-            : context.deferInfo && changed ? "streaming"
-            : dataState,
+          dataState: pruned.dataState,
         };
       }
     }
@@ -826,14 +822,17 @@ export class StoreReader {
     data,
     path,
     selectionSet,
-  }: PruneSelectionSetOptions): any {
+  }: PruneSelectionSetOptions): PruneResult<any> {
     const { variables, lookupFragment, policies } = context;
 
-    if (data == null || !boundaries) return data;
+    if (data == null || !boundaries) {
+      return { result: data, dataState: "complete" };
+    }
 
     const merger = new DeepMerger();
 
     let changed = false;
+    let dataState: DataState = "complete";
     const result: Record<string, any> = {};
 
     // __typename might not be part of the selection set, so preserve it when
@@ -865,8 +864,9 @@ export class StoreReader {
             path: path.concat(resultName),
           });
 
-          changed ||= pruned !== fieldValue;
-          result[resultName] = pruned;
+          changed ||= pruned.result !== fieldValue;
+          result[resultName] = pruned.result;
+          dataState = mergeDataState(dataState, pruned.dataState);
         } else if (!selection.selectionSet) {
           result[resultName] = fieldValue;
         } else {
@@ -878,14 +878,15 @@ export class StoreReader {
             path: path.concat(resultName),
           });
 
-          changed ||= pruned !== fieldValue;
+          changed ||= pruned.result !== fieldValue;
+          dataState = mergeDataState(dataState, pruned.dataState);
 
           // A response key can be selected by more than one selection (e.g. a
           // field and an overlapping fragment), so merge their kept fields.
           result[resultName] =
             Object.hasOwn(result, resultName) ?
-              merger.merge(result[resultName], pruned)
-            : pruned;
+              merger.merge(result[resultName], pruned.result)
+            : pruned.result;
         }
 
         return;
@@ -912,13 +913,12 @@ export class StoreReader {
         prune = !!context.deferInfo.peekArray(path.concat(label || []));
       }
 
-      if (
-        fragment &&
-        policies.fragmentMatches(fragment, data.__typename) &&
-        !boundaries.has(selection) &&
-        !prune
-      ) {
-        fragment.selectionSet.selections.forEach(workSet.add, workSet);
+      if (fragment && policies.fragmentMatches(fragment, data.__typename)) {
+        if (boundaries.has(selection) || prune) {
+          dataState = mergeDataState(dataState, "streaming");
+        } else {
+          fragment.selectionSet.selections.forEach(workSet.add, workSet);
+        }
       }
     });
 
@@ -932,7 +932,7 @@ export class StoreReader {
       changed = !equal(result, data);
     }
 
-    return changed ? result : data;
+    return { result: changed ? result : data, dataState };
   }
 
   private prunePartialStreamArrayImpl({
@@ -941,10 +941,11 @@ export class StoreReader {
     boundaries,
     context,
     path,
-  }: PruneArrayOptions) {
-    if (!boundaries) return array;
+  }: PruneArrayOptions): PruneResult<any> {
+    if (!boundaries) return { result: array, dataState: "complete" };
 
     let changed = false;
+    let dataState: DataState = "complete";
     let pruned: any[] = [];
 
     const state = context.streamInfo?.peekArray(path)?.state;
@@ -956,7 +957,10 @@ export class StoreReader {
     for (let i = 0; i < length; i++) {
       const item = array[i];
 
-      let prunedItem = item;
+      let prunedResult: PruneResult<any> = {
+        result: item,
+        dataState: "complete",
+      };
       const boundary = boundaries.getChild(i);
 
       if (boundary?.has(field)) {
@@ -977,7 +981,7 @@ export class StoreReader {
       }
 
       if (Array.isArray(item)) {
-        prunedItem = this.prunePartialStreamArray({
+        prunedResult = this.prunePartialStreamArray({
           field,
           array: item,
           boundaries: boundaries.getChild(i),
@@ -985,7 +989,7 @@ export class StoreReader {
           path: path.concat(i),
         });
       } else if (field.selectionSet) {
-        prunedItem = this.prunePartialBoundaries({
+        prunedResult = this.prunePartialBoundaries({
           data: item,
           selectionSet: field.selectionSet,
           boundaries: boundaries.getChild(i),
@@ -994,13 +998,14 @@ export class StoreReader {
         });
       }
 
-      pruned.push(prunedItem);
-      changed ||= prunedItem !== item;
+      pruned.push(prunedResult.result);
+      changed ||= prunedResult.result !== item;
+      dataState = mergeDataState(dataState, prunedResult.dataState);
     }
 
     changed ||= pruned.length !== array.length;
 
-    return changed ? pruned : array;
+    return { result: changed ? pruned : array, dataState };
   }
 }
 

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -978,6 +978,7 @@ export class StoreReader {
           pruned = pruned.slice(0, state.streamPosition);
         } else {
           pruned = [];
+          dataState = "complete";
         }
 
         break;

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -690,7 +690,10 @@ export class StoreReader {
             missing = missingMerger.merge(missing, execResult.missing);
           }
 
-          if (isDeferBoundary && nextDataState === "partial") {
+          if (
+            isDeferBoundary &&
+            (nextDataState === "partial" || nextDataState === "empty")
+          ) {
             partialBoundaries.add(selection);
           }
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -278,7 +278,7 @@ export class QueryInfo<
               errorPolicy !== "none" ||
               !this.incrementalHandler.extractErrors(incoming)?.length,
           },
-          this.getIncrementalInfo({ isNetworkOnly })
+          this.getIncrementalInfo({ prune: isNetworkOnly })
         )
       );
 
@@ -405,7 +405,7 @@ export class QueryInfo<
             // Never deliver partial data for network-only requests
             returnPartialData: returnPartialData && !isNetworkOnly,
           },
-          this.getIncrementalInfo({ isNetworkOnly })
+          this.getIncrementalInfo({ prune: isNetworkOnly })
         );
 
         if (
@@ -436,7 +436,7 @@ export class QueryInfo<
     return result;
   }
 
-  private getIncrementalInfo({ isNetworkOnly }: { isNetworkOnly: boolean }) {
+  private getIncrementalInfo({ prune }: { prune: boolean }) {
     const pending = this.incremental?.getPendingWithInfo?.() ?? [];
     const streamInfo = this.incremental?.streamInfo;
     const incrementalInfo: DiffIncrementalInfo = { streamInfo };
@@ -445,7 +445,7 @@ export class QueryInfo<
     // for a network-only request if they haven't yet streamed from the
     // network. We record all the still-pending paths so that cache.diff
     // can prune complete defer/stream boundaries at those paths.
-    if (isNetworkOnly) {
+    if (prune) {
       for (const item of pending) {
         if (item.type === "defer" && !item.delivered) {
           incrementalInfo.deferInfo ||= new Trie(true, () => true);

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -256,9 +256,6 @@ export class QueryInfo<
       optimistic: true,
     };
 
-    const isNetworkOnly =
-      fetchPolicy === "network-only" && networkStatus !== NetworkStatus.refetch;
-
     // Cancel the pending notify timeout (if it exists) to prevent extraneous network
     // requests. To allow future notify timeouts, diff and dirty are reset as well.
     this.observableQuery?.["resetNotifications"]();
@@ -405,8 +402,11 @@ export class QueryInfo<
         const { dataState, result: diffResult } = this.getDiff(
           {
             ...diffOptions,
-            // Never deliver partial data for network-only requests
-            returnPartialData: returnPartialData && !isNetworkOnly,
+            returnPartialData:
+              returnPartialData &&
+              // Never deliver partial data for network-only requests
+              (fetchPolicy !== "network-only" ||
+                networkStatus === NetworkStatus.refetch),
           },
           this.getIncrementalInfo({ prune })
         );

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -277,7 +277,7 @@ export class QueryInfo<
               errorPolicy !== "none" ||
               !this.incrementalHandler.extractErrors(incoming)?.length,
           },
-          this.getIncrementalInfo({ isNetworkOnly })
+          this.getIncrementalInfo({ prune: isNetworkOnly })
         )
       );
 
@@ -401,7 +401,7 @@ export class QueryInfo<
             // Never deliver partial data for network-only requests
             returnPartialData: returnPartialData && !isNetworkOnly,
           },
-          this.getIncrementalInfo({ isNetworkOnly })
+          this.getIncrementalInfo({ prune: isNetworkOnly })
         );
 
         if (
@@ -417,7 +417,7 @@ export class QueryInfo<
     return result;
   }
 
-  private getIncrementalInfo({ isNetworkOnly }: { isNetworkOnly: boolean }) {
+  private getIncrementalInfo({ prune }: { prune: boolean }) {
     const pending = this.incremental?.getPendingWithInfo?.() ?? [];
     const streamInfo = this.incremental?.streamInfo;
     const incrementalInfo: DiffIncrementalInfo = { streamInfo };
@@ -426,7 +426,7 @@ export class QueryInfo<
     // for a network-only request if they haven't yet streamed from the
     // network. We record all the still-pending paths so that cache.diff
     // can prune complete defer/stream boundaries at those paths.
-    if (isNetworkOnly) {
+    if (prune) {
       for (const item of pending) {
         if (item.type === "defer" && !item.delivered) {
           incrementalInfo.deferInfo ||= new Trie(true, () => true);

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -239,9 +239,11 @@ export class QueryInfo<
       returnPartialData,
       fetchPolicy,
       networkStatus,
+      prunePendingDeferFragments: prune,
     }: OperationInfo<TData, TVariables> & {
       fetchPolicy: WatchQueryFetchPolicy;
       networkStatus: NetworkStatus;
+      prunePendingDeferFragments: boolean;
     }
   ): MarkQueryResult<
     DataValue.Complete<TData> | DataValue.Streaming<TData>,
@@ -252,16 +254,9 @@ export class QueryInfo<
       variables,
       optimistic: true,
     };
+
     const isNetworkOnly =
       fetchPolicy === "network-only" && networkStatus !== NetworkStatus.refetch;
-    const prune =
-      // Always prune network-only since it doesn't deliver results from the
-      // cache
-      isNetworkOnly ||
-      // If we've reached this point with a cache-first fetch policy, a
-      // network request occurred, so prune anything that hasn't been
-      // delivered yet, even if its in the cache
-      fetchPolicy === "cache-first";
 
     // Cancel the pending notify timeout (if it exists) to prevent extraneous network
     // requests. To allow future notify timeouts, diff and dirty are reset as well.

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -254,6 +254,14 @@ export class QueryInfo<
     };
     const isNetworkOnly =
       fetchPolicy === "network-only" && networkStatus !== NetworkStatus.refetch;
+    const prune =
+      // Always prune network-only since it doesn't deliver results from the
+      // cache
+      isNetworkOnly ||
+      // If we've reached this point with a cache-first fetch policy, a
+      // network request occurred, so prune anything that hasn't been
+      // delivered yet, even if its in the cache
+      fetchPolicy === "cache-first";
 
     // Cancel the pending notify timeout (if it exists) to prevent extraneous network
     // requests. To allow future notify timeouts, diff and dirty are reset as well.
@@ -277,7 +285,7 @@ export class QueryInfo<
               errorPolicy !== "none" ||
               !this.incrementalHandler.extractErrors(incoming)?.length,
           },
-          this.getIncrementalInfo({ prune: isNetworkOnly })
+          this.getIncrementalInfo({ prune })
         )
       );
 
@@ -401,7 +409,7 @@ export class QueryInfo<
             // Never deliver partial data for network-only requests
             returnPartialData: returnPartialData && !isNetworkOnly,
           },
-          this.getIncrementalInfo({ prune: isNetworkOnly })
+          this.getIncrementalInfo({ prune })
         );
 
         if (

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -240,9 +240,11 @@ export class QueryInfo<
       returnPartialData,
       fetchPolicy,
       networkStatus,
+      prunePendingDeferFragments: prune,
     }: OperationInfo<TData, TVariables> & {
       fetchPolicy: WatchQueryFetchPolicy;
       networkStatus: NetworkStatus;
+      prunePendingDeferFragments: boolean;
     }
   ): MarkQueryResult<
     DataValue.Complete<TData> | DataValue.Streaming<TData>,
@@ -253,16 +255,9 @@ export class QueryInfo<
       variables,
       optimistic: true,
     };
+
     const isNetworkOnly =
       fetchPolicy === "network-only" && networkStatus !== NetworkStatus.refetch;
-    const prune =
-      // Always prune network-only since it doesn't deliver results from the
-      // cache
-      isNetworkOnly ||
-      // If we've reached this point with a cache-first fetch policy, a
-      // network request occurred, so prune anything that hasn't been
-      // delivered yet, even if its in the cache
-      fetchPolicy === "cache-first";
 
     // Cancel the pending notify timeout (if it exists) to prevent extraneous network
     // requests. To allow future notify timeouts, diff and dirty are reset as well.

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -255,9 +255,6 @@ export class QueryInfo<
       optimistic: true,
     };
 
-    const isNetworkOnly =
-      fetchPolicy === "network-only" && networkStatus !== NetworkStatus.refetch;
-
     // Cancel the pending notify timeout (if it exists) to prevent extraneous network
     // requests. To allow future notify timeouts, diff and dirty are reset as well.
     this.observableQuery?.["resetNotifications"]();
@@ -401,8 +398,11 @@ export class QueryInfo<
         const { dataState, result: diffResult } = this.getDiff(
           {
             ...diffOptions,
-            // Never deliver partial data for network-only requests
-            returnPartialData: returnPartialData && !isNetworkOnly,
+            returnPartialData:
+              returnPartialData &&
+              // Never deliver partial data for network-only requests
+              (fetchPolicy !== "network-only" ||
+                networkStatus === NetworkStatus.refetch),
           },
           this.getIncrementalInfo({ prune })
         );

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -255,6 +255,14 @@ export class QueryInfo<
     };
     const isNetworkOnly =
       fetchPolicy === "network-only" && networkStatus !== NetworkStatus.refetch;
+    const prune =
+      // Always prune network-only since it doesn't deliver results from the
+      // cache
+      isNetworkOnly ||
+      // If we've reached this point with a cache-first fetch policy, a
+      // network request occurred, so prune anything that hasn't been
+      // delivered yet, even if its in the cache
+      fetchPolicy === "cache-first";
 
     // Cancel the pending notify timeout (if it exists) to prevent extraneous network
     // requests. To allow future notify timeouts, diff and dirty are reset as well.
@@ -278,7 +286,7 @@ export class QueryInfo<
               errorPolicy !== "none" ||
               !this.incrementalHandler.extractErrors(incoming)?.length,
           },
-          this.getIncrementalInfo({ prune: isNetworkOnly })
+          this.getIncrementalInfo({ prune })
         )
       );
 
@@ -405,7 +413,7 @@ export class QueryInfo<
             // Never deliver partial data for network-only requests
             returnPartialData: returnPartialData && !isNetworkOnly,
           },
-          this.getIncrementalInfo({ prune: isNetworkOnly })
+          this.getIncrementalInfo({ prune })
         );
 
         if (

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1053,11 +1053,13 @@ export class QueryManager {
       cacheWriteBehavior,
       observableQuery,
       exposeExtensions,
+      prunePendingDeferFragments,
     }: {
       queryInfo: QueryInfo<TData, TVariables>;
       cacheWriteBehavior: CacheWriteBehavior;
       observableQuery: ObservableQuery<TData, TVariables> | undefined;
       exposeExtensions?: boolean;
+      prunePendingDeferFragments: boolean;
     }
   ): Observable<ObservableQuery.Result<TData>> {
     const { errorPolicy } = options;
@@ -1082,6 +1084,7 @@ export class QueryManager {
           document: linkDocument,
           cacheWriteBehavior,
           returnPartialData: options.returnPartialData,
+          prunePendingDeferFragments,
         });
         const hasErrors = graphQLResultHasError(result);
 
@@ -1689,7 +1692,11 @@ export class QueryManager {
       return fromData(data || undefined);
     };
 
-    const resultsFromLink = () =>
+    const resultsFromLink = ({
+      prunePendingDeferFragments = true,
+    }: {
+      prunePendingDeferFragments?: boolean;
+    } = {}) =>
       this.getResultsFromLink<TData, TVariables>(
         {
           query,
@@ -1705,6 +1712,7 @@ export class QueryManager {
           queryInfo,
           observableQuery,
           exposeExtensions,
+          prunePendingDeferFragments,
         }
       ).pipe(
         validateDidEmitValue(),
@@ -1754,7 +1762,7 @@ export class QueryManager {
             fromLink: true,
             observable: concat(
               resultsFromCache(diff, NetworkStatus.loading),
-              resultsFromLink()
+              resultsFromLink({ prunePendingDeferFragments: false })
             ),
           };
         }
@@ -1771,7 +1779,12 @@ export class QueryManager {
         };
 
       case "network-only":
-        return { fromLink: true, observable: resultsFromLink() };
+        return {
+          fromLink: true,
+          observable: resultsFromLink({
+            prunePendingDeferFragments: networkStatus !== NetworkStatus.refetch,
+          }),
+        };
 
       case "no-cache":
         return { fromLink: true, observable: resultsFromLink() };

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -6487,7 +6487,7 @@ test('does not return complete cached deferred data while streaming with a "cach
 
   enqueueInitialChunk({
     data: { greeting: { __typename: "Greeting", message: "Hello world" } },
-    pending: [{ id: "0", path: ["greeting"] }],
+    pending: [{ id: "0", path: ["greeting"], label: "ac_0" }],
     hasNext: true,
   });
 
@@ -6588,7 +6588,7 @@ test('does not return complete cached deferred data when a defer boundary comple
 
   enqueueInitialChunk({
     data: { greeting: { __typename: "Greeting", message: "Hello world" } },
-    pending: [{ id: "0", path: ["greeting"] }],
+    pending: [{ id: "0", path: ["greeting"], label: "ac_0" }],
     hasNext: true,
   });
 
@@ -6694,7 +6694,7 @@ test('does not return complete cached deferred data while streaming with a "cach
 
   enqueueInitialChunk({
     data: { greeting: { __typename: "Greeting", message: "Hello world" } },
-    pending: [{ id: "0", path: ["greeting"] }],
+    pending: [{ id: "0", path: ["greeting"], label: "ac_0" }],
     hasNext: true,
   });
 
@@ -6798,7 +6798,7 @@ test('does not return complete cached deferred data when a defer boundary comple
 
   enqueueInitialChunk({
     data: { greeting: { __typename: "Greeting", message: "Hello world" } },
-    pending: [{ id: "0", path: ["greeting"] }],
+    pending: [{ id: "0", path: ["greeting"], label: "ac_0" }],
     hasNext: true,
   });
 
@@ -7029,8 +7029,8 @@ test('prunes a list item\'s cached defer boundary while a sibling item has alrea
       },
     },
     pending: [
-      { id: "0", path: ["person", "friends", 0] },
-      { id: "1", path: ["person", "friends", 1] },
+      { id: "0", path: ["person", "friends", 0], label: "ac_0" },
+      { id: "1", path: ["person", "friends", 1], label: "ac_0" },
     ],
     hasNext: true,
   });

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -6312,6 +6312,795 @@ test('reports complete cached deferred data as "complete" while streaming with a
   await expect(stream).not.toEmitAnything();
 });
 
+test('keeps complete cached deferred data when a defer boundary completes with errors with a "cache-and-network" fetch policy', async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  cache.writeQuery({
+    query,
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello cached",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+  });
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "cache-and-network",
+      errorPolicy: "all",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello cached",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: false,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: false,
+  });
+
+  enqueueSubsequentChunk({
+    completed: [
+      {
+        id: "0",
+        errors: [
+          {
+            message: "Could not fetch recipient",
+            path: ["greeting", "recipient"],
+          },
+        ],
+      },
+    ],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "complete",
+    error: new CombinedGraphQLErrors({
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          message: "Hello world",
+          recipient: { __typename: "Person", name: "Cached Alice" },
+        },
+      },
+      errors: [
+        {
+          message: "Could not fetch recipient",
+          path: ["greeting", "recipient"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test('does not return complete cached deferred data while streaming with a "cache-first" fetch policy when the non-deferred cached data is incomplete', async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _consoleSpy = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Cached Alice" },
+        },
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(client.watchQuery({ query }));
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  // The cached recipient was never delivered to the observer because the
+  // non-deferred `message` field was missing from the cache, so the pending
+  // defer boundary is pruned instead of surfacing data that hasn't streamed in.
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [
+      {
+        data: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Alice" },
+        },
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Alice" },
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test('does not return complete cached deferred data when a defer boundary completes with errors with a "cache-first" fetch policy when the non-deferred cached data is incomplete', async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _consoleSpy = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Cached Alice" },
+        },
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({ query, errorPolicy: "all" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    completed: [
+      {
+        id: "0",
+        errors: [
+          {
+            message: "Could not fetch recipient",
+            path: ["greeting", "recipient"],
+          },
+        ],
+      },
+    ],
+    hasNext: false,
+  });
+
+  // The network never delivered the defer boundary, so the hole in the data
+  // remains instead of being backfilled with the cached recipient.
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    error: new CombinedGraphQLErrors({
+      data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+      errors: [
+        {
+          message: "Could not fetch recipient",
+          path: ["greeting", "recipient"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    partial: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test('does not return complete cached deferred data while streaming with a "cache-and-network" fetch policy when the non-deferred cached data is incomplete', async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _consoleSpy = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Cached Alice" },
+        },
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-and-network" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  // The first emit didn't contain the cached recipient, so the pending defer
+  // boundary is pruned rather than delivering it alongside the network result.
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [
+      {
+        data: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Alice" },
+        },
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Alice" },
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test('does not return complete cached deferred data when a defer boundary completes with errors with a "cache-and-network" fetch policy when the non-deferred cached data is incomplete', async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _consoleSpy = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Cached Alice" },
+        },
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "cache-and-network",
+      errorPolicy: "all",
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    completed: [
+      {
+        id: "0",
+        errors: [
+          {
+            message: "Could not fetch recipient",
+            path: ["greeting", "recipient"],
+          },
+        ],
+      },
+    ],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    }),
+    dataState: "streaming",
+    error: new CombinedGraphQLErrors({
+      data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+      errors: [
+        {
+          message: "Could not fetch recipient",
+          path: ["greeting", "recipient"],
+        },
+      ],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    partial: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test('reports residual deferred cached data as "complete" while streaming with a "cache-and-network" fetch policy and returnPartialData', async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _consoleSpy = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Cached Alice" },
+        },
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "cache-and-network",
+      returnPartialData: true,
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { greeting: { __typename: "Greeting", message: "Hello world" } },
+    pending: [{ id: "0", path: ["greeting"] }],
+    hasNext: true,
+  });
+
+  // The cached recipient was already delivered in the first emit, so it is kept
+  // as residual data instead of being pruned.
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Cached Alice" },
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: false,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [
+      {
+        data: {
+          __typename: "Greeting",
+          recipient: { __typename: "Person", name: "Alice" },
+        },
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      greeting: {
+        __typename: "Greeting",
+        message: "Hello world",
+        recipient: { __typename: "Person", name: "Alice" },
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test('prunes a list item\'s cached defer boundary while a sibling item has already streamed in with a "cache-first" fetch policy', async () => {
+  const query = gql`
+    query {
+      person {
+        id
+        friends {
+          id
+          ... @defer {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _consoleSpy = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        person: {
+          __typename: "Person",
+          friends: [
+            { __typename: "Person", id: "2", name: "Cached Leia" },
+            { __typename: "Person", id: "3", name: "Cached Han" },
+          ],
+        },
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-first" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: {
+      person: {
+        __typename: "Person",
+        id: "1",
+        friends: [
+          { __typename: "Person", id: "2" },
+          { __typename: "Person", id: "3" },
+        ],
+      },
+    },
+    pending: [
+      { id: "0", path: ["person", "friends", 0] },
+      { id: "1", path: ["person", "friends", 1] },
+    ],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      person: {
+        __typename: "Person",
+        id: "1",
+        friends: [
+          { __typename: "Person", id: "2" },
+          { __typename: "Person", id: "3" },
+        ],
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ data: { __typename: "Person", name: "Leia" }, id: "0" }],
+    hasNext: true,
+    completed: [{ id: "0" }],
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      person: {
+        __typename: "Person",
+        id: "1",
+        friends: [
+          { __typename: "Person", id: "2", name: "Leia" },
+          { __typename: "Person", id: "3" },
+        ],
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ data: { __typename: "Person", name: "Han" }, id: "1" }],
+    completed: [{ id: "1" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      person: {
+        __typename: "Person",
+        id: "1",
+        friends: [
+          { __typename: "Person", id: "2", name: "Leia" },
+          { __typename: "Person", id: "3", name: "Han" },
+        ],
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test('does not return complete cached deferred data while streaming with a "network-only" fetch policy', async () => {
   const query = gql`
     query {

--- a/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
@@ -4175,7 +4175,7 @@ test("does not surface complete cached `@defer` boundaries on streamed list item
       friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
     },
     pending: [
-      { id: "0", path: ["friendList", 0] },
+      { id: "0", path: ["friendList", 0], label: "ac_0" },
       { id: "1", path: ["friendList"] },
     ],
     hasNext: true,
@@ -4231,7 +4231,7 @@ test("does not surface complete cached `@defer` boundaries on streamed list item
         id: "1",
       },
     ],
-    pending: [{ id: "2", path: ["friendList", 1] }],
+    pending: [{ id: "2", path: ["friendList", 1], label: "ac_0" }],
     hasNext: true,
   });
 

--- a/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
@@ -4117,6 +4117,186 @@ test("prunes each streamed list item's sibling `@defer` boundaries independently
   await expect(stream).not.toEmitAnything();
 });
 
+test("does not surface complete cached `@defer` boundaries on streamed list items with returnPartialData: false", async () => {
+  const mock = mockDeferStreamGraphQL17Alpha9();
+
+  const query = gql`
+    query {
+      friendList @stream(initialCount: 1) {
+        id
+        name
+        ... on Friend @defer {
+          email
+          phone
+        }
+      }
+    }
+  `;
+
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _ = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        friendList: [
+          {
+            __typename: "Friend",
+            id: "1",
+            email: "cached-luke@example.com",
+            phone: "555-9101",
+          },
+        ],
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: mock.httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(client.watchQuery({ query }));
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  mock.enqueueInitialChunk({
+    data: {
+      friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
+    },
+    pending: [
+      { id: "0", path: ["friendList", 0] },
+      { id: "1", path: ["friendList"] },
+    ],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  mock.enqueueSubsequentChunk({
+    incremental: [
+      {
+        data: {
+          __typename: "Friend",
+          email: "luke@example.com",
+          phone: "555-0101",
+        },
+        id: "0",
+      },
+    ],
+    completed: [{ id: "0" }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      friendList: [
+        {
+          __typename: "Friend",
+          id: "1",
+          name: "Luke",
+          email: "luke@example.com",
+          phone: "555-0101",
+        },
+      ],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  mock.enqueueSubsequentChunk({
+    incremental: [
+      {
+        items: [{ __typename: "Friend", id: "2", name: "Han" }] as any,
+        id: "1",
+      },
+    ],
+    pending: [{ id: "2", path: ["friendList", 1] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      friendList: [
+        {
+          __typename: "Friend",
+          id: "1",
+          name: "Luke",
+          email: "luke@example.com",
+          phone: "555-0101",
+        },
+        { __typename: "Friend", id: "2", name: "Han" },
+      ],
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  mock.enqueueSubsequentChunk({
+    incremental: [
+      {
+        data: {
+          __typename: "Friend",
+          email: "han@example.com",
+          phone: "555-0102",
+        },
+        id: "2",
+      },
+    ],
+    completed: [{ id: "1" }, { id: "2" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [
+        {
+          __typename: "Friend",
+          id: "1",
+          name: "Luke",
+          email: "luke@example.com",
+          phone: "555-0101",
+        },
+        {
+          __typename: "Friend",
+          id: "2",
+          name: "Han",
+          email: "han@example.com",
+          phone: "555-0102",
+        },
+      ],
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test("applies field read functions to streamed list items on intermediate and final results", async () => {
   const { subject, stream: iterableStream } = asyncIterableSubject<Friend>();
 
@@ -4469,6 +4649,226 @@ test("applies field read functions to partial cached stream list data before and
         { __typename: "Friend", id: "1", name: "LUKE" },
         { __typename: "Friend", id: "2", name: "HAN" },
         { __typename: "Friend", id: "3", name: "LEIA" },
+      ],
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("only reports streamed items from a partial stream array with a cache-first fetch policy", async () => {
+  const { subject, stream: iterableStream } = asyncIterableSubject<Friend>();
+
+  const query = gql`
+    query {
+      friendList @stream(initialCount: 1) {
+        id
+        name
+      }
+    }
+  `;
+
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _ = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        friendList: [
+          { __typename: "Friend", id: "1" },
+          { __typename: "Friend", id: "2", name: "Cached Han" },
+          { __typename: "Friend", id: "3", name: "Cached Leia" },
+        ],
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: createLink({ friendList: () => iterableStream }),
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-first" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  subject.next(friends[0]);
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: false,
+  });
+
+  subject.next(friends[1]);
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [
+        { __typename: "Friend", id: "1", name: "Luke" },
+        { __typename: "Friend", id: "2", name: "Han" },
+      ],
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: false,
+  });
+
+  subject.next(friends[2]);
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [
+        { __typename: "Friend", id: "1", name: "Luke" },
+        { __typename: "Friend", id: "2", name: "Han" },
+        { __typename: "Friend", id: "3", name: "Leia" },
+      ],
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: false,
+  });
+
+  subject.complete();
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [
+        { __typename: "Friend", id: "1", name: "Luke" },
+        { __typename: "Friend", id: "2", name: "Han" },
+        { __typename: "Friend", id: "3", name: "Leia" },
+      ],
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
+test("only reports streamed items from a partial stream array with a cache-and-network fetch policy", async () => {
+  const { subject, stream: iterableStream } = asyncIterableSubject<Friend>();
+
+  const query = gql`
+    query {
+      friendList @stream(initialCount: 1) {
+        id
+        name
+      }
+    }
+  `;
+
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _ = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        friendList: [
+          { __typename: "Friend", id: "1" },
+          { __typename: "Friend", id: "2", name: "Cached Han" },
+          { __typename: "Friend", id: "3", name: "Cached Leia" },
+        ],
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: createLink({ friendList: () => iterableStream }),
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-and-network" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  subject.next(friends[0]);
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: false,
+  });
+
+  subject.next(friends[1]);
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [
+        { __typename: "Friend", id: "1", name: "Luke" },
+        { __typename: "Friend", id: "2", name: "Han" },
+      ],
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: false,
+  });
+
+  subject.next(friends[2]);
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [
+        { __typename: "Friend", id: "1", name: "Luke" },
+        { __typename: "Friend", id: "2", name: "Han" },
+        { __typename: "Friend", id: "3", name: "Leia" },
+      ],
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: false,
+  });
+
+  subject.complete();
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      friendList: [
+        { __typename: "Friend", id: "1", name: "Luke" },
+        { __typename: "Friend", id: "2", name: "Han" },
+        { __typename: "Friend", id: "3", name: "Leia" },
       ],
     },
     dataState: "complete",

--- a/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/streamGraphQL17Alpha9.test.ts
@@ -3650,10 +3650,7 @@ test("does not surface incomplete cached fields on a streamed item after the net
 
   await expect(stream).toEmitTypedValue({
     data: {
-      friendList: [
-        { __typename: "Friend", id: "1", name: "Luke" },
-        { __typename: "Friend", id: "2", name: "Cached Han" },
-      ],
+      friendList: [{ __typename: "Friend", id: "1", name: "Luke" }],
     },
     dataState: "complete",
     loading: true,
@@ -3693,7 +3690,7 @@ test("does not surface incomplete cached fields on a streamed item after the net
   await expect(stream).not.toEmitAnything();
 });
 
-test("does not surface incomplete cached fields inside a `@defer` boundary on streamed list items with returnPartialData: false", async () => {
+test("prunes undelivered defer fragments from partial cached fields inside a `@defer` boundary on streamed list items with returnPartialData: false", async () => {
   const mock = mockDeferStreamGraphQL17Alpha9();
 
   const query = gql`
@@ -3774,11 +3771,6 @@ test("does not surface incomplete cached fields inside a `@defer` boundary on st
           id: "1",
           name: "Luke",
         },
-        {
-          __typename: "Friend",
-          id: "2",
-          name: "Cached Han",
-        },
       ],
     }),
     dataState: "streaming",
@@ -3803,7 +3795,7 @@ test("does not surface incomplete cached fields inside a `@defer` boundary on st
   });
 
   await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
+    data: {
       friendList: [
         {
           __typename: "Friend",
@@ -3812,17 +3804,12 @@ test("does not surface incomplete cached fields inside a `@defer` boundary on st
           email: "luke@example.com",
           phone: "555-0101",
         },
-        {
-          __typename: "Friend",
-          id: "2",
-          name: "Cached Han",
-        },
       ],
-    }),
-    dataState: "streaming",
+    },
+    dataState: "complete",
     loading: true,
     networkStatus: NetworkStatus.streaming,
-    partial: true,
+    partial: false,
   });
 
   mock.enqueueSubsequentChunk({
@@ -4218,10 +4205,10 @@ test("does not surface complete cached `@defer` boundaries on streamed list item
         },
       ],
     }),
-    dataState: "streaming",
+    dataState: "complete",
     loading: true,
     networkStatus: NetworkStatus.streaming,
-    partial: true,
+    partial: false,
   });
 
   mock.enqueueSubsequentChunk({


### PR DESCRIPTION
This change adds a similar logic to `network-only` queries that prunes `@defer` fragments or `@stream` items not delivered by the network when the initial value returned by those fetch policies was partial. This makes the result more predictable as the network delivers values. See the changeset for an example of what this PR changed.