### PR TITLE
Fix one more bad dataState when data was partial or empty

### DIFF
--- a/.changeset/forty-trainers-switch.md
+++ b/.changeset/forty-trainers-switch.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue where the wrong `dataState` was returned when there was nothing written to the cache and a `@defer` fragment was marked pending.

--- a/.changeset/smooth-flies-refuse.md
+++ b/.changeset/smooth-flies-refuse.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix issue where setting `returnPartialData: true` might report the wrong `dataState` when partial data was written to the cache and `@defer` fragments were pending.

--- a/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
+++ b/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
@@ -10045,6 +10045,172 @@ test("keeps fields shared with a delivered @defer boundary while pruning a pendi
   });
 });
 
+test('returns dataState "partial" when a non-deferred field is missing and deferInfo marks a boundary as pending with returnPartialData: true', () => {
+  const cache = new InMemoryCache();
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+      hero {
+        id
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query: gql`
+      query {
+        greeting {
+          message
+        }
+      }
+    `,
+    data: {
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    },
+  });
+
+  const missingObject = { __typename: "Greeting", message: "Hello world" };
+  const missingRoot = { __ref: "ROOT_QUERY" };
+
+  const deferInfo: DeferInfoTrie = new Trie();
+  deferInfo.lookup("greeting");
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: true,
+      returnPartialData: true,
+      [handleIncrementalSymbol]: { deferInfo },
+    })
+  ).toStrictEqualTyped({
+    result: {
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    },
+    dataState: "partial",
+    complete: false,
+    missing: new MissingFieldError(
+      getMissingMessage("recipient", missingObject),
+      {
+        greeting: {
+          recipient: getMissingMessage("recipient", missingObject),
+        },
+        hero: getMissingMessage("hero", missingRoot),
+      },
+      query,
+      {}
+    ),
+  });
+});
+
+test('returns dataState "empty" when a non-deferred field is missing and deferInfo marks a boundary as pending with returnPartialData: false', () => {
+  const cache = new InMemoryCache();
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+      hero {
+        id
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query: gql`
+      query {
+        greeting {
+          message
+        }
+      }
+    `,
+    data: {
+      greeting: { __typename: "Greeting", message: "Hello world" },
+    },
+  });
+
+  const missingObject = { __typename: "Greeting", message: "Hello world" };
+  const missingRoot = { __ref: "ROOT_QUERY" };
+
+  const deferInfo: DeferInfoTrie = new Trie();
+  deferInfo.lookup("greeting");
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: true,
+      returnPartialData: false,
+      [handleIncrementalSymbol]: { deferInfo },
+    })
+  ).toStrictEqualTyped({
+    result: null,
+    dataState: "empty",
+    complete: false,
+    missing: new MissingFieldError(
+      getMissingMessage("recipient", missingObject),
+      {
+        greeting: {
+          recipient: getMissingMessage("recipient", missingObject),
+        },
+        hero: getMissingMessage("hero", missingRoot),
+      },
+      query,
+      {}
+    ),
+  });
+});
+
+test('returns dataState "empty" when the cache is empty and deferInfo marks a boundary as pending', () => {
+  const cache = new InMemoryCache();
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const missingRoot = { __ref: "ROOT_QUERY" };
+
+  const deferInfo: DeferInfoTrie = new Trie();
+  deferInfo.lookup("greeting");
+
+  expect(
+    cache.diff({
+      query,
+      optimistic: true,
+      returnPartialData: true,
+      [handleIncrementalSymbol]: { deferInfo },
+    })
+  ).toStrictEqualTyped({
+    result: null,
+    dataState: "empty",
+    complete: false,
+    missing: new MissingFieldError(
+      getMissingMessage("greeting", missingRoot),
+      { greeting: getMissingMessage("greeting", missingRoot) },
+      query,
+      {}
+    ),
+  });
+});
+
 function getMissingMessage(fieldName: string, obj: Record<string, unknown>) {
   return `Can't find field '${fieldName}' on ${
     isReference(obj) ?

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -358,6 +358,8 @@ export class StoreReader {
     // a defer boundary.
     if (
       returnIncremental &&
+      execResult.dataState !== "partial" &&
+      execResult.dataState !== "empty" &&
       (execResult.dataState === "deferPartial" ||
         execResult.dataState === "streamPartial" ||
         // If the last cache write repaired a partial @stream array to a

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -356,21 +356,7 @@ export class StoreReader {
     // partial defer boundaries. The "deferPartial" data state tells us that the
     // only part of the result that contributed to its partiality is data inside
     // a defer boundary.
-    if (
-      returnIncremental &&
-      execResult.dataState !== "partial" &&
-      execResult.dataState !== "empty" &&
-      (execResult.dataState === "deferPartial" ||
-        execResult.dataState === "streamPartial" ||
-        // If the last cache write repaired a partial @stream array to a
-        // complete array, the stream array might contain stale entries after
-        // the last written value. We only want to deliver the results up to
-        // the index the network wrote so we need to prune it too.
-        context.streamInfo ||
-        // The network hasn't delivered these @defer boundaries yet, so prune
-        // the (possibly complete) cached data sitting at them.
-        context.deferInfo)
-    ) {
+    if (returnIncremental && shouldPrune(execResult, context)) {
       const pruned = this.prunePartialBoundaries({
         selectionSet: getMainDefinition(query).selectionSet,
         data: execResult.result,
@@ -1100,6 +1086,29 @@ class PartialBoundaries {
 
     return this;
   }
+}
+
+function shouldPrune({ dataState }: ExecResult<any>, context: ReadContext) {
+  if (dataState === "deferPartial" || dataState === "streamPartial") {
+    return true;
+  }
+
+  if (dataState === "complete" || dataState === "streaming") {
+    return !!(
+      // If the last cache write repaired a partial @stream array to a
+      // complete array, the stream array might contain stale entries after
+      // the last written value. We only want to deliver the results up to
+      // the index the network wrote so we need to prune it too.
+      (
+        context.streamInfo ||
+        // The network hasn't delivered these @defer boundaries yet, so prune
+        // the (possibly complete) cached data sitting at them.
+        context.deferInfo
+      )
+    );
+  }
+
+  return false;
 }
 
 // Describes the data state transitions that change the running state when it's


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `dataState` reporting for queries with partial cache data while deferred fragments are still pending.
  * Improved handling of missing fields and empty-cache results during incremental updates.
  * Ensured incomplete deferred or streamed results are pruned consistently.

* **Tests**
  * Added coverage for partial data, null results, missing fields, and pending deferred fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->