### PR TITLE
Fix type signature of some `DocumentationTypes` to fix their display in our documentation.

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -312,7 +312,8 @@ export namespace useBackgroundQuery {
         // (undocumented)
         export namespace useBackgroundQuery {
             // (undocumented)
-            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Omit<Base.Options, "variables">, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options {
+                variables?: TVariables;
             }
         }
     }
@@ -1147,7 +1148,8 @@ export namespace useQuery {
         // (undocumented)
         export namespace useQuery {
             // (undocumented)
-            export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> extends Omit<Base.Options<TData, TVariables>, "variables">, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TData = unknown, TVariables extends OperationVariables = OperationVariables> extends Base.Options<TData, TVariables> {
+                variables?: TVariables;
             }
         }
     }
@@ -1542,7 +1544,8 @@ export namespace useSuspenseQuery {
         // (undocumented)
         export namespace useSuspenseQuery {
             // (undocumented)
-            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Omit<Base.Options<TVariables>, "variables">, DocumentationTypes.VariableOptions<TVariables> {
+            export interface Options<TVariables extends OperationVariables = OperationVariables> extends Base.Options<TVariables> {
+                variables?: TVariables;
             }
         }
     }

--- a/.changeset/serious-suns-warn.md
+++ b/.changeset/serious-suns-warn.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix type signature of some `DocumentationTypes` to fix their display in our documentation.

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -26,7 +26,6 @@ import {
   wrapQueryRef,
 } from "@apollo/client/react/internal";
 import type {
-  DocumentationTypes as UtilityDocumentationTypes,
   NoInfer,
   OptionWithFallback,
   Prettify,
@@ -101,8 +100,10 @@ export declare namespace useBackgroundQuery {
     namespace useBackgroundQuery {
       export interface Options<
         TVariables extends OperationVariables = OperationVariables,
-      > extends Omit<Base.Options, "variables">,
-          UtilityDocumentationTypes.VariableOptions<TVariables> {}
+      > extends Base.Options {
+        /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+        variables?: TVariables;
+      }
     }
   }
 

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -129,8 +129,10 @@ export declare namespace useQuery {
       export interface Options<
         TData = unknown,
         TVariables extends OperationVariables = OperationVariables,
-      > extends Omit<Base.Options<TData, TVariables>, "variables">,
-          UtilityDocumentationTypes.VariableOptions<TVariables> {}
+      > extends Base.Options<TData, TVariables> {
+        /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+        variables?: TVariables;
+      }
     }
   }
 

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -108,8 +108,10 @@ export declare namespace useSuspenseQuery {
     namespace useSuspenseQuery {
       export interface Options<
         TVariables extends OperationVariables = OperationVariables,
-      > extends Omit<Base.Options<TVariables>, "variables">,
-          UtilityDocumentationTypes.VariableOptions<TVariables> {}
+      > extends Base.Options<TVariables> {
+        /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#variables:member} */
+        variables?: TVariables;
+      }
     }
   }
 


### PR DESCRIPTION
The `Omit` breaks https://www.apollographql.com/docs/react/api/react/useQuery#usequery-parameters-options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type signatures for query, background query, and suspense query options.
  * Corrected how variable options are represented in generated documentation.
  * Added documentation updates describing the corrected type behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->