### PR TITLE
Ignore read/merge functions and warn when `scalar` is configured for a field policy

### DIFF
--- a/.changeset/short-fishes-enjoy.md
+++ b/.changeset/short-fishes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Field policy `read` and `merge` functions are now ignored when the field policy configures the `scalar` option. If a `read` or `merge` function is provided alongside `scalar`, a development-only warning is emitted.

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -13,6 +13,11 @@ import {
 
 const IS_GRAPHQL_17 = graphqlVersion.startsWith("17");
 
+const WARNINGS = {
+  SCALAR_FIELD_CONFIG:
+    "The field policy for '%s' is configured with the '%s' scalar, so its '%s' function is ignored. Scalar configuration cannot be used with custom read or merge functions.",
+};
+
 test("creates a scalar from a GraphQLScalarType", () => {
   const graphQLScalar = new GraphQLScalarType<Date, string>({
     name: "DateTime",
@@ -871,7 +876,10 @@ test("stores parsed scalar value in the cache when overwriting an existing field
   });
 });
 
-test("stores parsed scalar value in the cache when a merge function is also configured on the field", () => {
+test("ignores the merge function and stores the parsed scalar value when a merge function is also configured on the field", () => {
+  using _ = spyOnConsole("warn");
+  const merge = jest.fn((_existing: unknown, incoming: unknown) => incoming);
+
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -879,7 +887,7 @@ test("stores parsed scalar value in the cache when a merge function is also conf
         fields: {
           startTime: {
             scalar: "DateTime",
-            merge: (_, incoming) => incoming,
+            merge,
           },
         },
       },
@@ -906,6 +914,7 @@ test("stores parsed scalar value in the cache when a merge function is also conf
     },
   });
 
+  expect(merge).not.toHaveBeenCalled();
   expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
@@ -917,9 +926,19 @@ test("stores parsed scalar value in the cache when a merge function is also conf
       startTime: new Date("2026-01-01T00:00:00.000Z"),
     },
   });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "merge"
+  );
 });
 
-test("stores the parsed value returned by a merge function in the cache", () => {
+test("stores the parsed incoming value instead of the value returned by an ignored merge function", () => {
+  using _ = spyOnConsole("warn");
+
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -927,7 +946,7 @@ test("stores the parsed value returned by a merge function in the cache", () => 
         fields: {
           startTime: {
             scalar: "DateTime",
-            merge: (_, incoming) => new Date(incoming),
+            merge: () => new Date("2020-06-15T14:30:00.000Z"),
           },
         },
       },
@@ -967,7 +986,10 @@ test("stores the parsed value returned by a merge function in the cache", () => 
   });
 });
 
-test("stores each element as a parsed value when writing an array of scalar values with a merge function", () => {
+test("stores each element as a parsed value when writing an array of scalar values with an ignored merge function", () => {
+  using _ = spyOnConsole("warn");
+  const merge = jest.fn((_existing: unknown, incoming: unknown) => incoming);
+
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -975,7 +997,7 @@ test("stores each element as a parsed value when writing an array of scalar valu
         fields: {
           meetingTimes: {
             scalar: "DateTime",
-            merge: (_, incoming) => incoming,
+            merge,
           },
         },
       },
@@ -1003,6 +1025,7 @@ test("stores each element as a parsed value when writing an array of scalar valu
     },
   });
 
+  expect(merge).not.toHaveBeenCalled();
   expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
@@ -1017,7 +1040,10 @@ test("stores each element as a parsed value when writing an array of scalar valu
   });
 });
 
-test("stores each leaf element as a parsed value when writing a 2D array of scalar values with a merge function", () => {
+test("stores each leaf element as a parsed value when writing a 2D array of scalar values with an ignored merge function", () => {
+  using _ = spyOnConsole("warn");
+  const merge = jest.fn((_existing: unknown, incoming: unknown) => incoming);
+
   const cache = new InMemoryCache({
     scalars: { DateTime: dateTimeScalar },
     typePolicies: {
@@ -1025,7 +1051,7 @@ test("stores each leaf element as a parsed value when writing a 2D array of scal
         fields: {
           availabilitySlots: {
             scalar: "DateTime",
-            merge: (_, incoming) => incoming,
+            merge,
           },
         },
       },
@@ -1056,6 +1082,7 @@ test("stores each leaf element as a parsed value when writing a 2D array of scal
     },
   });
 
+  expect(merge).not.toHaveBeenCalled();
   expect(rawCacheData(cache)).toEqual({
     ROOT_QUERY: {
       __typename: "Query",
@@ -3807,7 +3834,619 @@ test("ignores scalar and emits a dev warning when a scalar option is set on a fi
   );
 });
 
+test("ignores a read function and emits a dev warning when the field is configured with a scalar", () => {
+  using _ = spyOnConsole("warn");
+  const read = jest.fn(() => new Date("2020-06-15T14:30:00.000Z"));
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime", read },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(read).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "read"
+  );
+});
+
+test("ignores both read and merge functions and warns for each when the field is configured with a scalar", () => {
+  using _ = spyOnConsole("warn");
+  const read = jest.fn(() => new Date("2020-06-15T14:30:00.000Z"));
+  const merge = jest.fn((_existing: unknown, incoming: unknown) => incoming);
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime", read, merge },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(read).not.toHaveBeenCalled();
+  expect(merge).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(2);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "read"
+  );
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "merge"
+  );
+});
+
+test("ignores the merge: true shorthand and warns when the field is configured with a scalar", () => {
+  using _ = spyOnConsole("warn");
+
+  const cache = new InMemoryCache({
+    scalars: { JSONObject: jsonObjectScalar },
+    typePolicies: {
+      Product: {
+        fields: {
+          metadata: { scalar: "JSONObject", merge: true },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      product {
+        id
+        metadata
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      product: {
+        __typename: "Product",
+        id: "1",
+        metadata: { color: "red" },
+      },
+    },
+  });
+
+  cache.writeQuery({
+    query,
+    data: {
+      product: {
+        __typename: "Product",
+        id: "1",
+        metadata: { size: "large" },
+      },
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: { __typename: "Query", product: { __ref: "Product:1" } },
+    "Product:1": {
+      __typename: "Product",
+      id: "1",
+      metadata: new Map([["size", "large"]]),
+    },
+  });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Product.metadata",
+    "JSONObject",
+    "merge"
+  );
+});
+
+test("does not apply the implicit keyArgs: false when read and merge functions are ignored for a scalar field", () => {
+  using _ = spyOnConsole("warn");
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: {
+            scalar: "DateTime",
+            read: (existing) => existing,
+            merge: (_, incoming) => incoming,
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime(timezone: "UTC")
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      'startTime({"timezone":"UTC"})': new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+});
+
+test("warns once for an ignored function no matter how many times the field is written or read", () => {
+  using _ = spyOnConsole("warn");
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: {
+            scalar: "DateTime",
+            merge: (_, incoming) => incoming,
+          },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-06-15T14:30:00.000Z",
+      },
+    },
+  });
+
+  cache.readQuery({ query });
+  cache.readQuery({ query });
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+});
+
+test("runs read and merge functions and does not warn when the field policy has no scalar option", () => {
+  using _ = spyOnConsole("warn");
+  const read = jest.fn((existing: string) => existing.toUpperCase());
+  const merge = jest.fn((_existing: unknown, incoming: string) =>
+    incoming.trim()
+  );
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          name: { read, merge },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        name
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        name: "  Opening keynote  ",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      name: "OPENING KEYNOTE",
+    },
+  });
+
+  expect(read).toHaveBeenCalled();
+  expect(merge).toHaveBeenCalled();
+  expect(console.warn).not.toHaveBeenCalled();
+});
+
+test("ignores read and merge functions when the scalar option names an unregistered scalar", () => {
+  using _ = spyOnConsole("warn");
+  const read = jest.fn(() => "read value");
+  const merge = jest.fn((_existing: unknown, incoming: unknown) => incoming);
+
+  const cache = new InMemoryCache({
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "Unregistered", read, merge },
+        },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  expect(read).not.toHaveBeenCalled();
+  expect(merge).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(2);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "Unregistered",
+    "read"
+  );
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "Unregistered",
+    "merge"
+  );
+});
+
+test("unsets read and merge functions when policies.addTypePolicies adds a scalar to the field", () => {
+  using _ = spyOnConsole("warn");
+  const read = jest.fn(() => new Date("2020-06-15T14:30:00.000Z"));
+  const merge = jest.fn((_existing: unknown, incoming: unknown) => incoming);
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { read, merge },
+        },
+      },
+    },
+  });
+
+  cache.policies.addTypePolicies({
+    Event: {
+      fields: {
+        startTime: { scalar: "DateTime" },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(read).not.toHaveBeenCalled();
+  expect(merge).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(2);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "read"
+  );
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "merge"
+  );
+});
+
+test("ignores read and merge functions added by policies.addTypePolicies to a field that already has a scalar", () => {
+  using _ = spyOnConsole("warn");
+  const read = jest.fn(() => new Date("2020-06-15T14:30:00.000Z"));
+  const merge = jest.fn((_existing: unknown, incoming: unknown) => incoming);
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  cache.policies.addTypePolicies({
+    Event: {
+      fields: {
+        startTime: { read, merge },
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(rawCacheData(cache)).toEqual({
+    ROOT_QUERY: { __typename: "Query", event: { __ref: "Event:1" } },
+    "Event:1": {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(read).not.toHaveBeenCalled();
+  expect(merge).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(2);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "read"
+  );
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "merge"
+  );
+});
+
+test("ignores a read function added by policies.addTypePolicies with the field policy shorthand for a field that already has a scalar", () => {
+  using _ = spyOnConsole("warn");
+  const read = jest.fn(() => new Date("2020-06-15T14:30:00.000Z"));
+
+  const cache = new InMemoryCache({
+    scalars: { DateTime: dateTimeScalar },
+    typePolicies: {
+      Event: {
+        fields: {
+          startTime: { scalar: "DateTime" },
+        },
+      },
+    },
+  });
+
+  cache.policies.addTypePolicies({
+    Event: {
+      fields: {
+        startTime: read,
+      },
+    },
+  });
+
+  const query = gql`
+    query {
+      event {
+        id
+        startTime
+      }
+    }
+  `;
+
+  cache.writeQuery({
+    query,
+    data: {
+      event: {
+        __typename: "Event",
+        id: "1",
+        startTime: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  });
+
+  expect(cache.readQuery({ query })).toEqual({
+    event: {
+      __typename: "Event",
+      id: "1",
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  });
+
+  expect(read).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Event.startTime",
+    "DateTime",
+    "read"
+  );
+});
+
 test("deep merges scalar option with policies.addTypePolices", () => {
+  using _ = spyOnConsole("warn");
+  const endDateMerge = jest.fn(
+    (_existing: unknown, incoming: unknown) => incoming
+  );
+
   const cache = new InMemoryCache({
     scalars: {
       DateTime: dateTimeScalar,
@@ -3818,7 +4457,7 @@ test("deep merges scalar option with policies.addTypePolices", () => {
       Conference: {
         fields: {
           startDate: { scalar: "DateTime" },
-          endDate: { merge: (_, incoming) => incoming },
+          endDate: { merge: endDateMerge },
         },
       },
       Schedule: {
@@ -3979,6 +4618,15 @@ test("deep merges scalar option with policies.addTypePolices", () => {
       ],
     },
   });
+
+  expect(endDateMerge).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    WARNINGS.SCALAR_FIELD_CONFIG,
+    "Conference.endDate",
+    "DateTime",
+    "merge"
+  );
 });
 
 test("preserves an existing scalar option when policies.addTypePolicies updates another field option", () => {
@@ -3999,7 +4647,7 @@ test("preserves an existing scalar option when policies.addTypePolicies updates 
     Event: {
       fields: {
         startTime: {
-          merge: (_, incoming) => incoming,
+          keyArgs: ["timezone"],
         },
       },
     },
@@ -4009,7 +4657,7 @@ test("preserves an existing scalar option when policies.addTypePolicies updates 
     query {
       event {
         id
-        startTime
+        startTime(timezone: "UTC")
       }
     }
   `;
@@ -4033,7 +4681,7 @@ test("preserves an existing scalar option when policies.addTypePolicies updates 
     "Event:1": {
       __typename: "Event",
       id: "1",
-      startTime: new Date("2026-01-01T00:00:00.000Z"),
+      'startTime:{"timezone":"UTC"}': new Date("2026-01-01T00:00:00.000Z"),
     },
   });
 });

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -16,6 +16,8 @@ const IS_GRAPHQL_17 = graphqlVersion.startsWith("17");
 const WARNINGS = {
   SCALAR_FIELD_CONFIG:
     "The field policy for '%s' is configured with the '%s' scalar, so its '%s' function is ignored. Scalar configuration cannot be used with custom read or merge functions.",
+  NON_SCALAR_FIELD:
+    "The field policy for '%s' is configured with the '%s' scalar, but the field is not a scalar field because it contains a selection set. The field value remains unchanged.",
 };
 
 test("creates a scalar from a GraphQLScalarType", () => {
@@ -3828,7 +3830,7 @@ test("ignores scalar and emits a dev warning when a scalar option is set on a fi
 
   expect(console.warn).toHaveBeenCalledTimes(1);
   expect(console.warn).toHaveBeenCalledWith(
-    "The field policy for '%s' is configured as a '%s' scalar, but the field is not a scalar field because it contains a selection set. The field value remains unchanged.",
+    WARNINGS.NON_SCALAR_FIELD,
     "Query.event",
     "DateTime"
   );

--- a/src/cache/inmemory/__tests__/scalars.ts
+++ b/src/cache/inmemory/__tests__/scalars.ts
@@ -4443,7 +4443,7 @@ test("ignores a read function added by policies.addTypePolicies with the field p
   );
 });
 
-test("deep merges scalar option with policies.addTypePolices", () => {
+test("deep merges scalar option with policies.addTypePolicies", () => {
   using _ = spyOnConsole("warn");
   const endDateMerge = jest.fn(
     (_existing: unknown, incoming: unknown) => incoming

--- a/src/cache/inmemory/policies.ts
+++ b/src/cache/inmemory/policies.ts
@@ -358,7 +358,7 @@ type InternalFieldPolicy = {
   keyFn?: KeyArgsFunction;
   read?: FieldReadFunction<any>;
   merge?: FieldMergeFunction<any>;
-  scalar?: keyof ApolloCache.Scalars;
+  scalar?: keyof ApolloCache.Scalars & string;
 };
 
 export class Policies {
@@ -568,12 +568,48 @@ export class Policies {
         const incoming = fields[fieldName];
 
         if (typeof incoming === "function") {
-          existing.read = incoming;
+          if (existing.scalar) {
+            if (__DEV__) {
+              warnAboutScalarConfig(
+                typename,
+                fieldName,
+                existing.scalar,
+                "read"
+              );
+            }
+          } else {
+            existing.read = incoming;
+          }
         } else {
-          const { keyArgs, read, merge, scalar } = incoming;
+          let { keyArgs, read, merge, scalar } = incoming;
 
           if (scalar) {
             existing.scalar = scalar;
+          }
+
+          if (existing.scalar) {
+            if (__DEV__) {
+              if (read !== undefined || existing.read !== undefined) {
+                warnAboutScalarConfig(
+                  typename,
+                  fieldName,
+                  existing.scalar,
+                  "read"
+                );
+              }
+
+              if (merge !== undefined || existing.merge !== undefined) {
+                warnAboutScalarConfig(
+                  typename,
+                  fieldName,
+                  existing.scalar,
+                  "merge"
+                );
+              }
+            }
+
+            existing.read = read = undefined;
+            existing.merge = merge = undefined;
           }
 
           existing.keyFn =
@@ -1231,4 +1267,18 @@ function makeMergeObjectsFunction(
 
     return incoming;
   };
+}
+
+function warnAboutScalarConfig(
+  typename: string,
+  fieldName: string,
+  scalar: string,
+  kind: "read" | "merge"
+) {
+  invariant.warn(
+    "The field policy for '%s' is configured with the '%s' scalar, so its '%s' function is ignored. Scalar configuration cannot be used with custom read or merge functions.",
+    `${typename}.${fieldName}`,
+    scalar,
+    kind
+  );
 }

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -584,7 +584,7 @@ export class StoreReader {
 
               if (policy?.scalar) {
                 invariant.warn(
-                  "The field policy for '%s' is configured as a '%s' scalar, but the field is not a scalar field because it contains a selection set. The field value remains unchanged.",
+                  "The field policy for '%s' is configured with the '%s' scalar, but the field is not a scalar field because it contains a selection set. The field value remains unchanged.",
                   `${typename}.${fieldName}`,
                   policy.scalar
                 );


### PR DESCRIPTION
After much discussion, we haven't come up with a good reason why you'd want to configure a `read` or `merge` function for a custom scalar field since the scalar manages how the value is written and read. As such, we are disabling the ability to use `read` and `merge` functions with scalar fields and a dev-only warning is emitted. NOTE: with this change, read/merge functions are blocked as soon as the field configures a scalar. There is no way to "reset" the field policy to accept a read/merge function instead of a scalar.

We're open to changing our minds in a future release if we get feedback on a valid use case for allowing them. For now, the `scalar` will manage the lifecycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scalar-configured fields now consistently take precedence over custom `read` and `merge` policies.
  - Added development warnings when conflicting field policies are provided.
  - Preserved scalar parsing, key arguments, nested values, arrays, fragments, and dynamically added policies.
  - Improved warning text for scalar fields configured with selection sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->