### PR TITLE
Change feud stopping logic so that read functions/custom scalars are applied

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -938,8 +938,6 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     getCurrentResult(): ObservableQuery.Result<MaybeMasked<TData>>;
     // (undocumented)
     hasObservers(): boolean;
-    // @internal @deprecated
-    _lastWrite?: unknown;
     // @internal @deprecated (undocumented)
     notify(scheduled?: boolean): void;
     // (undocumented)
@@ -1407,7 +1405,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 // Warnings were encountered during analysis:
 //
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:378:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:405:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1405,7 +1405,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 // Warnings were encountered during analysis:
 //
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:415:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:406:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -1405,7 +1405,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 // Warnings were encountered during analysis:
 //
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:405:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:415:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -3317,7 +3317,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:162:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:405:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:415:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:202:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -3317,7 +3317,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:162:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:415:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:406:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:202:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2402,8 +2402,6 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     getCurrentResult(): ObservableQuery.Result<MaybeMasked<TData>>;
     // (undocumented)
     hasObservers(): boolean;
-    // @internal @deprecated
-    _lastWrite?: unknown;
     // @internal @deprecated (undocumented)
     notify(scheduled?: boolean): void;
     // (undocumented)
@@ -3319,7 +3317,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:162:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:378:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:405:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:202:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/gorgeous-tools-dream.md
+++ b/.changeset/gorgeous-tools-dream.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Emit a development-only warning when a feud is detected between queries that overwrite each other's data. This should make it easier to detect when you need to select a key field or add a `merge` function to a field policy.

--- a/.changeset/wise-swans-wash.md
+++ b/.changeset/wise-swans-wash.md
@@ -1,0 +1,9 @@
+---
+"@apollo/client": minor
+---
+
+Fixes an issue where cache feuds between queries selecting incompatible non-normalized data could return untransformed network values.
+
+Apollo Client now always writes network results to the cache before delivering them, ensuring custom scalars and field `read` functions are applied. To prevent repeated refetches when competing queries repeatedly make each other's cache results incomplete, Apollo Client stops automatically refetching a query after it sees the same incomplete result again.
+
+This may add one network request in these cache-feud scenarios.

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1805,22 +1805,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   private notifyTimeout?: ReturnType<typeof setTimeout>;
 
   /** @internal */
-  private shouldAutoRefetch(diff: Cache.DiffResult<any>) {
-    const { lastMissingResult } = this;
-
-    return (
-      !lastMissingResult ||
-      // If a destructive cache method has been called since the last recorded
-      // incomplete result, there's a chance fetching this data again will
-      // restore what was evicted, even though the cache result looks the same
-      // as before.
-      lastMissingResult.dmCount !== destructiveMethodCounts.get(this.cache) ||
-      !equal(lastMissingResult.variables, this.variables) ||
-      !equal(lastMissingResult.missing, diff.missing?.missing)
-    );
-  }
-
-  /** @internal */
   private resetNotifications() {
     if (this.notifyTimeout) {
       clearTimeout(this.notifyTimeout);
@@ -1851,7 +1835,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       }
     }
 
-    const { dirty } = this;
+    const { dirty, lastMissingResult } = this;
     const { fetchPolicy } = this.options;
     this.resetNotifications();
 
@@ -1904,7 +1888,16 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         partial: true,
       });
       return;
-    } else if (this.shouldAutoRefetch(diff)) {
+    } else if (
+      !lastMissingResult ||
+      // If a destructive cache method has been called since the last recorded
+      // incomplete result, there's a chance fetching this data again will
+      // restore what was evicted, even though the cache result looks the same
+      // as before.
+      lastMissingResult.dmCount !== destructiveMethodCounts.get(this.cache) ||
+      !equal(lastMissingResult.variables, this.variables) ||
+      !equal(lastMissingResult.missing, diff.missing?.missing)
+    ) {
       this.lastMissingResult = {
         variables: this.variables,
         missing: diff.missing?.missing,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1863,6 +1863,17 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       const diff = this.getCacheDiff();
       const current = this.getCurrentResult();
 
+      const deliverCacheResult = (result: ObservableQuery.Result<any>) => {
+        this.input.next({
+          kind: "N",
+          value: result,
+          source: "cache",
+          query: this.query,
+          variables: this.variables,
+          meta: {},
+        });
+      };
+
       if (
         // `fromOptimisticTransaction` is not available through the `cache.diff`
         // code path, so we need to check it this way
@@ -1874,20 +1885,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           current.dataState === "streaming" ||
           diff.dataState === "streaming"
         ) {
-          this.input.next({
-            kind: "N",
-            value: {
-              data: diff.result,
-              dataState: "streaming",
-              networkStatus: current.networkStatus,
-              loading: current.loading,
-              error: undefined,
-              partial: true,
-            } as ObservableQuery.Result<TData>,
-            source: "cache",
-            query: this.query,
-            variables: this.variables,
-            meta: {},
+          deliverCacheResult({
+            data: diff.result,
+            dataState: "streaming",
+            networkStatus: current.networkStatus,
+            loading: current.loading,
+            error: undefined,
+            partial: true,
           });
           return;
         } else if (this.shouldAutoRefetch(diff)) {
@@ -1912,20 +1916,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // though, so we also make sure we only deliver if the previous result
           // was also partial.
           if (current.dataState === "partial") {
-            this.input.next({
-              kind: "N",
-              value: {
-                data: diff.result,
-                dataState: current.dataState,
-                networkStatus: current.networkStatus,
-                loading: current.loading,
-                error: undefined,
-                partial: true,
-              } as ObservableQuery.Result<TData>,
-              source: "cache",
-              query: this.query,
-              variables: this.variables,
-              meta: {},
+            deliverCacheResult({
+              data: diff.result,
+              dataState: current.dataState,
+              networkStatus: current.networkStatus,
+              loading: current.loading,
+              error: undefined,
+              partial: true,
             });
           }
           // If the (partial) result is the same as the last partial result
@@ -1989,21 +1986,14 @@ For more information about these options, please refer to the documentation:
         // request, and we never want to trigger network requests in the
         // middle of optimistic updates.
         this.lastMissingResult = undefined;
-        this.input.next({
-          kind: "N",
-          value: {
-            data: diff.result,
-            dataState: diff.dataState,
-            networkStatus: current.networkStatus,
-            loading: current.loading,
-            error: undefined,
-            partial: !diff.complete,
-          } as ObservableQuery.Result<TData>,
-          source: "cache",
-          query: this.query,
-          variables: this.variables,
-          meta: {},
-        });
+        deliverCacheResult({
+          data: diff.result,
+          dataState: diff.dataState,
+          networkStatus: current.networkStatus,
+          loading: current.loading,
+          error: undefined,
+          partial: !diff.complete,
+        } as ObservableQuery.Result<TData>);
       }
     }
   }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1994,8 +1994,8 @@ For more information about these options, please refer to the documentation:
           value: {
             data: diff.result,
             dataState: diff.dataState,
-            networkStatus: NetworkStatus.ready,
-            loading: false,
+            networkStatus: current.networkStatus,
+            loading: current.loading,
             error: undefined,
             partial: !diff.complete,
           } as ObservableQuery.Result<TData>,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1861,6 +1861,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         !this.activeOperations.size)
     ) {
       const diff = this.getCacheDiff();
+      const current = this.getCurrentResult();
+
       if (
         // `fromOptimisticTransaction` is not available through the `cache.diff`
         // code path, so we need to check it this way
@@ -1868,6 +1870,26 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       ) {
         if (diff.complete) {
           this.lastMissingResult = undefined;
+        } else if (
+          current.dataState === "streaming" ||
+          diff.dataState === "streaming"
+        ) {
+          this.input.next({
+            kind: "N",
+            value: {
+              data: diff.result,
+              dataState: "streaming",
+              networkStatus: current.networkStatus,
+              loading: current.loading,
+              error: undefined,
+              partial: true,
+            } as ObservableQuery.Result<TData>,
+            source: "cache",
+            query: this.query,
+            variables: this.variables,
+            meta: {},
+          });
+          return;
         } else if (this.shouldAutoRefetch(diff)) {
           this.lastMissingResult = {
             variables: this.variables,
@@ -1882,8 +1904,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // confusing for a cache-only query anyways.
           this.options.fetchPolicy !== "cache-only"
         ) {
-          const current = this.getCurrentResult();
-
           // If we've fallen through to this case, a cache emit has returned the
           // same missing fields which means fields we've already delivered for
           // this query have changed. We are ok delivering the updated value in
@@ -1891,10 +1911,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // downgrade this query from a complete query to a partial query
           // though, so we also make sure we only deliver if the previous result
           // was also partial.
-          if (
-            current.dataState === "partial" ||
-            current.dataState === "streaming"
-          ) {
+          if (current.dataState === "partial") {
             this.input.next({
               kind: "N",
               value: {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1876,6 +1876,12 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     if (diff.complete) {
       this.lastMissingResult = undefined;
     } else if (current.networkStatus === NetworkStatus.streaming) {
+      // If we get a cache update in the middle of streaming (possible with
+      // cache-and-network fetch policy), just deliver the cache value without
+      // going through the full reobserve which would otherwise trigger another
+      // request (deduplication should kick in, but doing so replays any
+      // previous emits from the link chain, which get rewritten into the cache
+      // and might clobber this cache update)
       this.deliverCacheResult({
         data: diff.result,
         dataState: diff.dataState,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -94,6 +94,30 @@ const empty: ObservableQuery.Result<any> = {
   partial: true,
 };
 
+const destructiveMethodCounts = new WeakMap<Cache.Implementation, number>();
+
+function wrapDestructiveCacheMethod(
+  cache: Cache.Implementation,
+  methodName: "evict" | "modify" | "reset"
+) {
+  const original = cache[methodName];
+  if (typeof original === "function") {
+    // @ts-expect-error this is just too generic to be typed correctly
+    cache[methodName] = function () {
+      destructiveMethodCounts.set(
+        cache,
+        // The %1e15 allows the count to wrap around to 0 safely every
+        // quadrillion evictions, so there's no risk of overflow. To be
+        // clear, this is more of a pedantic principle than something
+        // that matters in any conceivable practical scenario.
+        (destructiveMethodCounts.get(cache)! + 1) % 1e15
+      );
+      // @ts-expect-error this is just too generic to be typed correctly
+      return original.apply(this, arguments);
+    };
+  }
+}
+
 const enum EmitBehavior {
   /**
    * Emit will be calculated by the normal rules. (`undefined` will be treated the same as this)
@@ -309,8 +333,11 @@ export class ObservableQuery<
   public readonly queryName?: string;
   private variablesUnknown: boolean = false;
 
-  /** @internal will be read and written from `QueryInfo` */
-  public _lastWrite?: unknown;
+  private lastIncompleteResult?: {
+    result: unknown;
+    variables: TVariables;
+    dmCount: number | undefined;
+  };
 
   // The `query` computed property will always reflect the document transformed
   // by the last run query. `this.options.query` will always reflect the raw
@@ -381,6 +408,19 @@ export class ObservableQuery<
     queryId?: string;
   }) {
     this.queryManager = queryManager;
+
+    // Track how often destructive cache methods are called, since we want
+    // eviction to override the feud-stopping logic in `shouldAutoRefetch`,
+    // by causing it to return true. Wrapping these cache methods is a bit of a
+    // hack, but it saves us from having to make eviction counting an official
+    // part of the ApolloCache API.
+    const { cache } = queryManager;
+    if (!destructiveMethodCounts.has(cache)) {
+      destructiveMethodCounts.set(cache, 0);
+      wrapDestructiveCacheMethod(cache, "evict");
+      wrapDestructiveCacheMethod(cache, "modify");
+      wrapDestructiveCacheMethod(cache, "reset");
+    }
 
     // active state
     this.waitForNetworkResult = options.fetchPolicy === "network-only";
@@ -819,7 +859,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         this.getVariablesWithDefaults({ ...this.variables, ...variables });
     }
 
-    this._lastWrite = undefined;
+    this.lastIncompleteResult = undefined;
     return this._reobserve(reobserveOptions, {
       newNetworkStatus: NetworkStatus.refetch,
     });
@@ -1485,7 +1525,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           !isNetworkRequestInFlight(this.networkStatus) &&
           !this.options.skipPollAttempt?.()
         ) {
-          this._lastWrite = undefined;
+          this.lastIncompleteResult = undefined;
           this._reobserve(
             {
               // Most fetchPolicy options don't make sense to use in a polling context, as
@@ -1538,6 +1578,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   ): ObservableQuery.ResultPromise<
     ApolloClient.QueryResult<MaybeMasked<TData>>
   > {
+    this.lastIncompleteResult = undefined;
     return this._reobserve(newOptions);
   }
   private _reobserve(
@@ -1730,7 +1771,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     this.queryManager.obsQueries.delete(this);
     this.isTornDown = true;
     this.abortActiveOperations();
-    this._lastWrite = undefined;
+    this.lastIncompleteResult = undefined;
   }
 
   private transformDocument(document: DocumentNode) {
@@ -1752,6 +1793,23 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   private dirty: boolean = false;
 
   private notifyTimeout?: ReturnType<typeof setTimeout>;
+
+  /** @internal */
+  private shouldAutoRefetch(result: unknown) {
+    const { lastIncompleteResult } = this;
+
+    return (
+      !lastIncompleteResult ||
+      // If a destructive cache method has been called since the last recorded
+      // incomplete result, there's a chance fetching this data again will
+      // restore what was evicted, even though the cache result looks the same
+      // as before.
+      lastIncompleteResult.dmCount !==
+        destructiveMethodCounts.get(this.cache) ||
+      !equal(lastIncompleteResult.variables, this.variables) ||
+      !equal(lastIncompleteResult.result, result)
+    );
+  }
 
   /** @internal */
   private resetNotifications() {
@@ -1799,6 +1857,37 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         // code path, so we need to check it this way
         equal(diff.result, this.getCacheDiff({ optimistic: false }).result)
       ) {
+        if (diff.complete) {
+          this.lastIncompleteResult = undefined;
+        } else if (this.shouldAutoRefetch(diff.result)) {
+          this.lastIncompleteResult = {
+            variables: this.variables,
+            result: diff.result,
+            dmCount: destructiveMethodCounts.get(this.cache),
+          };
+        } else {
+          // If the (partial) result is the same as the last partial result
+          // we recorded from a previous broadcast (and the variables match
+          // too), avoid calling reobserveCacheFirst to refetch this query
+          // again. If we allow refetching anytime this result becomes partial,
+          // we risk feuds between queries competing to update the same data in
+          // incompatible ways, which can lead to an endless cycle of cache
+          // broadcasts and useless network requests. As with any
+          // feud, eventually one side must step back from the brink,
+          // letting the other side(s) have the last word(s). There may
+          // be other points where we could break this cycle, such as
+          // silencing the broadcast for cache.writeQuery (not a good
+          // idea, since it just delays the feud a bit) or somehow
+          // avoiding the network request that just happened (also bad,
+          // because the server could return useful new data). All
+          // options considered, returning early and stopping the
+          // reobserveCacheFirst cycle seems to be the least damaging place to
+          // break the cycle because it allows read functions/custom scalars to
+          // be applied to the feuding query while while avoiding the endless
+          // cycle of requests.
+          return;
+        }
+
         //If this diff did not come from an optimistic transaction
         // make the ObservableQuery "reobserve" the latest data
         // using a temporary fetch policy of "cache-first", so complete cache
@@ -1815,6 +1904,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         // reobservation, since oq.reobserveCacheFirst might make a network
         // request, and we never want to trigger network requests in the
         // middle of optimistic updates.
+        this.lastIncompleteResult = undefined;
         this.input.next({
           kind: "N",
           value: {
@@ -1909,6 +1999,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     // exception for cache-only queries - we reset them into a "ready" state
     // as we won't trigger a refetch for them
     const resetToEmpty = this.options.fetchPolicy === "cache-only";
+    this.lastIncompleteResult = undefined;
     this.setResult(resetToEmpty ? empty : uninitialized, {
       shouldEmit: resetToEmpty ? EmitBehavior.force : EmitBehavior.never,
     });
@@ -2083,7 +2174,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const { fetchPolicy, nextFetchPolicy } = this.options;
 
     if (fetchPolicy === "cache-and-network" || fetchPolicy === "network-only") {
-      this.reobserve({
+      // Calls `_reobserve` rather than `reobserve` so that a refetch initiated
+      // by the cache update does not clear `lastIncompleteResult`, which
+      // only user-initiated reobservations should do.
+      this._reobserve({
         fetchPolicy: "cache-first",
         // Use a temporary nextFetchPolicy function that replaces itself with the
         // previous nextFetchPolicy value and returns the original fetchPolicy.
@@ -2105,7 +2199,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         },
       });
     } else {
-      this.reobserve();
+      this._reobserve();
     }
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -333,11 +333,21 @@ export class ObservableQuery<
   public readonly queryName?: string;
   private variablesUnknown: boolean = false;
 
-  private lastIncompleteResult?: {
+  private didWarnOnFeud = false;
+  private _lastIncompleteResult?: {
     result: unknown;
     variables: TVariables;
     dmCount: number | undefined;
   };
+
+  private get lastIncompleteResult() {
+    return this._lastIncompleteResult;
+  }
+
+  private set lastIncompleteResult(newValue) {
+    this.didWarnOnFeud = false;
+    this._lastIncompleteResult = newValue;
+  }
 
   // The `query` computed property will always reflect the document transformed
   // by the last run query. `this.options.query` will always reflect the raw
@@ -1885,7 +1895,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // break the cycle because it allows read functions/custom scalars to
           // be applied to the feuding query while avoiding the endless cycle of
           // requests.
-          if (__DEV__) {
+          if (__DEV__ && !this.didWarnOnFeud) {
+            this.didWarnOnFeud = true;
             invariant.warn(
               `Apollo Client stopped refetching '%s' because the same incomplete cache result was already refetched. Automatic refetching was halted to prevent an endless cycle of network requests.
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1885,6 +1885,27 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // break the cycle because it allows read functions/custom scalars to
           // be applied to the feuding query while avoiding the endless cycle of
           // requests.
+          if (__DEV__) {
+            invariant.warn(
+              `Apollo Client stopped refetching '%s' because the same incomplete cache result was already refetched. Automatic refetching was halted to prevent an endless cycle of network requests.
+
+This often means another query is overwriting non-normalized data selected by this query. Common fixes:
+
+  * Select an \`id\` or \`_id\` field in each query that writes the object
+  * Set custom \`keyFields\` if the object uses a different identity
+  * Add a field \`merge\` function so partial writes combine instead of replace
+
+  missing fields: %o
+
+For more information about these options, please refer to the documentation:
+
+  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
+  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
+`,
+              getOperationName(this.query, "(anonymous)"),
+              diff.missing?.missing
+            );
+          }
           return;
         }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1856,99 +1856,102 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     this.resetNotifications();
 
     if (
-      dirty &&
-      (fetchPolicy === "cache-only" ||
-        fetchPolicy === "cache-and-network" ||
-        !this.activeOperations.size)
+      !dirty ||
+      (fetchPolicy !== "cache-only" &&
+        fetchPolicy !== "cache-and-network" &&
+        this.activeOperations.size)
     ) {
-      const diff = this.getCacheDiff();
-      const current = this.getCurrentResult();
+      return;
+    }
 
-      const deliverCacheResult = (result: ObservableQuery.Result<any>) => {
-        this.input.next({
-          kind: "N",
-          value: result,
-          source: "cache",
-          query: this.query,
-          variables: this.variables,
-          meta: {},
-        });
-      };
+    const diff = this.getCacheDiff();
+    const current = this.getCurrentResult();
 
-      if (
-        // `fromOptimisticTransaction` is not available through the `cache.diff`
-        // code path, so we need to check it this way
-        equal(diff.result, this.getCacheDiff({ optimistic: false }).result)
+    const deliverCacheResult = (result: ObservableQuery.Result<any>) => {
+      this.input.next({
+        kind: "N",
+        value: result,
+        source: "cache",
+        query: this.query,
+        variables: this.variables,
+        meta: {},
+      });
+    };
+
+    if (
+      // `fromOptimisticTransaction` is not available through the `cache.diff`
+      // code path, so we need to check it this way
+      equal(diff.result, this.getCacheDiff({ optimistic: false }).result)
+    ) {
+      if (diff.complete) {
+        this.lastMissingResult = undefined;
+      } else if (
+        current.dataState === "streaming" ||
+        diff.dataState === "streaming"
       ) {
-        if (diff.complete) {
-          this.lastMissingResult = undefined;
-        } else if (
-          current.dataState === "streaming" ||
-          diff.dataState === "streaming"
-        ) {
+        deliverCacheResult({
+          data: diff.result,
+          dataState: "streaming",
+          networkStatus: current.networkStatus,
+          loading: current.loading,
+          error: undefined,
+          partial: true,
+        });
+        return;
+      } else if (this.shouldAutoRefetch(diff)) {
+        this.lastMissingResult = {
+          variables: this.variables,
+          missing: diff.missing?.missing,
+          dmCount: destructiveMethodCounts.get(this.cache),
+        };
+      } else if (
+        // reobserveCacheFirst with cache-only fetch policy only calls
+        // reobserve which never fetches from the network so we are ok
+        // allowing cache-only queries to fallthrough to reobserveCacheFirst.
+        // This prevents the "stopped refetching" warning which would be
+        // confusing for a cache-only query anyways.
+        fetchPolicy !== "cache-only"
+      ) {
+        // If we've fallen through to this case, a cache emit has returned the
+        // same missing fields which means fields we've already delivered for
+        // this query have changed. We are ok delivering the updated value in
+        // this case to keep the result as fresh as possible. We NEVER want to
+        // downgrade this query from a complete query to a partial query
+        // though, so we also make sure we only deliver if the previous result
+        // was also partial.
+        if (current.dataState === "partial") {
           deliverCacheResult({
             data: diff.result,
-            dataState: "streaming",
+            dataState: current.dataState,
             networkStatus: current.networkStatus,
             loading: current.loading,
             error: undefined,
             partial: true,
           });
-          return;
-        } else if (this.shouldAutoRefetch(diff)) {
-          this.lastMissingResult = {
-            variables: this.variables,
-            missing: diff.missing?.missing,
-            dmCount: destructiveMethodCounts.get(this.cache),
-          };
-        } else if (
-          // reobserveCacheFirst with cache-only fetch policy only calls
-          // reobserve which never fetches from the network so we are ok
-          // allowing cache-only queries to fallthrough to reobserveCacheFirst.
-          // This prevents the "stopped refetching" warning which would be
-          // confusing for a cache-only query anyways.
-          fetchPolicy !== "cache-only"
-        ) {
-          // If we've fallen through to this case, a cache emit has returned the
-          // same missing fields which means fields we've already delivered for
-          // this query have changed. We are ok delivering the updated value in
-          // this case to keep the result as fresh as possible. We NEVER want to
-          // downgrade this query from a complete query to a partial query
-          // though, so we also make sure we only deliver if the previous result
-          // was also partial.
-          if (current.dataState === "partial") {
-            deliverCacheResult({
-              data: diff.result,
-              dataState: current.dataState,
-              networkStatus: current.networkStatus,
-              loading: current.loading,
-              error: undefined,
-              partial: true,
-            });
-          }
-          // If the (partial) result is the same as the last partial result
-          // we recorded from a previous broadcast (and the variables match
-          // too), avoid calling reobserveCacheFirst to refetch this query
-          // again. If we allow refetching anytime this result becomes partial,
-          // we risk feuds between queries competing to update the same data in
-          // incompatible ways, which can lead to an endless cycle of cache
-          // broadcasts and useless network requests. As with any
-          // feud, eventually one side must step back from the brink,
-          // letting the other side(s) have the last word(s). There may
-          // be other points where we could break this cycle, such as
-          // silencing the broadcast for cache.writeQuery (not a good
-          // idea, since it just delays the feud a bit) or somehow
-          // avoiding the network request that just happened (also bad,
-          // because the server could return useful new data). All
-          // options considered, returning early and stopping the
-          // reobserveCacheFirst cycle seems to be the least damaging place to
-          // break the cycle because it allows read functions/custom scalars to
-          // be applied to the feuding query while avoiding the endless cycle of
-          // requests.
-          if (__DEV__ && !this.didWarnOnFeud) {
-            this.didWarnOnFeud = true;
-            invariant.warn(
-              `Apollo Client stopped refetching '%s' because the same incomplete cache result was already refetched. Automatic refetching was halted to prevent an endless cycle of network requests.
+        }
+        // If the (partial) result is the same as the last partial result
+        // we recorded from a previous broadcast (and the variables match
+        // too), avoid calling reobserveCacheFirst to refetch this query
+        // again. If we allow refetching anytime this result becomes partial,
+        // we risk feuds between queries competing to update the same data in
+        // incompatible ways, which can lead to an endless cycle of cache
+        // broadcasts and useless network requests. As with any
+        // feud, eventually one side must step back from the brink,
+        // letting the other side(s) have the last word(s). There may
+        // be other points where we could break this cycle, such as
+        // silencing the broadcast for cache.writeQuery (not a good
+        // idea, since it just delays the feud a bit) or somehow
+        // avoiding the network request that just happened (also bad,
+        // because the server could return useful new data). All
+        // options considered, returning early and stopping the
+        // reobserveCacheFirst cycle seems to be the least damaging place to
+        // break the cycle because it allows read functions/custom scalars to
+        // be applied to the feuding query while avoiding the endless cycle of
+        // requests.
+        if (__DEV__ && !this.didWarnOnFeud) {
+          this.didWarnOnFeud = true;
+          invariant.warn(
+            `Apollo Client stopped refetching '%s' because the same incomplete cache result was already refetched. Automatic refetching was halted to prevent an endless cycle of network requests.
 
 This often means another query is overwriting non-normalized data selected by this query. Common fixes:
 
@@ -1963,39 +1966,38 @@ For more information about these options, please refer to the documentation:
   * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
   * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
 `,
-              getOperationName(this.query, "(anonymous)"),
-              diff.missing?.missing
-            );
-          }
-          return;
+            getOperationName(this.query, "(anonymous)"),
+            diff.missing?.missing
+          );
         }
-
-        //If this diff did not come from an optimistic transaction
-        // make the ObservableQuery "reobserve" the latest data
-        // using a temporary fetch policy of "cache-first", so complete cache
-        // results have a chance to be delivered without triggering additional
-        // network requests, even when options.fetchPolicy is "network-only"
-        // or "cache-and-network". All other fetch policies are preserved by
-        // this method, and are handled by calling oq.reobserve(). If this
-        // reobservation is spurious, distinctUntilChanged still has a
-        // chance to catch it before delivery to ObservableQuery subscribers.
-        this.reobserveCacheFirst();
-      } else {
-        // If this diff came from an optimistic transaction, deliver the
-        // current cache data to the ObservableQuery, but don't perform a
-        // reobservation, since oq.reobserveCacheFirst might make a network
-        // request, and we never want to trigger network requests in the
-        // middle of optimistic updates.
-        this.lastMissingResult = undefined;
-        deliverCacheResult({
-          data: diff.result,
-          dataState: diff.dataState,
-          networkStatus: current.networkStatus,
-          loading: current.loading,
-          error: undefined,
-          partial: !diff.complete,
-        } as ObservableQuery.Result<TData>);
+        return;
       }
+
+      //If this diff did not come from an optimistic transaction
+      // make the ObservableQuery "reobserve" the latest data
+      // using a temporary fetch policy of "cache-first", so complete cache
+      // results have a chance to be delivered without triggering additional
+      // network requests, even when options.fetchPolicy is "network-only"
+      // or "cache-and-network". All other fetch policies are preserved by
+      // this method, and are handled by calling oq.reobserve(). If this
+      // reobservation is spurious, distinctUntilChanged still has a
+      // chance to catch it before delivery to ObservableQuery subscribers.
+      this.reobserveCacheFirst();
+    } else {
+      // If this diff came from an optimistic transaction, deliver the
+      // current cache data to the ObservableQuery, but don't perform a
+      // reobservation, since oq.reobserveCacheFirst might make a network
+      // request, and we never want to trigger network requests in the
+      // middle of optimistic updates.
+      this.lastMissingResult = undefined;
+      deliverCacheResult({
+        data: diff.result,
+        dataState: diff.dataState,
+        networkStatus: current.networkStatus,
+        loading: current.loading,
+        error: undefined,
+        partial: !diff.complete,
+      } as ObservableQuery.Result<TData>);
     }
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1867,17 +1867,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const diff = this.getCacheDiff();
     const current = this.getCurrentResult();
 
-    const deliverCacheResult = (result: ObservableQuery.Result<any>) => {
-      this.input.next({
-        kind: "N",
-        value: result,
-        source: "cache",
-        query: this.query,
-        variables: this.variables,
-        meta: {},
-      });
-    };
-
     // `fromOptimisticTransaction` is not available through the `cache.diff`
     // code path, so we need to check whether the cache result is an optimistic
     // result this way
@@ -1888,7 +1877,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // request, and we never want to trigger network requests in the
       // middle of optimistic updates.
       this.lastMissingResult = undefined;
-      deliverCacheResult({
+      this.deliverCacheResult({
         data: diff.result,
         dataState: diff.dataState,
         networkStatus: current.networkStatus,
@@ -1906,7 +1895,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       current.dataState === "streaming" ||
       diff.dataState === "streaming"
     ) {
-      deliverCacheResult({
+      this.deliverCacheResult({
         data: diff.result,
         dataState: "streaming",
         networkStatus: current.networkStatus,
@@ -1937,7 +1926,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // though, so we also make sure we only deliver if the previous result
       // was also partial.
       if (current.dataState === "partial") {
-        deliverCacheResult({
+        this.deliverCacheResult({
           data: diff.result,
           dataState: current.dataState,
           networkStatus: current.networkStatus,
@@ -2000,6 +1989,17 @@ For more information about these options, please refer to the documentation:
     // reobservation is spurious, distinctUntilChanged still has a
     // chance to catch it before delivery to ObservableQuery subscribers.
     this.reobserveCacheFirst();
+  }
+
+  private deliverCacheResult(result: ObservableQuery.Result<any>) {
+    this.input.next({
+      kind: "N",
+      value: result,
+      source: "cache",
+      query: this.query,
+      variables: this.variables,
+      meta: {},
+    });
   }
 
   private activeOperations = new Set<TrackedOperation>();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -2215,9 +2215,9 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const { fetchPolicy, nextFetchPolicy } = this.options;
 
     if (fetchPolicy === "cache-and-network" || fetchPolicy === "network-only") {
-      // Preserve lastMissingResult so a cache-driven reobserve does not
-      // reset feud detection. User-initiated reobserve/refetch/poll clear it
-      // in `_reobserve` by default.
+      // Preserve this.lastMissing so a cache update that triggers this
+      // reobserve doesn't reset feud detection. All user-initiated calls to
+      // reobserve (refetch/poll/reobserve, etc) should clear it.
       this._reobserve(
         {
           fetchPolicy: "cache-first",

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1883,8 +1883,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // options considered, returning early and stopping the
           // reobserveCacheFirst cycle seems to be the least damaging place to
           // break the cycle because it allows read functions/custom scalars to
-          // be applied to the feuding query while while avoiding the endless
-          // cycle of requests.
+          // be applied to the feuding query while avoiding the endless cycle of
+          // requests.
           return;
         }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1842,34 +1842,37 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     }
 
     const diff = this.getCacheDiff();
-
+    const current = this.getCurrentResult();
     // `fromOptimisticTransaction` is not available through the `cache.diff`
     // code path, so we need to check whether the cache result is an optimistic
-    // result this way
-    if (!equal(diff.result, this.getCacheDiff({ optimistic: false }).result)) {
-      // If this diff came from an optimistic transaction, deliver the
+    // result this way.
+    const isOptimistic = !equal(
+      diff.result,
+      this.getCacheDiff({ optimistic: false }).result
+    );
+
+    if (
+      // When this diff came from an optimistic transaction, deliver the
       // current cache data to the ObservableQuery, but don't perform a
       // reobservation, since oq.reobserveCacheFirst might make a network
       // request, and we never want to trigger network requests in the
       // middle of optimistic updates.
-      this.deliverCacheDiff(diff);
-
-      return;
-    }
-
-    const current = this.getCurrentResult();
-
-    if (diff.complete) {
-      this.lastMissing = undefined;
-    } else if (current.networkStatus === NetworkStatus.streaming) {
+      isOptimistic ||
       // If we get a cache update in the middle of streaming (possible with
       // cache-and-network fetch policy), just deliver the cache value without
       // going through the full reobserve which would otherwise trigger another
       // request (deduplication should kick in, but doing so replays any
       // previous emits from the link chain, which get rewritten into the cache
       // and might clobber this cache update)
+      (!diff.complete && current.networkStatus === NetworkStatus.streaming)
+    ) {
       this.deliverCacheDiff(diff);
+
       return;
+    }
+
+    if (diff.complete) {
+      this.lastMissing = undefined;
     } else if (
       !lastMissing ||
       // If a destructive cache method has been called since the last recorded

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1896,7 +1896,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
               kind: "N",
               value: {
                 data: diff.result,
-                dataState: diff.result ? "partial" : "empty",
+                dataState: "partial",
                 networkStatus: current.networkStatus,
                 loading: current.loading,
                 error: undefined,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1892,9 +1892,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // though, so we also make sure we only deliver if the previous result
           // was also partial.
           if (
-            !equal(current.data, diff.result) &&
-            (current.dataState === "partial" ||
-              current.dataState === "streaming")
+            current.dataState === "partial" ||
+            current.dataState === "streaming"
           ) {
             this.input.next({
               kind: "N",

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1875,19 +1875,22 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
             dmCount: destructiveMethodCounts.get(this.cache),
           };
         } else if (
-          // cache-only calls reobserve and never fetches from the network, so
-          // we are ok allowing it to flow through the standard workflow. This
-          // also prevents the "stopped refetching" warning which would be
+          // reobserveCacheFirst with cache-only fetch policy only calls
+          // reobserve which never fetches from the network so we are ok
+          // allowing cache-only queries to fallthrough to reobserveCacheFirst.
+          // This prevents the "stopped refetching" warning which would be
           // confusing for a cache-only query anyways.
           this.options.fetchPolicy !== "cache-only"
         ) {
           const current = this.getCurrentResult();
 
-          // Because we track the missing fields in `lastMissingResult`, its
-          // possible data might have changed from a cache write. We want to
-          // prevent refetches to avoid feuds, but we are ok delivering the
-          // cache result only if the previous result was also partial. We NEVER
-          // want to downgrade a complete result to a partial result.
+          // If we've fallen through to this case, a cache emit has returned the
+          // same missing fields which means fields we've already delivered for
+          // this query have changed. We are ok delivering the updated value in
+          // this case to keep the result as fresh as possible. We NEVER want to
+          // downgrade this query from a complete query to a partial query
+          // though, so we also make sure we only deliver if the previous result
+          // was also partial.
           if (
             !equal(current.data, diff.result) &&
             current.dataState === "partial"

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1893,13 +1893,14 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // was also partial.
           if (
             !equal(current.data, diff.result) &&
-            current.dataState === "partial"
+            (current.dataState === "partial" ||
+              current.dataState === "streaming")
           ) {
             this.input.next({
               kind: "N",
               value: {
                 data: diff.result,
-                dataState: "partial",
+                dataState: current.dataState,
                 networkStatus: current.networkStatus,
                 loading: current.loading,
                 error: undefined,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1878,112 +1878,10 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       });
     };
 
-    if (
-      // `fromOptimisticTransaction` is not available through the `cache.diff`
-      // code path, so we need to check it this way
-      equal(diff.result, this.getCacheDiff({ optimistic: false }).result)
-    ) {
-      if (diff.complete) {
-        this.lastMissingResult = undefined;
-      } else if (
-        current.dataState === "streaming" ||
-        diff.dataState === "streaming"
-      ) {
-        deliverCacheResult({
-          data: diff.result,
-          dataState: "streaming",
-          networkStatus: current.networkStatus,
-          loading: current.loading,
-          error: undefined,
-          partial: true,
-        });
-        return;
-      } else if (this.shouldAutoRefetch(diff)) {
-        this.lastMissingResult = {
-          variables: this.variables,
-          missing: diff.missing?.missing,
-          dmCount: destructiveMethodCounts.get(this.cache),
-        };
-      } else if (
-        // reobserveCacheFirst with cache-only fetch policy only calls
-        // reobserve which never fetches from the network so we are ok
-        // allowing cache-only queries to fallthrough to reobserveCacheFirst.
-        // This prevents the "stopped refetching" warning which would be
-        // confusing for a cache-only query anyways.
-        fetchPolicy !== "cache-only"
-      ) {
-        // If we've fallen through to this case, a cache emit has returned the
-        // same missing fields which means fields we've already delivered for
-        // this query have changed. We are ok delivering the updated value in
-        // this case to keep the result as fresh as possible. We NEVER want to
-        // downgrade this query from a complete query to a partial query
-        // though, so we also make sure we only deliver if the previous result
-        // was also partial.
-        if (current.dataState === "partial") {
-          deliverCacheResult({
-            data: diff.result,
-            dataState: current.dataState,
-            networkStatus: current.networkStatus,
-            loading: current.loading,
-            error: undefined,
-            partial: true,
-          });
-        }
-        // If the (partial) result is the same as the last partial result
-        // we recorded from a previous broadcast (and the variables match
-        // too), avoid calling reobserveCacheFirst to refetch this query
-        // again. If we allow refetching anytime this result becomes partial,
-        // we risk feuds between queries competing to update the same data in
-        // incompatible ways, which can lead to an endless cycle of cache
-        // broadcasts and useless network requests. As with any
-        // feud, eventually one side must step back from the brink,
-        // letting the other side(s) have the last word(s). There may
-        // be other points where we could break this cycle, such as
-        // silencing the broadcast for cache.writeQuery (not a good
-        // idea, since it just delays the feud a bit) or somehow
-        // avoiding the network request that just happened (also bad,
-        // because the server could return useful new data). All
-        // options considered, returning early and stopping the
-        // reobserveCacheFirst cycle seems to be the least damaging place to
-        // break the cycle because it allows read functions/custom scalars to
-        // be applied to the feuding query while avoiding the endless cycle of
-        // requests.
-        if (__DEV__ && !this.didWarnOnFeud) {
-          this.didWarnOnFeud = true;
-          invariant.warn(
-            `Apollo Client stopped refetching '%s' because the same incomplete cache result was already refetched. Automatic refetching was halted to prevent an endless cycle of network requests.
-
-This often means another query is overwriting non-normalized data selected by this query. Common fixes:
-
-  * Select an \`id\` or \`_id\` field in each query that writes the object
-  * Set custom \`keyFields\` if the object uses a different identity
-  * Add a field \`merge\` function so partial writes combine instead of replace
-
-  missing fields: %o
-
-For more information about these options, please refer to the documentation:
-
-  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
-  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
-`,
-            getOperationName(this.query, "(anonymous)"),
-            diff.missing?.missing
-          );
-        }
-        return;
-      }
-
-      //If this diff did not come from an optimistic transaction
-      // make the ObservableQuery "reobserve" the latest data
-      // using a temporary fetch policy of "cache-first", so complete cache
-      // results have a chance to be delivered without triggering additional
-      // network requests, even when options.fetchPolicy is "network-only"
-      // or "cache-and-network". All other fetch policies are preserved by
-      // this method, and are handled by calling oq.reobserve(). If this
-      // reobservation is spurious, distinctUntilChanged still has a
-      // chance to catch it before delivery to ObservableQuery subscribers.
-      this.reobserveCacheFirst();
-    } else {
+    // `fromOptimisticTransaction` is not available through the `cache.diff`
+    // code path, so we need to check whether the cache result is an optimistic
+    // result this way
+    if (!equal(diff.result, this.getCacheDiff({ optimistic: false }).result)) {
       // If this diff came from an optimistic transaction, deliver the
       // current cache data to the ObservableQuery, but don't perform a
       // reobservation, since oq.reobserveCacheFirst might make a network
@@ -1998,7 +1896,110 @@ For more information about these options, please refer to the documentation:
         error: undefined,
         partial: !diff.complete,
       } as ObservableQuery.Result<TData>);
+
+      return;
     }
+
+    if (diff.complete) {
+      this.lastMissingResult = undefined;
+    } else if (
+      current.dataState === "streaming" ||
+      diff.dataState === "streaming"
+    ) {
+      deliverCacheResult({
+        data: diff.result,
+        dataState: "streaming",
+        networkStatus: current.networkStatus,
+        loading: current.loading,
+        error: undefined,
+        partial: true,
+      });
+      return;
+    } else if (this.shouldAutoRefetch(diff)) {
+      this.lastMissingResult = {
+        variables: this.variables,
+        missing: diff.missing?.missing,
+        dmCount: destructiveMethodCounts.get(this.cache),
+      };
+    } else if (
+      // reobserveCacheFirst with cache-only fetch policy only calls
+      // reobserve which never fetches from the network so we are ok
+      // allowing cache-only queries to fallthrough to reobserveCacheFirst.
+      // This prevents the "stopped refetching" warning which would be
+      // confusing for a cache-only query anyways.
+      fetchPolicy !== "cache-only"
+    ) {
+      // If we've fallen through to this case, a cache emit has returned the
+      // same missing fields which means fields we've already delivered for
+      // this query have changed. We are ok delivering the updated value in
+      // this case to keep the result as fresh as possible. We NEVER want to
+      // downgrade this query from a complete query to a partial query
+      // though, so we also make sure we only deliver if the previous result
+      // was also partial.
+      if (current.dataState === "partial") {
+        deliverCacheResult({
+          data: diff.result,
+          dataState: current.dataState,
+          networkStatus: current.networkStatus,
+          loading: current.loading,
+          error: undefined,
+          partial: true,
+        });
+      }
+      // If the (partial) result is the same as the last partial result
+      // we recorded from a previous broadcast (and the variables match
+      // too), avoid calling reobserveCacheFirst to refetch this query
+      // again. If we allow refetching anytime this result becomes partial,
+      // we risk feuds between queries competing to update the same data in
+      // incompatible ways, which can lead to an endless cycle of cache
+      // broadcasts and useless network requests. As with any
+      // feud, eventually one side must step back from the brink,
+      // letting the other side(s) have the last word(s). There may
+      // be other points where we could break this cycle, such as
+      // silencing the broadcast for cache.writeQuery (not a good
+      // idea, since it just delays the feud a bit) or somehow
+      // avoiding the network request that just happened (also bad,
+      // because the server could return useful new data). All
+      // options considered, returning early and stopping the
+      // reobserveCacheFirst cycle seems to be the least damaging place to
+      // break the cycle because it allows read functions/custom scalars to
+      // be applied to the feuding query while avoiding the endless cycle of
+      // requests.
+      if (__DEV__ && !this.didWarnOnFeud) {
+        this.didWarnOnFeud = true;
+        invariant.warn(
+          `Apollo Client stopped refetching '%s' because the same incomplete cache result was already refetched. Automatic refetching was halted to prevent an endless cycle of network requests.
+
+This often means another query is overwriting non-normalized data selected by this query. Common fixes:
+
+  * Select an \`id\` or \`_id\` field in each query that writes the object
+  * Set custom \`keyFields\` if the object uses a different identity
+  * Add a field \`merge\` function so partial writes combine instead of replace
+
+  missing fields: %o
+
+For more information about these options, please refer to the documentation:
+
+  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
+  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
+`,
+          getOperationName(this.query, "(anonymous)"),
+          diff.missing?.missing
+        );
+      }
+      return;
+    }
+
+    //If this diff did not come from an optimistic transaction
+    // make the ObservableQuery "reobserve" the latest data
+    // using a temporary fetch policy of "cache-first", so complete cache
+    // results have a chance to be delivered without triggering additional
+    // network requests, even when options.fetchPolicy is "network-only"
+    // or "cache-and-network". All other fetch policies are preserved by
+    // this method, and are handled by calling oq.reobserve(). If this
+    // reobservation is spurious, distinctUntilChanged still has a
+    // chance to catch it before delivery to ObservableQuery subscribers.
+    this.reobserveCacheFirst();
   }
 
   private activeOperations = new Set<TrackedOperation>();

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1874,7 +1874,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
             missing: diff.missing?.missing,
             dmCount: destructiveMethodCounts.get(this.cache),
           };
-        } else {
+        } else if (
+          // cache-only calls reobserve and never fetches from the network, so
+          // we are ok allowing it to flow through the standard workflow. This
+          // also prevents the "stopped refetching" warning which would be
+          // confusing for a cache-only query anyways.
+          this.options.fetchPolicy !== "cache-only"
+        ) {
           const current = this.getCurrentResult();
 
           // Because we track the missing fields in `lastMissingResult`, its

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -334,19 +334,19 @@ export class ObservableQuery<
   private variablesUnknown: boolean = false;
 
   private didWarnOnFeud = false;
-  private _lastIncompleteResult?: {
-    result: unknown;
+  private _lastMissingResult?: {
+    missing: MissingTree | undefined;
     variables: TVariables;
     dmCount: number | undefined;
   };
 
-  private get lastIncompleteResult() {
-    return this._lastIncompleteResult;
+  private get lastMissingResult() {
+    return this._lastMissingResult;
   }
 
-  private set lastIncompleteResult(newValue) {
+  private set lastMissingResult(newValue) {
     this.didWarnOnFeud = false;
-    this._lastIncompleteResult = newValue;
+    this._lastMissingResult = newValue;
   }
 
   // The `query` computed property will always reflect the document transformed
@@ -869,7 +869,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         this.getVariablesWithDefaults({ ...this.variables, ...variables });
     }
 
-    this.lastIncompleteResult = undefined;
+    this.lastMissingResult = undefined;
     return this._reobserve(reobserveOptions, {
       newNetworkStatus: NetworkStatus.refetch,
     });
@@ -1535,7 +1535,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           !isNetworkRequestInFlight(this.networkStatus) &&
           !this.options.skipPollAttempt?.()
         ) {
-          this.lastIncompleteResult = undefined;
+          this.lastMissingResult = undefined;
           this._reobserve(
             {
               // Most fetchPolicy options don't make sense to use in a polling context, as
@@ -1588,7 +1588,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   ): ObservableQuery.ResultPromise<
     ApolloClient.QueryResult<MaybeMasked<TData>>
   > {
-    this.lastIncompleteResult = undefined;
+    this.lastMissingResult = undefined;
     return this._reobserve(newOptions);
   }
   private _reobserve(
@@ -1781,7 +1781,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     this.queryManager.obsQueries.delete(this);
     this.isTornDown = true;
     this.abortActiveOperations();
-    this.lastIncompleteResult = undefined;
+    this.lastMissingResult = undefined;
   }
 
   private transformDocument(document: DocumentNode) {
@@ -1805,19 +1805,18 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   private notifyTimeout?: ReturnType<typeof setTimeout>;
 
   /** @internal */
-  private shouldAutoRefetch(result: unknown) {
-    const { lastIncompleteResult } = this;
+  private shouldAutoRefetch(diff: Cache.DiffResult<any>) {
+    const { lastMissingResult } = this;
 
     return (
-      !lastIncompleteResult ||
+      !lastMissingResult ||
       // If a destructive cache method has been called since the last recorded
       // incomplete result, there's a chance fetching this data again will
       // restore what was evicted, even though the cache result looks the same
       // as before.
-      lastIncompleteResult.dmCount !==
-        destructiveMethodCounts.get(this.cache) ||
-      !equal(lastIncompleteResult.variables, this.variables) ||
-      !equal(lastIncompleteResult.result, result)
+      lastMissingResult.dmCount !== destructiveMethodCounts.get(this.cache) ||
+      !equal(lastMissingResult.variables, this.variables) ||
+      !equal(lastMissingResult.missing, diff.missing?.missing)
     );
   }
 
@@ -1868,14 +1867,41 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         equal(diff.result, this.getCacheDiff({ optimistic: false }).result)
       ) {
         if (diff.complete) {
-          this.lastIncompleteResult = undefined;
-        } else if (this.shouldAutoRefetch(diff.result)) {
-          this.lastIncompleteResult = {
+          this.lastMissingResult = undefined;
+        } else if (this.shouldAutoRefetch(diff)) {
+          this.lastMissingResult = {
             variables: this.variables,
-            result: diff.result,
+            missing: diff.missing?.missing,
             dmCount: destructiveMethodCounts.get(this.cache),
           };
         } else {
+          const current = this.getCurrentResult();
+
+          // Because we track the missing fields in `lastMissingResult`, its
+          // possible data might have changed from a cache write. We want to
+          // prevent refetches to avoid feuds, but we are ok delivering the
+          // cache result only if the previous result was also partial. We NEVER
+          // want to downgrade a complete result to a partial result.
+          if (
+            !equal(current.data, diff.result) &&
+            current.dataState === "partial"
+          ) {
+            this.input.next({
+              kind: "N",
+              value: {
+                data: diff.result,
+                dataState: diff.result ? "partial" : "empty",
+                networkStatus: current.networkStatus,
+                loading: current.loading,
+                error: undefined,
+                partial: true,
+              } as ObservableQuery.Result<TData>,
+              source: "cache",
+              query: this.query,
+              variables: this.variables,
+              meta: {},
+            });
+          }
           // If the (partial) result is the same as the last partial result
           // we recorded from a previous broadcast (and the variables match
           // too), avoid calling reobserveCacheFirst to refetch this query
@@ -1936,7 +1962,7 @@ For more information about these options, please refer to the documentation:
         // reobservation, since oq.reobserveCacheFirst might make a network
         // request, and we never want to trigger network requests in the
         // middle of optimistic updates.
-        this.lastIncompleteResult = undefined;
+        this.lastMissingResult = undefined;
         this.input.next({
           kind: "N",
           value: {
@@ -2031,7 +2057,7 @@ For more information about these options, please refer to the documentation:
     // exception for cache-only queries - we reset them into a "ready" state
     // as we won't trigger a refetch for them
     const resetToEmpty = this.options.fetchPolicy === "cache-only";
-    this.lastIncompleteResult = undefined;
+    this.lastMissingResult = undefined;
     this.setResult(resetToEmpty ? empty : uninitialized, {
       shouldEmit: resetToEmpty ? EmitBehavior.force : EmitBehavior.never,
     });

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1878,12 +1878,12 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     } else if (current.networkStatus === NetworkStatus.streaming) {
       this.deliverCacheResult({
         data: diff.result,
-        dataState: "streaming",
+        dataState: diff.dataState,
         networkStatus: current.networkStatus,
         loading: current.loading,
         error: undefined,
         partial: true,
-      });
+      } as ObservableQuery.Result<TData>);
       return;
     } else if (
       !lastMissingResult ||

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1952,25 +1952,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // requests.
       if (__DEV__ && !this.didWarnOnFeud) {
         this.didWarnOnFeud = true;
-        invariant.warn(
-          `Apollo Client stopped refetching '%s' because the same incomplete cache result was already refetched. Automatic refetching was halted to prevent an endless cycle of network requests.
-
-This often means another query is overwriting non-normalized data selected by this query. Common fixes:
-
-  * Select an \`id\` or \`_id\` field in each query that writes the object
-  * Set custom \`keyFields\` if the object uses a different identity
-  * Add a field \`merge\` function so partial writes combine instead of replace
-
-  missing fields: %o
-
-For more information about these options, please refer to the documentation:
-
-  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
-  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
-`,
-          getOperationName(this.query, "(anonymous)"),
-          diff.missing?.missing
-        );
+        warnOnFeud(this.query, diff);
       }
       return;
     }
@@ -2342,4 +2324,26 @@ function getTrackingOperatorPromise<TData>(
       },
     });
   return { promise, operator };
+}
+
+function warnOnFeud(query: DocumentNode, diff: Cache.DiffResult<any>) {
+  invariant.warn(
+    `Apollo Client stopped refetching '%s' because the same incomplete cache result was already refetched. Automatic refetching was halted to prevent an endless cycle of network requests.
+
+This often means another query is overwriting non-normalized data selected by this query. Common fixes:
+
+  * Select an \`id\` or \`_id\` field in each query that writes the object
+  * Set custom \`keyFields\` if the object uses a different identity
+  * Add a field \`merge\` function so partial writes combine instead of replace
+
+  missing fields: %o
+
+For more information about these options, please refer to the documentation:
+
+  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
+  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
+`,
+    getOperationName(query, "(anonymous)"),
+    diff.missing?.missing
+  );
 }

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1852,12 +1852,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     }
 
     const { dirty } = this;
+    const { fetchPolicy } = this.options;
     this.resetNotifications();
 
     if (
       dirty &&
-      (this.options.fetchPolicy === "cache-only" ||
-        this.options.fetchPolicy === "cache-and-network" ||
+      (fetchPolicy === "cache-only" ||
+        fetchPolicy === "cache-and-network" ||
         !this.activeOperations.size)
     ) {
       const diff = this.getCacheDiff();
@@ -1906,7 +1907,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           // allowing cache-only queries to fallthrough to reobserveCacheFirst.
           // This prevents the "stopped refetching" warning which would be
           // confusing for a cache-only query anyways.
-          this.options.fetchPolicy !== "cache-only"
+          fetchPolicy !== "cache-only"
         ) {
           // If we've fallen through to this case, a cache emit has returned the
           // same missing fields which means fields we've already delivered for

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1875,10 +1875,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     if (diff.complete) {
       this.lastMissingResult = undefined;
-    } else if (
-      current.dataState === "streaming" ||
-      diff.dataState === "streaming"
-    ) {
+    } else if (current.networkStatus === NetworkStatus.streaming) {
       this.deliverCacheResult({
         data: diff.result,
         dataState: "streaming",

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1849,7 +1849,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     }
 
     const diff = this.getCacheDiff();
-    const current = this.getCurrentResult();
 
     // `fromOptimisticTransaction` is not available through the `cache.diff`
     // code path, so we need to check whether the cache result is an optimistic
@@ -1865,6 +1864,8 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
       return;
     }
+
+    const current = this.getCurrentResult();
 
     if (diff.complete) {
       this.lastMissingResult = undefined;

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1861,14 +1861,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // request, and we never want to trigger network requests in the
       // middle of optimistic updates.
       this.lastMissingResult = undefined;
-      this.deliverCacheResult({
-        data: diff.result,
-        dataState: diff.dataState,
-        networkStatus: current.networkStatus,
-        loading: current.loading,
-        error: undefined,
-        partial: !diff.complete,
-      } as ObservableQuery.Result<TData>);
+      this.deliverCacheDiff(diff);
 
       return;
     }
@@ -1882,14 +1875,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // request (deduplication should kick in, but doing so replays any
       // previous emits from the link chain, which get rewritten into the cache
       // and might clobber this cache update)
-      this.deliverCacheResult({
-        data: diff.result,
-        dataState: diff.dataState,
-        networkStatus: current.networkStatus,
-        loading: current.loading,
-        error: undefined,
-        partial: true,
-      } as ObservableQuery.Result<TData>);
+      this.deliverCacheDiff(diff);
       return;
     } else if (
       !lastMissingResult ||
@@ -1922,14 +1908,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // though, so we also make sure we only deliver if the previous result
       // was also partial.
       if (current.dataState === "partial") {
-        this.deliverCacheResult({
-          data: diff.result,
-          dataState: current.dataState,
-          networkStatus: current.networkStatus,
-          loading: current.loading,
-          error: undefined,
-          partial: true,
-        });
+        this.deliverCacheDiff(diff);
       }
       // If the (partial) result is the same as the last partial result
       // we recorded from a previous broadcast (and the variables match
@@ -1969,10 +1948,19 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     this.reobserveCacheFirst();
   }
 
-  private deliverCacheResult(result: ObservableQuery.Result<any>) {
+  private deliverCacheDiff(diff: Cache.InternalDiffResultWithDataState<TData>) {
+    const current = this.getCurrentResult();
+
     this.input.next({
       kind: "N",
-      value: result,
+      value: {
+        data: diff.result,
+        dataState: diff.dataState,
+        networkStatus: current.networkStatus,
+        loading: current.loading,
+        error: undefined,
+        partial: !diff.complete,
+      } as ObservableQuery.Result<TData>,
       source: "cache",
       query: this.query,
       variables: this.variables,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -334,20 +334,11 @@ export class ObservableQuery<
   private variablesUnknown: boolean = false;
 
   private didWarnOnFeud = false;
-  private _lastMissingResult?: {
+  private lastMissing?: {
     missing: MissingTree | undefined;
     variables: TVariables;
     dmCount: number | undefined;
   };
-
-  private get lastMissingResult() {
-    return this._lastMissingResult;
-  }
-
-  private set lastMissingResult(newValue) {
-    this.didWarnOnFeud = false;
-    this._lastMissingResult = newValue;
-  }
 
   // The `query` computed property will always reflect the document transformed
   // by the last run query. `this.options.query` will always reflect the raw
@@ -869,7 +860,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
         this.getVariablesWithDefaults({ ...this.variables, ...variables });
     }
 
-    this.lastMissingResult = undefined;
     return this._reobserve(reobserveOptions, {
       newNetworkStatus: NetworkStatus.refetch,
     });
@@ -1535,7 +1525,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           !isNetworkRequestInFlight(this.networkStatus) &&
           !this.options.skipPollAttempt?.()
         ) {
-          this.lastMissingResult = undefined;
           this._reobserve(
             {
               // Most fetchPolicy options don't make sense to use in a polling context, as
@@ -1588,19 +1577,23 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
   ): ObservableQuery.ResultPromise<
     ApolloClient.QueryResult<MaybeMasked<TData>>
   > {
-    this.lastMissingResult = undefined;
     return this._reobserve(newOptions);
   }
   private _reobserve(
     newOptions?: Partial<ObservableQuery.Options<TData, TVariables>>,
     internalOptions?: {
       newNetworkStatus?: NetworkStatus;
+      keepLastMissing?: boolean;
     }
   ): ObservableQuery.ResultPromise<
     ApolloClient.QueryResult<MaybeMasked<TData>>
   > {
     this.isTornDown = false;
-    let { newNetworkStatus } = internalOptions || {};
+    let { newNetworkStatus, keepLastMissing } = internalOptions || {};
+
+    if (!keepLastMissing) {
+      this.lastMissing = undefined;
+    }
 
     this.queryManager.obsQueries.add(this);
 
@@ -1781,7 +1774,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     this.queryManager.obsQueries.delete(this);
     this.isTornDown = true;
     this.abortActiveOperations();
-    this.lastMissingResult = undefined;
+    this.lastMissing = undefined;
   }
 
   private transformDocument(document: DocumentNode) {
@@ -1835,7 +1828,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       }
     }
 
-    const { dirty, lastMissingResult } = this;
+    const { dirty, lastMissing } = this;
     const { fetchPolicy } = this.options;
     this.resetNotifications();
 
@@ -1859,7 +1852,6 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // reobservation, since oq.reobserveCacheFirst might make a network
       // request, and we never want to trigger network requests in the
       // middle of optimistic updates.
-      this.lastMissingResult = undefined;
       this.deliverCacheDiff(diff);
 
       return;
@@ -1868,7 +1860,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const current = this.getCurrentResult();
 
     if (diff.complete) {
-      this.lastMissingResult = undefined;
+      this.lastMissing = undefined;
     } else if (current.networkStatus === NetworkStatus.streaming) {
       // If we get a cache update in the middle of streaming (possible with
       // cache-and-network fetch policy), just deliver the cache value without
@@ -1879,16 +1871,17 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       this.deliverCacheDiff(diff);
       return;
     } else if (
-      !lastMissingResult ||
+      !lastMissing ||
       // If a destructive cache method has been called since the last recorded
       // incomplete result, there's a chance fetching this data again will
       // restore what was evicted, even though the cache result looks the same
       // as before.
-      lastMissingResult.dmCount !== destructiveMethodCounts.get(this.cache) ||
-      !equal(lastMissingResult.variables, this.variables) ||
-      !equal(lastMissingResult.missing, diff.missing?.missing)
+      lastMissing.dmCount !== destructiveMethodCounts.get(this.cache) ||
+      !equal(lastMissing.variables, this.variables) ||
+      !equal(lastMissing.missing, diff.missing?.missing)
     ) {
-      this.lastMissingResult = {
+      this.didWarnOnFeud = false;
+      this.lastMissing = {
         variables: this.variables,
         missing: diff.missing?.missing,
         dmCount: destructiveMethodCounts.get(this.cache),
@@ -2044,7 +2037,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     // exception for cache-only queries - we reset them into a "ready" state
     // as we won't trigger a refetch for them
     const resetToEmpty = this.options.fetchPolicy === "cache-only";
-    this.lastMissingResult = undefined;
+    this.lastMissing = undefined;
     this.setResult(resetToEmpty ? empty : uninitialized, {
       shouldEmit: resetToEmpty ? EmitBehavior.force : EmitBehavior.never,
     });
@@ -2219,32 +2212,35 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
     const { fetchPolicy, nextFetchPolicy } = this.options;
 
     if (fetchPolicy === "cache-and-network" || fetchPolicy === "network-only") {
-      // Calls `_reobserve` rather than `reobserve` so that a refetch initiated
-      // by the cache update does not clear `lastIncompleteResult`, which
-      // only user-initiated reobservations should do.
-      this._reobserve({
-        fetchPolicy: "cache-first",
-        // Use a temporary nextFetchPolicy function that replaces itself with the
-        // previous nextFetchPolicy value and returns the original fetchPolicy.
-        nextFetchPolicy(
-          this: ApolloClient.WatchQueryOptions<TData, TVariables>,
-          currentFetchPolicy: WatchQueryFetchPolicy,
-          context: NextFetchPolicyContext<TData, TVariables>
-        ) {
-          // Replace this nextFetchPolicy function in the options object with the
-          // original this.options.nextFetchPolicy value.
-          this.nextFetchPolicy = nextFetchPolicy;
-          // If the original nextFetchPolicy value was a function, give it a
-          // chance to decide what happens here.
-          if (typeof this.nextFetchPolicy === "function") {
-            return this.nextFetchPolicy(currentFetchPolicy, context);
-          }
-          // Otherwise go back to the original this.options.fetchPolicy.
-          return fetchPolicy!;
+      // Preserve lastMissingResult so a cache-driven reobserve does not
+      // reset feud detection. User-initiated reobserve/refetch/poll clear it
+      // in `_reobserve` by default.
+      this._reobserve(
+        {
+          fetchPolicy: "cache-first",
+          // Use a temporary nextFetchPolicy function that replaces itself with the
+          // previous nextFetchPolicy value and returns the original fetchPolicy.
+          nextFetchPolicy(
+            this: ApolloClient.WatchQueryOptions<TData, TVariables>,
+            currentFetchPolicy: WatchQueryFetchPolicy,
+            context: NextFetchPolicyContext<TData, TVariables>
+          ) {
+            // Replace this nextFetchPolicy function in the options object with the
+            // original this.options.nextFetchPolicy value.
+            this.nextFetchPolicy = nextFetchPolicy;
+            // If the original nextFetchPolicy value was a function, give it a
+            // chance to decide what happens here.
+            if (typeof this.nextFetchPolicy === "function") {
+              return this.nextFetchPolicy(currentFetchPolicy, context);
+            }
+            // Otherwise go back to the original this.options.fetchPolicy.
+            return fetchPolicy!;
+          },
         },
-      });
+        { keepLastMissing: true }
+      );
     } else {
-      this._reobserve();
+      this._reobserve(undefined, { keepLastMissing: true });
     }
   }
 

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1897,17 +1897,17 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       // reobserveCacheFirst with cache-only fetch policy only calls
       // reobserve which never fetches from the network so we are ok
       // allowing cache-only queries to fallthrough to reobserveCacheFirst.
-      // This prevents the "stopped refetching" warning which would be
-      // confusing for a cache-only query anyways.
+      // This also prevents the feud warning which would be confusing for a
+      // cache-only query anyways.
       fetchPolicy !== "cache-only"
     ) {
       // If we've fallen through to this case, a cache emit has returned the
-      // same missing fields which means fields we've already delivered for
-      // this query have changed. We are ok delivering the updated value in
-      // this case to keep the result as fresh as possible. We NEVER want to
-      // downgrade this query from a complete query to a partial query
-      // though, so we also make sure we only deliver if the previous result
-      // was also partial.
+      // same missing fields which means at least one value on the fields we've
+      // already delivered have changed. We are ok delivering the updated
+      // partial result in this case to keep the result as fresh as possible. We
+      // NEVER want to downgrade this query from a complete query to a partial
+      // query though, so we also make sure we only deliver if the previous
+      // result was also partial.
       if (current.dataState === "partial") {
         this.deliverCacheDiff(diff);
       }

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -1,9 +1,7 @@
-import { equal } from "@wry/equality";
 import { Trie } from "@wry/trie";
 import type { DocumentNode, FormattedExecutionResult } from "graphql";
 
 import type {
-  ApolloCache,
   Cache,
   DiffIncrementalInfo,
   IgnoreModifier,
@@ -57,15 +55,6 @@ export const enum CacheWriteBehavior {
   MERGE,
 }
 
-interface LastWrite {
-  result: FormattedExecutionResult<any, ExtensionsWithStreamInfo>;
-  variables: ApolloClient.WatchQueryOptions["variables"];
-  dmCount: number | undefined;
-  hasNext: boolean;
-}
-
-const destructiveMethodCounts = new WeakMap<ApolloCache, number>();
-
 interface OperationInfo<
   TData,
   TVariables extends OperationVariables,
@@ -81,28 +70,6 @@ interface OperationInfo<
 interface MarkQueryResult<TData, TExtensions>
   extends FormattedExecutionResult<TData, TExtensions> {
   dataState: "empty" | "partial" | "streaming" | "complete";
-}
-
-function wrapDestructiveCacheMethod(
-  cache: ApolloCache,
-  methodName: "evict" | "modify" | "reset"
-) {
-  const original = cache[methodName];
-  if (typeof original === "function") {
-    // @ts-expect-error this is just too generic to be typed correctly
-    cache[methodName] = function () {
-      destructiveMethodCounts.set(
-        cache,
-        // The %1e15 allows the count to wrap around to 0 safely every
-        // quadrillion evictions, so there's no risk of overflow. To be
-        // clear, this is more of a pedantic principle than something
-        // that matters in any conceivable practical scenario.
-        (destructiveMethodCounts.get(cache)! + 1) % 1e15
-      );
-      // @ts-expect-error this is just too generic to be typed correctly
-      return original.apply(this, arguments);
-    };
-  }
 }
 
 const queryInfoIds = new WeakMap<QueryManager, number>();
@@ -137,67 +104,12 @@ export class QueryInfo<
     queryManager: QueryManager,
     observableQuery?: ObservableQuery<any, any>
   ) {
-    const cache = (this.cache = queryManager.cache as TCache);
+    this.cache = queryManager.cache as TCache;
     const id = (queryInfoIds.get(queryManager) || 0) + 1;
     queryInfoIds.set(queryManager, id);
     this.id = id + "";
     this.observableQuery = observableQuery;
     this.queryManager = queryManager;
-
-    // Track how often cache.evict is called, since we want eviction to
-    // override the write-skipping logic in `shouldWrite`, by causing it to
-    // return true. Wrapping the cache.evict method is a bit of a hack, but it
-    // saves us from having to make eviction counting an official part of the
-    // ApolloCache API.
-    if (!destructiveMethodCounts.has(cache)) {
-      destructiveMethodCounts.set(cache, 0);
-      wrapDestructiveCacheMethod(cache, "evict");
-      wrapDestructiveCacheMethod(cache, "modify");
-      wrapDestructiveCacheMethod(cache, "reset");
-    }
-  }
-
-  /**
-   * @internal
-   * Tracks the last result written to the cache so that `shouldWrite` can skip
-   * an identical write. Since a `QueryInfo` only ever represents a single
-   * network request, this is shared by all `QueryInfo` instances of an
-   * `ObservableQuery`. A standalone `QueryInfo` keeps a local version.
-   *
-   * A network result that was explicitly asked for always takes precedence over
-   * what is already cached, so `ObservableQuery.refetch` and polling clear this
-   * value before starting their request.
-   */
-  public _lastWrite?: LastWrite;
-  private get lastWrite(): LastWrite | undefined {
-    return (this.observableQuery || this)._lastWrite as LastWrite | undefined;
-  }
-  private set lastWrite(value: LastWrite | undefined) {
-    (this.observableQuery || this)._lastWrite = value;
-  }
-
-  public resetLastWrite() {
-    this.lastWrite = void 0;
-  }
-
-  private shouldWrite(
-    result: FormattedExecutionResult<any, ExtensionsWithStreamInfo>,
-    variables: ApolloClient.WatchQueryOptions["variables"]
-  ) {
-    const { lastWrite } = this;
-    return (
-      !lastWrite ||
-      // If cache.evict has been called since the last time we wrote this
-      // data into the cache, there's a chance writing this result into
-      // the cache will repair what was evicted.
-      lastWrite.dmCount !== destructiveMethodCounts.get(this.cache) ||
-      !equal(variables, lastWrite.variables) ||
-      !equal(result.data, lastWrite.result.data) ||
-      // We have to compare these values because its possible the final chunk
-      // emitted in the incremental result is just `hasNext: false`. This
-      // ensures we trigger a cache write when we get `isLastChunk: true`.
-      lastWrite.hasNext !== this.hasNext
-    );
   }
 
   get hasNext() {
@@ -320,16 +232,9 @@ export class QueryInfo<
       result.dataState = "streaming";
     }
 
-    if (skipCache) {
+    if (skipCache || !shouldWriteResult(result, errorPolicy)) {
       return result;
     }
-
-    if (!shouldWriteResult(result, errorPolicy)) {
-      this.lastWrite = void 0;
-      return result;
-    }
-
-    let written = false;
 
     // Using a transaction here so we have a chance to read the result
     // back from the cache before the watch callback fires as a result
@@ -348,57 +253,13 @@ export class QueryInfo<
         }
       },
       update: (cache) => {
-        const shouldWrite = this.shouldWrite(result, variables);
-
-        // If result is the same as the last result we received from
-        // the network (and the variables match too), avoid writing
-        // result into the cache again. The wisdom of skipping this
-        // cache write is far from obvious, since any cache write
-        // could be the one that puts the cache back into a desired
-        // state, fixing corruption or missing data. However, if we
-        // always write every network result into the cache, we enable
-        // feuds between queries competing to update the same data in
-        // incompatible ways, which can lead to an endless cycle of
-        // cache broadcasts and useless network requests. As with any
-        // feud, eventually one side must step back from the brink,
-        // letting the other side(s) have the last word(s). There may
-        // be other points where we could break this cycle, such as
-        // silencing the broadcast for cache.writeQuery (not a good
-        // idea, since it just delays the feud a bit) or somehow
-        // avoiding the network request that just happened (also bad,
-        // because the server could return useful new data). All
-        // options considered, skipping this cache write seems to be
-        // the least damaging place to break the cycle, because it
-        // reflects the intuition that we recently wrote this exact
-        // result into the cache, so the cache *should* already/still
-        // contain this data. If some other query has clobbered that
-        // data in the meantime, that's too bad, but there will be no
-        // winners if every query blindly reverts to its own version
-        // of the data. This approach also gives the network a chance
-        // to return new data, which will be written into the cache as
-        // usual, notifying only those queries that are directly
-        // affected by the cache updates, as usual. In the future, an
-        // even more sophisticated cache could perhaps prevent or
-        // mitigate the clobbering somehow, but that would make this
-        // particular cache write even less important, and thus
-        // skipping it would be even safer than it is today.
-        if (shouldWrite) {
-          cache.writeQuery({
-            query,
-            data: result.data as Unmasked<any>,
-            variables,
-            overwrite: cacheWriteBehavior === CacheWriteBehavior.OVERWRITE,
-            extensions: result.extensions,
-          });
-
-          this.lastWrite = {
-            result,
-            variables,
-            dmCount: destructiveMethodCounts.get(this.cache),
-            hasNext: this.hasNext,
-          };
-          written = true;
-        }
+        cache.writeQuery({
+          query,
+          data: result.data as Unmasked<any>,
+          variables,
+          overwrite: cacheWriteBehavior === CacheWriteBehavior.OVERWRITE,
+          extensions: result.extensions,
+        });
 
         const { dataState, result: diffResult } = this.getDiff(
           {
@@ -415,12 +276,11 @@ export class QueryInfo<
         if (
           dataState === "complete" ||
           dataState === "streaming" ||
-          (returnPartialData && dataState === "partial" && shouldWrite)
+          (returnPartialData && dataState === "partial")
         ) {
           result = { ...result, data: diffResult, dataState };
         } else if (
           __DEV__ &&
-          written &&
           // A result that is still streaming is expected to read back
           // incomplete until the remaining chunks arrive.
           !this.hasNext

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1089,7 +1089,6 @@ export class QueryManager {
         const hasErrors = graphQLResultHasError(result);
 
         if (hasErrors && errorPolicy === "none") {
-          queryInfo.resetLastWrite();
           observableQuery?.["resetNotifications"]();
           const error = new CombinedGraphQLErrors(
             removeStreamDetailsFromExtensions(result)
@@ -1134,7 +1133,6 @@ export class QueryManager {
       }),
       catchError((error) => {
         if (errorPolicy === "none") {
-          queryInfo.resetLastWrite();
           observableQuery?.["resetNotifications"]();
           throw error;
         }

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3463,7 +3463,7 @@ describe("ApolloClient", () => {
       returnPartialData: true,
     });
 
-    const stream = new ObservableStream(obs);
+    using stream = new ObservableStream(obs);
 
     await expect(stream).toEmitTypedValue({
       loading: true,

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -2877,6 +2877,9 @@ describe("ApolloClient", () => {
   });
 
   it("stops repeated refetches when queries feud over non-normalized data", async () => {
+    // Silence the feud-stop warning; warn content is covered in dedicated tests.
+    using _ = spyOnConsole("warn");
+
     const cache = new InMemoryCache({
       typePolicies: {
         Query: {
@@ -3031,6 +3034,195 @@ describe("ApolloClient", () => {
     // the network again.
     await expect(aStream).not.toEmitAnything();
     await expect(bStream).not.toEmitAnything();
+  });
+
+  it("warns when feud-stopping skips a refetch", async () => {
+    using _ = spyOnConsole("warn");
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        typePolicies: {
+          Query: {
+            fields: {
+              info: {
+                merge: false,
+              },
+            },
+          },
+        },
+      }),
+      link: new ApolloLink(
+        (operation) =>
+          new Observable((observer) => {
+            setTimeout(() => {
+              switch (operation.operationName) {
+                case "A":
+                  observer.next({ data: { info: { a: "ay" } } });
+                  break;
+                case "B":
+                  observer.next({ data: { info: { b: "bee" } } });
+                  break;
+              }
+              observer.complete!();
+            });
+          })
+      ),
+    });
+
+    const queryA = gql`
+      query A {
+        info {
+          a
+        }
+      }
+    `;
+    const queryB = gql`
+      query B {
+        info {
+          b
+        }
+      }
+    `;
+
+    using aStream = new ObservableStream(
+      client.watchQuery({
+        query: queryA,
+        returnPartialData: true,
+      })
+    );
+    using bStream = new ObservableStream(
+      client.watchQuery({
+        query: queryB,
+        returnPartialData: true,
+      })
+    );
+
+    // initial loading
+    await aStream.takeNext();
+    await bStream.takeNext();
+    // initial complete results
+    await aStream.takeNext();
+    await bStream.takeNext();
+    // A auto-refetches after B overwrites it
+    await aStream.takeNext();
+    await aStream.takeNext();
+    // B auto-refetches after A overwrites it
+    await bStream.takeNext();
+    await bStream.takeNext();
+    // A stops rather than restarting the feud
+    await expect(aStream).not.toEmitAnything();
+    await expect(bStream).not.toEmitAnything();
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Apollo Client stopped refetching '%s'"),
+      "A",
+      {
+        info: {
+          a: expect.stringContaining("Can't find field 'a'"),
+        },
+      }
+    );
+  });
+
+  it("warns once until feud stopping is reset", async () => {
+    using consoleSpy = spyOnConsole("warn");
+
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            info: {
+              merge: false,
+            },
+          },
+        },
+      },
+    });
+
+    const client = new ApolloClient({
+      cache,
+      link: new ApolloLink(
+        (operation) =>
+          new Observable((observer) => {
+            setTimeout(() => {
+              switch (operation.operationName) {
+                case "A":
+                  observer.next({ data: { info: { a: "ay" } } });
+                  break;
+                case "B":
+                  observer.next({ data: { info: { b: "bee" } } });
+                  break;
+              }
+              observer.complete!();
+            });
+          })
+      ),
+    });
+
+    const queryA = gql`
+      query A {
+        info {
+          a
+        }
+      }
+    `;
+    const queryB = gql`
+      query B {
+        info {
+          b
+        }
+      }
+    `;
+
+    using aStream = new ObservableStream(
+      client.watchQuery({
+        query: queryA,
+        returnPartialData: true,
+      })
+    );
+    using bStream = new ObservableStream(
+      client.watchQuery({
+        query: queryB,
+        returnPartialData: true,
+      })
+    );
+
+    // Drive the feud until A stops auto-refetching.
+    await aStream.takeNext();
+    await bStream.takeNext();
+    await aStream.takeNext();
+    await bStream.takeNext();
+    await aStream.takeNext();
+    await aStream.takeNext();
+    await bStream.takeNext();
+    await bStream.takeNext();
+    await expect(aStream).not.toEmitAnything();
+    await expect(bStream).not.toEmitAnything();
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    consoleSpy.warn.mockClear();
+
+    // Another overwrite that leaves A incomplete the same way shouldn't warn
+    // again
+    cache.writeQuery({
+      query: queryB,
+      data: { info: { b: "bee again" } },
+    });
+    await expect(aStream).not.toEmitAnything();
+    await expect(bStream).toEmitTypedValue({
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      data: {
+        info: {
+          b: "bee again",
+        },
+      },
+      dataState: "complete",
+      partial: false,
+    });
+
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it("fetches a clobbered value again after reading a complete result in between", async () => {

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -2876,7 +2876,7 @@ describe("ApolloClient", () => {
     });
   });
 
-  it("should not write unchanged network results to cache", async () => {
+  it("stops repeated refetches when queries feud over non-normalized data", async () => {
     const cache = new InMemoryCache({
       typePolicies: {
         Query: {
@@ -2978,6 +2978,8 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
+    // B overwrites A's non-normalized data, so it refetches to fulfill its
+    // data requirements.
     await expect(aStream).toEmitTypedValue({
       loading: true,
       networkStatus: NetworkStatus.loading,
@@ -3000,8 +3002,234 @@ describe("ApolloClient", () => {
       partial: false,
     });
 
+    // A's refetch leaves B incomplete, so it refetches to fulfill its data
+    // requirements.
+    await expect(bStream).toEmitTypedValue({
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      data: {
+        info: {},
+      },
+      dataState: "partial",
+      partial: true,
+    });
+
+    await expect(bStream).toEmitTypedValue({
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      data: {
+        info: {
+          b: "bee",
+        },
+      },
+      dataState: "complete",
+      partial: false,
+    });
+
+    // B's refetch leaves A incomplete in exactly the way it already tried to
+    // fix with the initial refetch, so A stops rather than sending B back to
+    // the network again.
     await expect(aStream).not.toEmitAnything();
     await expect(bStream).not.toEmitAnything();
+  });
+
+  it("fetches a clobbered value again after reading a complete result in between", async () => {
+    const query = gql`
+      query A {
+        info {
+          a
+        }
+      }
+    `;
+
+    const clobberQuery = gql`
+      query Clobber {
+        info {
+          b
+        }
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        typePolicies: {
+          Query: {
+            fields: {
+              info: {
+                merge: false,
+              },
+            },
+          },
+        },
+      }),
+      link: new MockLink([
+        {
+          request: { query },
+          result: { data: { info: { __typename: "Info", a: "ay" } } },
+          delay: 20,
+          maxUsageCount: Number.POSITIVE_INFINITY,
+        },
+      ]),
+    });
+
+    using stream = new ObservableStream(client.watchQuery({ query }));
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+    await expect(stream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "ay" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    client.writeQuery({
+      query: clobberQuery,
+      data: { info: { __typename: "Info", b: "bee" } },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "ay" } },
+      dataState: "complete",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: false,
+    });
+    await expect(stream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "ay" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    // Writing a complete result allows the query to refetch again when a future
+    // cache write causes the query to go incomplete
+    client.writeQuery({
+      query,
+      data: { info: { __typename: "Info", a: "restored" } },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "restored" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    client.writeQuery({
+      query: clobberQuery,
+      data: { info: { __typename: "Info", b: "bee" } },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "restored" } },
+      dataState: "complete",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: false,
+    });
+    await expect(stream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "ay" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  it("should deliver a cache-only result again after an optimistic update is rolled back", async () => {
+    const query = gql`
+      query {
+        config {
+          a
+          b
+        }
+      }
+    `;
+
+    const partialQuery = gql`
+      query {
+        config {
+          a
+        }
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+    });
+
+    client.writeQuery({
+      query: partialQuery,
+      data: { config: { __typename: "Config", a: "one" } },
+    });
+
+    using stream = new ObservableStream(
+      client.watchQuery({
+        query,
+        fetchPolicy: "cache-only",
+        // returnPartialData is needed to reproduce the behavior. Complete cache
+        // results are always delivered
+        returnPartialData: true,
+      })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: { config: { __typename: "Config", a: "one" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    client.writeQuery({
+      query: partialQuery,
+      data: { config: { __typename: "Config", a: "two" } },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { config: { __typename: "Config", a: "two" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    client.cache.recordOptimisticTransaction((cache) => {
+      cache.writeQuery({
+        query: partialQuery,
+        data: { config: { __typename: "Config", a: "optimistic" } },
+      });
+    }, "optimistic");
+
+    await expect(stream).toEmitTypedValue({
+      data: { config: { __typename: "Config", a: "optimistic" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    client.cache.removeOptimistic("optimistic");
+
+    await expect(stream).toEmitTypedValue({
+      data: { config: { __typename: "Config", a: "two" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
   });
 
   it("should disable feud-stopping logic after evict or modify", async () => {
@@ -3116,6 +3344,169 @@ describe("ApolloClient", () => {
     });
 
     await expect(stream).not.toEmitAnything();
+  });
+
+  it("applies read functions when feud-stopping skips refetches", async () => {
+    using _ = spyOnConsole("warn");
+
+    const queryA = gql`
+      query A {
+        info {
+          a
+        }
+      }
+    `;
+
+    const queryB = gql`
+      query B {
+        info {
+          b
+        }
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        typePolicies: {
+          Query: {
+            fields: {
+              info: {
+                merge: false,
+              },
+            },
+          },
+          Info: {
+            fields: {
+              a: {
+                read: (existing: string | undefined) => existing?.toUpperCase(),
+              },
+              b: {
+                read: (existing: string | undefined) => existing?.toUpperCase(),
+              },
+            },
+          },
+        },
+      }),
+      link: new MockLink([
+        {
+          request: { query: queryA },
+          result: { data: { info: { __typename: "Info", a: "ay" } } },
+          delay: 20,
+          maxUsageCount: Number.POSITIVE_INFINITY,
+        },
+        {
+          request: { query: queryB },
+          result: { data: { info: { __typename: "Info", b: "bee" } } },
+          delay: 20,
+          maxUsageCount: Number.POSITIVE_INFINITY,
+        },
+      ]),
+    });
+
+    const obsA = client.watchQuery({ query: queryA });
+    using aStream = new ObservableStream(obsA);
+
+    await expect(aStream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+    await expect(aStream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "AY" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    const obsB = client.watchQuery({ query: queryB });
+    using bStream = new ObservableStream(obsB);
+
+    await expect(bStream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+    await expect(bStream).toEmitTypedValue({
+      data: { info: { __typename: "Info", b: "BEE" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    expect(client.cache.extract()).toStrictEqualTyped({
+      ROOT_QUERY: {
+        __typename: "Query",
+        info: { __typename: "Info", b: "bee" },
+      },
+    });
+
+    await expect(aStream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "AY" } },
+      dataState: "complete",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: false,
+    });
+    await expect(aStream).toEmitTypedValue({
+      data: { info: { __typename: "Info", a: "AY" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    expect(client.cache.extract()).toStrictEqualTyped({
+      ROOT_QUERY: {
+        __typename: "Query",
+        info: { __typename: "Info", a: "ay" },
+      },
+    });
+
+    await expect(bStream).toEmitTypedValue({
+      data: { info: { __typename: "Info", b: "BEE" } },
+      dataState: "complete",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: false,
+    });
+    await expect(bStream).toEmitTypedValue({
+      data: { info: { __typename: "Info", b: "BEE" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+
+    expect(client.cache.extract()).toStrictEqualTyped({
+      ROOT_QUERY: {
+        __typename: "Query",
+        info: { __typename: "Info", b: "bee" },
+      },
+    });
+
+    await expect(aStream).not.toEmitAnything();
+    await expect(bStream).not.toEmitAnything();
+
+    expect(obsA.getCurrentResult()).toStrictEqualTyped({
+      data: { info: { __typename: "Info", a: "AY" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
+    expect(obsB.getCurrentResult()).toStrictEqualTyped({
+      data: { info: { __typename: "Info", b: "BEE" } },
+      dataState: "complete",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: false,
+    });
   });
 
   it("writes the latest polled result over a clobbered cache value when polled result equals last polled result", async () => {

--- a/src/core/__tests__/ApolloClient/general.test.ts
+++ b/src/core/__tests__/ApolloClient/general.test.ts
@@ -3701,6 +3701,207 @@ describe("ApolloClient", () => {
     });
   });
 
+  it("delivers repeated cache updates to a cache-only query kept partial by a read function", async () => {
+    const query = gql`
+      query A {
+        user {
+          id
+          name
+          age
+        }
+      }
+    `;
+
+    const fragment = gql`
+      fragment UserName on User {
+        name
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        typePolicies: {
+          User: {
+            fields: {
+              age: { read: () => undefined },
+            },
+          },
+        },
+      }),
+      link: ApolloLink.empty(),
+    });
+
+    client.writeQuery({
+      query,
+      data: { user: { __typename: "User", id: "1", name: "Alice", age: 30 } },
+    });
+
+    using stream = new ObservableStream(
+      client.watchQuery({
+        query,
+        fetchPolicy: "cache-only",
+        returnPartialData: true,
+      })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: { user: { __typename: "User", id: "1", name: "Alice" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    client.writeFragment({
+      fragment: fragment,
+      from: { __typename: "User", id: "1" },
+      data: { __typename: "User", id: "1", name: "Alice Smith" },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { user: { __typename: "User", id: "1", name: "Alice Smith" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    // The same field changes a second time. `age` is still the only missing
+    // field, but the data this query can read changed again, so it still needs
+    // to deliver it.
+    client.writeFragment({
+      fragment: fragment,
+      from: { __typename: "User", id: "1" },
+      data: { __typename: "User", id: "1", name: "Alice Jones" },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { user: { __typename: "User", id: "1", name: "Alice Jones" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    await expect(stream).not.toEmitAnything();
+  });
+
+  it("delivers repeated cache updates to a cache-first query kept partial by a read function", async () => {
+    using _ = spyOnConsole("warn");
+
+    const query = gql`
+      query A {
+        user {
+          id
+          name
+          age
+        }
+      }
+    `;
+
+    const fragment = gql`
+      fragment UserName on User {
+        name
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache({
+        typePolicies: {
+          User: {
+            fields: {
+              age: { read: () => undefined },
+            },
+          },
+        },
+      }),
+      link: new MockLink([
+        {
+          request: { query },
+          result: {
+            data: {
+              user: { __typename: "User", id: "1", name: "Alice", age: 30 },
+            },
+          },
+          delay: 20,
+        },
+        {
+          request: { query },
+          result: {
+            data: {
+              user: {
+                __typename: "User",
+                id: "1",
+                name: "Alice Smith",
+                age: 30,
+              },
+            },
+          },
+          delay: 20,
+        },
+      ]),
+    });
+
+    using stream = new ObservableStream(
+      client.watchQuery({ query, returnPartialData: true })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+    await expect(stream).toEmitTypedValue({
+      data: { user: { __typename: "User", id: "1", name: "Alice" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    client.writeFragment({
+      fragment,
+      from: { __typename: "User", id: "1" },
+      data: { __typename: "User", id: "1", name: "Alice Smith" },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { user: { __typename: "User", id: "1", name: "Alice Smith" } },
+      dataState: "partial",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+    await expect(stream).toEmitTypedValue({
+      data: { user: { __typename: "User", id: "1", name: "Alice Smith" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    // The same field changes a second time. `age` is still the only missing
+    // field, but the data this query can read changed again, so it still needs
+    // to deliver it.
+    client.writeFragment({
+      fragment,
+      from: { __typename: "User", id: "1" },
+      data: { __typename: "User", id: "1", name: "Alice Jones" },
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { user: { __typename: "User", id: "1", name: "Alice Jones" } },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    await expect(stream).not.toEmitAnything();
+  });
+
   it("writes the latest polled result over a clobbered cache value when polled result equals last polled result", async () => {
     const query = gql`
       query {

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -20,6 +20,7 @@ import {
   mockDefer20220824,
   mockDeferStreamGraphQL17Alpha9,
   ObservableStream,
+  spyOnConsole,
 } from "@apollo/client/testing/internal";
 
 test("serializes scalar variables used in field arguments", async () => {
@@ -1979,6 +1980,8 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
 });
 
 test("parses custom scalar fields when feud-stopping skips refetches", async () => {
+  using _ = spyOnConsole("warn");
+
   const createdAtQuery = gql`
     query {
       post {
@@ -2141,6 +2144,8 @@ test("parses custom scalar fields when feud-stopping skips refetches", async () 
 });
 
 test("parses custom scalar fields when feud-stopping skips refetches with overlapping fields", async () => {
+  using _ = spyOnConsole("warn");
+
   const updatedAtQuery = gql`
     query UpdatedAtQuery {
       post {

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -13,6 +13,7 @@ import {
   Defer20220824Handler,
   GraphQL17Alpha9Handler,
 } from "@apollo/client/incremental";
+import { MockLink } from "@apollo/client/testing";
 import {
   dateScalar,
   markAsStreaming,
@@ -1975,4 +1976,403 @@ test("parses custom scalar fields across `@stream` payloads (graphql17Alpha9)", 
   });
 
   await expect(stream).not.toEmitAnything();
+});
+
+test("parses custom scalar fields when feud-stopping skips refetches", async () => {
+  const createdAtQuery = gql`
+    query {
+      post {
+        createdAt
+      }
+    }
+  `;
+
+  const updatedAtQuery = gql`
+    query {
+      post {
+        updatedAt
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Query: {
+          fields: {
+            post: {
+              merge: false,
+            },
+          },
+        },
+        Post: {
+          fields: {
+            createdAt: { scalar: "Date" },
+            updatedAt: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query: createdAtQuery },
+        result: {
+          data: { post: { __typename: "Post", createdAt: "2026-01-01" } },
+        },
+        delay: 20,
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+      {
+        request: { query: updatedAtQuery },
+        result: {
+          data: { post: { __typename: "Post", updatedAt: "2026-02-02" } },
+        },
+        delay: 20,
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+  });
+
+  const createdAtObservable = client.watchQuery({ query: createdAtQuery });
+  using createdAtStream = new ObservableStream(createdAtObservable);
+
+  await expect(createdAtStream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(createdAtStream).toEmitTypedValue({
+    data: { post: { __typename: "Post", createdAt: new Date(2026, 0, 1) } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  const updatedAtObservable = client.watchQuery({ query: updatedAtQuery });
+  using updatedAtStream = new ObservableStream(updatedAtObservable);
+
+  await expect(updatedAtStream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(updatedAtStream).toEmitTypedValue({
+    data: { post: { __typename: "Post", updatedAt: new Date(2026, 1, 2) } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(client.extract()).toStrictEqualTyped({
+    ROOT_QUERY: {
+      __typename: "Query",
+      post: { __typename: "Post", updatedAt: "2026-02-02" },
+    },
+  });
+
+  await expect(createdAtStream).toEmitTypedValue({
+    data: { post: { __typename: "Post", createdAt: new Date(2026, 0, 1) } },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: false,
+  });
+  await expect(createdAtStream).toEmitTypedValue({
+    data: { post: { __typename: "Post", createdAt: new Date(2026, 0, 1) } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(client.cache.extract()).toStrictEqualTyped({
+    ROOT_QUERY: {
+      __typename: "Query",
+      post: { __typename: "Post", createdAt: "2026-01-01" },
+    },
+  });
+
+  await expect(updatedAtStream).toEmitTypedValue({
+    data: { post: { __typename: "Post", updatedAt: new Date(2026, 1, 2) } },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: false,
+  });
+  await expect(updatedAtStream).toEmitTypedValue({
+    data: { post: { __typename: "Post", updatedAt: new Date(2026, 1, 2) } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(client.cache.extract()).toStrictEqualTyped({
+    ROOT_QUERY: {
+      __typename: "Query",
+      post: { __typename: "Post", updatedAt: "2026-02-02" },
+    },
+  });
+
+  await expect(createdAtStream).not.toEmitAnything();
+  await expect(updatedAtStream).not.toEmitAnything();
+
+  expect(createdAtObservable.getCurrentResult()).toStrictEqualTyped({
+    data: { post: { __typename: "Post", createdAt: new Date(2026, 0, 1) } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  expect(updatedAtObservable.getCurrentResult()).toStrictEqualTyped({
+    data: { post: { __typename: "Post", updatedAt: new Date(2026, 1, 2) } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+});
+
+test("parses custom scalar fields when feud-stopping skips refetches with overlapping fields", async () => {
+  const updatedAtQuery = gql`
+    query UpdatedAtQuery {
+      post {
+        createdAt
+        updatedAt
+      }
+    }
+  `;
+
+  const publishedAtQuery = gql`
+    query PublishedAtQuery {
+      post {
+        createdAt
+        publishedAt
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache({
+      scalars: { Date: dateScalar },
+      typePolicies: {
+        Query: {
+          fields: {
+            post: {
+              merge: false,
+            },
+          },
+        },
+        Post: {
+          fields: {
+            createdAt: { scalar: "Date" },
+            updatedAt: { scalar: "Date" },
+            publishedAt: { scalar: "Date" },
+          },
+        },
+      },
+    }),
+    link: new MockLink([
+      {
+        request: { query: updatedAtQuery },
+        result: {
+          data: {
+            post: {
+              __typename: "Post",
+              createdAt: "2026-01-01",
+              updatedAt: "2026-02-02",
+            },
+          },
+        },
+        delay: 20,
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+      {
+        request: { query: publishedAtQuery },
+        result: {
+          data: {
+            post: {
+              __typename: "Post",
+              createdAt: "2026-01-01",
+              publishedAt: "2026-03-03",
+            },
+          },
+        },
+        delay: 20,
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ]),
+  });
+
+  const updatedAtObservable = client.watchQuery({ query: updatedAtQuery });
+  using updatedAtStream = new ObservableStream(updatedAtObservable);
+
+  await expect(updatedAtStream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(updatedAtStream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        createdAt: new Date(2026, 0, 1),
+        updatedAt: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  const publishedAtObservable = client.watchQuery({ query: publishedAtQuery });
+  using publishedAtStream = new ObservableStream(publishedAtObservable);
+
+  await expect(publishedAtStream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+  await expect(publishedAtStream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        createdAt: new Date(2026, 0, 1),
+        publishedAt: new Date(2026, 2, 3),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(client.cache.extract()).toStrictEqualTyped({
+    ROOT_QUERY: {
+      __typename: "Query",
+      post: {
+        __typename: "Post",
+        createdAt: "2026-01-01",
+        publishedAt: "2026-03-03",
+      },
+    },
+  });
+
+  await expect(updatedAtStream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        createdAt: new Date(2026, 0, 1),
+        updatedAt: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: false,
+  });
+  await expect(updatedAtStream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        createdAt: new Date(2026, 0, 1),
+        updatedAt: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(client.cache.extract()).toStrictEqualTyped({
+    ROOT_QUERY: {
+      __typename: "Query",
+      post: {
+        __typename: "Post",
+        createdAt: "2026-01-01",
+        updatedAt: "2026-02-02",
+      },
+    },
+  });
+
+  await expect(publishedAtStream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        createdAt: new Date(2026, 0, 1),
+        publishedAt: new Date(2026, 2, 3),
+      },
+    },
+    dataState: "complete",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: false,
+  });
+  await expect(publishedAtStream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        createdAt: new Date(2026, 0, 1),
+        publishedAt: new Date(2026, 2, 3),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(client.cache.extract()).toStrictEqualTyped({
+    ROOT_QUERY: {
+      __typename: "Query",
+      post: {
+        __typename: "Post",
+        createdAt: "2026-01-01",
+        publishedAt: "2026-03-03",
+      },
+    },
+  });
+
+  await expect(updatedAtStream).not.toEmitAnything();
+  await expect(publishedAtStream).not.toEmitAnything();
+
+  expect(updatedAtObservable.getCurrentResult()).toStrictEqualTyped({
+    data: {
+      post: {
+        __typename: "Post",
+        createdAt: new Date(2026, 0, 1),
+        updatedAt: new Date(2026, 1, 2),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+  expect(publishedAtObservable.getCurrentResult()).toStrictEqualTyped({
+    data: {
+      post: {
+        __typename: "Post",
+        createdAt: new Date(2026, 0, 1),
+        publishedAt: new Date(2026, 2, 3),
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
 });

--- a/src/core/__tests__/client.watchQuery/customScalars.test.ts
+++ b/src/core/__tests__/client.watchQuery/customScalars.test.ts
@@ -2095,7 +2095,7 @@ test("parses custom scalar fields when feud-stopping skips refetches", async () 
     partial: false,
   });
 
-  expect(client.cache.extract()).toStrictEqualTyped({
+  expect(client.extract()).toStrictEqualTyped({
     ROOT_QUERY: {
       __typename: "Query",
       post: { __typename: "Post", createdAt: "2026-01-01" },
@@ -2117,7 +2117,7 @@ test("parses custom scalar fields when feud-stopping skips refetches", async () 
     partial: false,
   });
 
-  expect(client.cache.extract()).toStrictEqualTyped({
+  expect(client.extract()).toStrictEqualTyped({
     ROOT_QUERY: {
       __typename: "Query",
       post: { __typename: "Post", updatedAt: "2026-02-02" },
@@ -2264,7 +2264,7 @@ test("parses custom scalar fields when feud-stopping skips refetches with overla
     partial: false,
   });
 
-  expect(client.cache.extract()).toStrictEqualTyped({
+  expect(client.extract()).toStrictEqualTyped({
     ROOT_QUERY: {
       __typename: "Query",
       post: {
@@ -2302,7 +2302,7 @@ test("parses custom scalar fields when feud-stopping skips refetches with overla
     partial: false,
   });
 
-  expect(client.cache.extract()).toStrictEqualTyped({
+  expect(client.extract()).toStrictEqualTyped({
     ROOT_QUERY: {
       __typename: "Query",
       post: {
@@ -2340,7 +2340,7 @@ test("parses custom scalar fields when feud-stopping skips refetches with overla
     partial: false,
   });
 
-  expect(client.cache.extract()).toStrictEqualTyped({
+  expect(client.extract()).toStrictEqualTyped({
     ROOT_QUERY: {
       __typename: "Query",
       post: {

--- a/src/core/__tests__/client.watchQuery/defer20220824.test.ts
+++ b/src/core/__tests__/client.watchQuery/defer20220824.test.ts
@@ -535,16 +535,6 @@ test("delivers cache updates written while a deferred response is still streamin
     }),
     dataState: "streaming",
     loading: true,
-    networkStatus: NetworkStatus.loading,
-    partial: true,
-  });
-
-  await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
-      post: { __typename: "Post", id: "1", title: "title from write 1" },
-    }),
-    dataState: "streaming",
-    loading: true,
     networkStatus: NetworkStatus.streaming,
     partial: true,
   });
@@ -553,16 +543,6 @@ test("delivers cache updates written while a deferred response is still streamin
     fragment: titleFragment,
     from: { __typename: "Post", id: "1" },
     data: { __typename: "Post", id: "1", title: "title from write 2" },
-  });
-
-  await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
-      post: { __typename: "Post", id: "1", title: "title from write 2" },
-    }),
-    dataState: "streaming",
-    loading: true,
-    networkStatus: NetworkStatus.loading,
-    partial: true,
   });
 
   await expect(stream).toEmitTypedValue({

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10492,21 +10492,11 @@ test("keeps dataState streaming for an optimistic cache write while a deferred r
     }),
     dataState: "streaming",
     loading: true,
-    networkStatus: NetworkStatus.loading,
+    networkStatus: NetworkStatus.streaming,
     partial: true,
   });
 
   client.cache.removeOptimistic("optimistic");
-
-  await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
-      post: { __typename: "Post", id: "1", title: "title from server" },
-    }),
-    dataState: "streaming",
-    loading: true,
-    networkStatus: NetworkStatus.loading,
-    partial: true,
-  });
 
   await expect(stream).toEmitTypedValue({
     data: markAsStreaming({
@@ -10617,7 +10607,7 @@ test("delivers an optimistic cache write while a deferred response is still stre
     }),
     dataState: "streaming",
     loading: true,
-    networkStatus: NetworkStatus.loading,
+    networkStatus: NetworkStatus.streaming,
     partial: true,
   });
 

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10731,16 +10731,6 @@ test("delivers cache updates written while a deferred response is still streamin
     }),
     dataState: "streaming",
     loading: true,
-    networkStatus: NetworkStatus.loading,
-    partial: true,
-  });
-
-  await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
-      post: { __typename: "Post", id: "1", title: "title from write 1" },
-    }),
-    dataState: "streaming",
-    loading: true,
     networkStatus: NetworkStatus.streaming,
     partial: true,
   });
@@ -10749,16 +10739,6 @@ test("delivers cache updates written while a deferred response is still streamin
     fragment: titleFragment,
     from: { __typename: "Post", id: "1" },
     data: { __typename: "Post", id: "1", title: "title from write 2" },
-  });
-
-  await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
-      post: { __typename: "Post", id: "1", title: "title from write 2" },
-    }),
-    dataState: "streaming",
-    loading: true,
-    networkStatus: NetworkStatus.loading,
-    partial: true,
   });
 
   await expect(stream).toEmitTypedValue({

--- a/src/core/__tests__/incompleteCacheReadWarning.test.ts
+++ b/src/core/__tests__/incompleteCacheReadWarning.test.ts
@@ -389,7 +389,7 @@ test("does not warn while a deferred result is still streaming", async () => {
   expect(console.warn).not.toHaveBeenCalled();
 });
 
-test("does not warn again when the cache write is skipped because the identical result was already written", async () => {
+test("warns again when a refetched network result reads back from the cache as partial", async () => {
   using _ = spyOnConsole("warn");
 
   const query = gql`
@@ -453,7 +453,7 @@ test("does not warn again when the cache write is skipped because the identical 
   // result
   await stream.takeNext();
 
-  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledTimes(2);
 });
 
 // https://github.com/apollographql/apollo-client/issues/9293


### PR DESCRIPTION
Fixes #13394
Fixes #7028
Fixes #11879

Changes the feud stopping logic so that transformed values from `read` functions or custom scalars are applied to the network request. Rather than avoiding cache writes when the network request is the same, we instead record the last incomplete result 

This comes at the cost of an additional network request, but ensures data correctness.

This PR also adds a new warning when feuds are detected to make it easier to determine when it happens and do something about it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved handling of conflicting, non-normalized query data in the cache.
* Ensured network results apply custom scalar parsing and field read functions before delivery.
* Prevented repeated automatic refetch loops for recurring incomplete results.
* Improved cache updates, optimistic rollback, partial results, and error handling.
* Added development warnings with guidance when conflicting query data overwrites cache values.

## Improvements

* Improved streaming status reporting for deferred query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->