### PR TITLE
Update warning to mention custom scalars

### DIFF
--- a/src/__tests__/__snapshots__/client.ts.snap
+++ b/src/__tests__/__snapshots__/client.ts.snap
@@ -71,7 +71,7 @@ exports[`client should warn if server returns wrong data 2`] = `
     Array [
       "The network result for query %s was written to the cache, but reading it back returned a partial result.
 
-A \`read\` or \`merge\` function left missing fields after this write. Because the cache result is incomplete, Apollo Client cannot apply it to the network result. The raw network result was returned instead, and doesn't include any transformed values returned from \`read\` functions.
+A \`read\` or \`merge\` function left missing fields after this write. Because the cache result is incomplete, Apollo Client cannot apply it to the network result. The raw network result was returned instead, and doesn't include any transformed values returned from \`read\` functions or custom scalars.
 
 To address this problem (which is not a bug in Apollo Client), check the \`read\` and \`merge\` functions for the fields in this query. A \`read\` or \`merge\` function that leaves missing fields leaves the cache unable to fulfill the query's data requirements.
 

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -789,7 +789,7 @@ function warnAboutPartialCacheResult(
   invariant.warn(
     `The network result for query %s was written to the cache, but reading it back returned a partial result.
 
-A \`read\` or \`merge\` function left missing fields after this write. Because the cache result is incomplete, Apollo Client cannot apply it to the network result. The raw network result was returned instead, and doesn't include any transformed values returned from \`read\` functions.
+A \`read\` or \`merge\` function left missing fields after this write. Because the cache result is incomplete, Apollo Client cannot apply it to the network result. The raw network result was returned instead, and doesn't include any transformed values returned from \`read\` functions or custom scalars.
 
 To address this problem (which is not a bug in Apollo Client), check the \`read\` and \`merge\` functions for the fields in this query. A \`read\` or \`merge\` function that leaves missing fields leaves the cache unable to fulfill the query's data requirements.
 


### PR DESCRIPTION
Tweak the warning message added by #13392 to include custom scalars, which have the same problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the partial cache result warning to clarify when custom scalar transformations are unavailable in the raw network response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->