### PR TITLE
Fix failing tests after merge

### DIFF
--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -389,7 +389,7 @@ export class QueryInfo<
           fetchPolicy === "network-only" &&
           networkStatus !== NetworkStatus.refetch;
 
-        const diff = this.getDiff(
+        const { dataState, result: diffResult } = this.getDiff(
           {
             ...diffOptions,
             // Never deliver partial data for network-only requests
@@ -398,14 +398,12 @@ export class QueryInfo<
           this.getIncrementalInfo(result, { isNetworkOnly })
         );
 
-        const { dataState } = diff;
-
         if (
           dataState === "complete" ||
           (returnPartialData && dataState === "partial" && shouldWrite) ||
           (this.hasNext && dataState === "streaming")
         ) {
-          result = { ...result, data: diff.result, dataState };
+          result = { ...result, data: diffResult, dataState };
         } else if (
           __DEV__ &&
           written &&
@@ -413,7 +411,12 @@ export class QueryInfo<
           // incomplete until the remaining chunks arrive.
           !this.hasNext
         ) {
-          warnAboutPartialCacheResult(query, result.data, diff);
+          warnAboutPartialCacheResult(
+            query,
+            result.data,
+            // Always show the partial result for debugging
+            cache.diff({ ...diffOptions, returnPartialData: true })
+          );
         }
       },
     });

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -414,7 +414,9 @@ export class QueryInfo<
           warnAboutPartialCacheResult(
             query,
             result.data,
-            // Always show the partial result for debugging
+            // Always show the partial result for debugging, otherwise the user
+            // sees `null` when `returnPartialData` is false which isn't helpful
+            // for figuring out where the problem is.
             cache.diff({ ...diffOptions, returnPartialData: true })
           );
         }

--- a/src/core/__tests__/incompleteCacheReadWarning.test.ts
+++ b/src/core/__tests__/incompleteCacheReadWarning.test.ts
@@ -427,18 +427,31 @@ test("does not warn again when the cache write is skipped because the identical 
     ]),
   });
 
-  const observable = client.watchQuery({ query, pollInterval: 10 });
+  const observable = client.watchQuery({ query });
   using stream = new ObservableStream(observable);
 
+  // loading
   await stream.takeNext();
+  // result
   await stream.takeNext();
 
   expect(console.warn).toHaveBeenCalledTimes(1);
 
-  // Each poll returns the identical result, so the cache write is skipped and
-  // the warning must not repeat.
-  await wait(60);
-  observable.stopPolling();
+  client.writeQuery({
+    query: gql`
+      query {
+        user {
+          name
+        }
+      }
+    `,
+    data: { user: { __typename: "User", name: "Alice (updated)" } },
+  });
+
+  // loading
+  await stream.takeNext();
+  // result
+  await stream.takeNext();
 
   expect(console.warn).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
4.2.11 added a new warning which touched code in `QueryInfo`. Since `QueryInfo` has changed a lot in 4.3, it broke the tests that check for the warning since we now honor `returnPartialData` in the `cache.diff` reread. This updates the tests so that we are at a good baseline again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of partial cached query results.
  * Prevented duplicate warnings when watched query data changes.
  * Ensured normal query results continue to be applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->