### PR TITLE
Ensure accurate `dataState` with `@defer` only missing fields on initial emit with `returnPartialData: true`

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -933,7 +933,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     // @internal @deprecated (undocumented)
     getCacheDiff({ optimistic }?: {
         optimistic?: boolean | undefined;
-    }): Cache_2.DiffResult<TData>;
+    }): Cache_2.InternalDiffResultWithDataState<TData>;
     // (undocumented)
     getCurrentResult(): ObservableQuery.Result<MaybeMasked<TData>>;
     // (undocumented)
@@ -1407,7 +1407,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 // Warnings were encountered during analysis:
 //
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:376:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:378:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -7,6 +7,7 @@
 import type { ApolloCache } from '@apollo/client';
 import type { ApolloClient } from '@apollo/client';
 import type { ASTNode } from 'graphql';
+import type { Cache as Cache_2 } from '@apollo/client/cache';
 import type { DataValue } from '@apollo/client';
 import type { DirectiveNode } from 'graphql';
 import type { DocumentNode } from 'graphql';
@@ -569,6 +570,9 @@ export type StreamInfoTrie = Trie<{
 
 // @internal @deprecated (undocumented)
 export function stringifyForDisplay(value: any, space?: number): string;
+
+// @public (undocumented)
+export function toDiffWithDataState<TData>(diff: Cache_2.DiffResult<TData> | Cache_2.InternalDiffResultWithDataState<TData>): Cache_2.InternalDiffResultWithDataState<TData>;
 
 // @internal @deprecated (undocumented)
 export function toQueryResult<TData = unknown>(value: ObservableQuery.Result<TData>): {

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -571,7 +571,7 @@ export type StreamInfoTrie = Trie<{
 // @internal @deprecated (undocumented)
 export function stringifyForDisplay(value: any, space?: number): string;
 
-// @public (undocumented)
+// @internal @deprecated (undocumented)
 export function toDiffWithDataState<TData>(diff: Cache_2.DiffResult<TData> | Cache_2.InternalDiffResultWithDataState<TData>): Cache_2.InternalDiffResultWithDataState<TData>;
 
 // @internal @deprecated (undocumented)

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2397,7 +2397,7 @@ export class ObservableQuery<TData = unknown, TVariables extends OperationVariab
     // @internal @deprecated (undocumented)
     getCacheDiff({ optimistic }?: {
         optimistic?: boolean | undefined;
-    }): Cache_2.DiffResult<TData>;
+    }): Cache_2.InternalDiffResultWithDataState<TData>;
     // (undocumented)
     getCurrentResult(): ObservableQuery.Result<MaybeMasked<TData>>;
     // (undocumented)
@@ -3319,7 +3319,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/types.ts:162:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
-// src/core/ObservableQuery.ts:376:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
+// src/core/ObservableQuery.ts:378:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:196:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:202:7 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/beige-colts-flow.md
+++ b/.changeset/beige-colts-flow.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix `dataState` to report `"streaming"` instead of `"partial"` when `returnPartialData` is `true` and the cache result is missing only `@defer` fields.

--- a/src/__tests__/__snapshots__/exports.ts.snap
+++ b/src/__tests__/__snapshots__/exports.ts.snap
@@ -504,6 +504,7 @@ Array [
   "storeKeyNameFromField",
   "streamInfoSymbol",
   "stringifyForDisplay",
+  "toDiffWithDataState",
   "toQueryResult",
   "variablesUnknownSymbol",
 ]

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -1383,6 +1383,58 @@ describe("Force local resolvers", () => {
 
     expect(isLoggedInCount).toBe(2);
   });
+
+  test("reports dataState partial when a forced resolver fills an empty cache result with returnPartialData", async () => {
+    const query = gql`
+      query {
+        greeting {
+          message
+        }
+        isLoggedIn @client(always: true)
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: ApolloLink.empty(),
+      localState: new LocalState({
+        resolvers: {
+          Query: {
+            isLoggedIn: () => true,
+          },
+        },
+      }),
+    });
+
+    const stream = new ObservableStream(
+      client.watchQuery({
+        query,
+        fetchPolicy: "cache-only",
+        returnPartialData: true,
+      })
+    );
+
+    // Forced resolvers run asynchronously, so the first emit is the empty
+    // loading state. The next emit must stay "partial": the cache diff is
+    // empty, but the resolver added a field.
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: { isLoggedIn: true },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    await expect(stream).not.toEmitAnything();
+  });
 });
 
 describe("Async resolvers", () => {

--- a/src/__tests__/local-state/resolvers.ts
+++ b/src/__tests__/local-state/resolvers.ts
@@ -1435,6 +1435,65 @@ describe("Force local resolvers", () => {
 
     await expect(stream).not.toEmitAnything();
   });
+
+  test("reports dataState when a forced client field is unresolved and server fields are complete", async () => {
+    const query = gql`
+      query {
+        greeting {
+          message
+        }
+        isLoggedIn @client(always: true)
+      }
+    `;
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: gql`
+        query {
+          greeting {
+            message
+          }
+        }
+      `,
+      data: {
+        greeting: { __typename: "Greeting", message: "Hello" },
+      },
+    });
+
+    const client = new ApolloClient({
+      cache,
+      link: ApolloLink.empty(),
+      localState: new LocalState(),
+    });
+
+    const stream = new ObservableStream(
+      client.watchQuery({
+        query,
+        fetchPolicy: "cache-only",
+        returnPartialData: true,
+      })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: {
+        greeting: { __typename: "Greeting", message: "Hello" },
+      },
+      dataState: "partial",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
+    });
+
+    await expect(stream).not.toEmitAnything();
+  });
 });
 
 describe("Async resolvers", () => {

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1819,10 +1819,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           kind: "N",
           value: {
             data: diff.result,
-            dataState:
-              diff.complete ? "complete"
-              : diff.result ? "partial"
-              : "empty",
+            dataState: diff.dataState,
             networkStatus: NetworkStatus.ready,
             loading: false,
             error: undefined,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -27,7 +27,9 @@ import {
   getOperationDefinition,
   getOperationName,
   getQueryDefinition,
+  handleIncrementalSymbol,
   preventUnhandledRejection,
+  toDiffWithDataState,
   toQueryResult,
   variablesUnknownSymbol,
 } from "@apollo/client/utilities/internal";
@@ -579,12 +581,15 @@ export class ObservableQuery<
    * @internal
    */
   public getCacheDiff({ optimistic = true } = {}) {
-    return this.cache.diff<TData>({
-      query: this.query,
-      variables: this.variables,
-      returnPartialData: true,
-      optimistic,
-    });
+    return toDiffWithDataState(
+      this.cache.diff<TData>({
+        query: this.query,
+        variables: this.variables,
+        returnPartialData: true,
+        optimistic,
+        [handleIncrementalSymbol]: undefined,
+      })
+    );
   }
 
   private getInitialResult(
@@ -600,6 +605,7 @@ export class ObservableQuery<
 
     const cacheResult = (): ObservableQuery.Result<TData> => {
       const diff = this.getCacheDiff();
+      let { dataState } = diff;
       // TODO: queryInfo.getDiff should handle this since cache.diff returns a
       // null when returnPartialData is false
       const data =
@@ -607,12 +613,13 @@ export class ObservableQuery<
           (diff.result as TData) ?? undefined
         : undefined;
 
+      if (data === undefined) {
+        dataState = "empty";
+      }
+
       return this.maskResult({
         data,
-        dataState:
-          diff.complete ? "complete"
-          : data === undefined ? "empty"
-          : "partial",
+        dataState,
         loading: !diff.complete,
         networkStatus:
           diff.complete ? NetworkStatus.ready : NetworkStatus.loading,

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1998,7 +1998,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       result = notification.value;
       if (
         result.networkStatus === NetworkStatus.ready &&
-        result.partial &&
+        result.dataState === "partial" &&
         (!this.options.returnPartialData ||
           previous.result.networkStatus === NetworkStatus.error) &&
         this.options.fetchPolicy !== "cache-only"

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -19,6 +19,7 @@ import {
   graphQLResultHasError,
   handleIncrementalSymbol,
   hasDirectives,
+  toDiffWithDataState,
 } from "@apollo/client/utilities/internal";
 import { invariant } from "@apollo/client/utilities/invariant";
 
@@ -467,23 +468,13 @@ export class QueryInfo<
   getDiff(
     options: Cache.DiffOptions<TData>,
     incrementalInfo?: DiffIncrementalInfo
-  ): Cache.InternalDiffResultWithDataState<TData> {
-    const diff = this.cache.diff({
-      ...options,
-      [handleIncrementalSymbol]: incrementalInfo,
-    });
-
-    if ("dataState" in diff) {
-      return diff;
-    }
-
-    return {
-      ...diff,
-      dataState:
-        diff.complete ? "complete"
-        : diff.result === null ? "empty"
-        : "partial",
-    } as Cache.InternalDiffResultWithDataState<TData>;
+  ) {
+    return toDiffWithDataState(
+      this.cache.diff({
+        ...options,
+        [handleIncrementalSymbol]: incrementalInfo,
+      })
+    );
   }
 
   public markMutationResult(

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -464,7 +464,7 @@ export class QueryInfo<
     return incrementalInfo;
   }
 
-  private getDiff(
+  getDiff(
     options: Cache.DiffOptions<TData>,
     incrementalInfo?: DiffIncrementalInfo
   ): Cache.InternalDiffResultWithDataState<TData> {

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -57,7 +57,6 @@ import {
   getOperationDefinition,
   getOperationName,
   graphQLResultHasError,
-  handleIncrementalSymbol,
   hasDirectives,
   hasForcedResolvers,
   isDocumentNode,
@@ -1583,25 +1582,12 @@ export class QueryManager {
     }
   ): ObservableAndInfo<TData> {
     const readCache = () => {
-      const diff = this.cache.diff<any>({
+      return queryInfo.getDiff({
         query,
         variables,
         returnPartialData: true,
         optimistic: true,
-        [handleIncrementalSymbol]: undefined,
       });
-
-      if ("dataState" in diff) {
-        return diff;
-      }
-
-      return {
-        ...diff,
-        dataState:
-          diff.complete ? "complete"
-          : diff.result === null ? "empty"
-          : "partial",
-      } as Cache.InternalDiffResultWithDataState<TData>;
     };
 
     const resultsFromCache = (

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -57,6 +57,7 @@ import {
   getOperationDefinition,
   getOperationName,
   graphQLResultHasError,
+  handleIncrementalSymbol,
   hasDirectives,
   hasForcedResolvers,
   isDocumentNode,
@@ -1581,16 +1582,30 @@ export class QueryManager {
       exposeExtensions?: boolean;
     }
   ): ObservableAndInfo<TData> {
-    const readCache = () =>
-      this.cache.diff<any>({
+    const readCache = () => {
+      const diff = this.cache.diff<any>({
         query,
         variables,
         returnPartialData: true,
         optimistic: true,
+        [handleIncrementalSymbol]: undefined,
       });
 
+      if ("dataState" in diff) {
+        return diff;
+      }
+
+      return {
+        ...diff,
+        dataState:
+          diff.complete ? "complete"
+          : diff.result === null ? "empty"
+          : "partial",
+      } as Cache.InternalDiffResultWithDataState<TData>;
+    };
+
     const resultsFromCache = (
-      diff: Cache.DiffResult<TData>,
+      diff: Cache.InternalDiffResultWithDataState<TData>,
       networkStatus: NetworkStatus
     ): Observable<QueryNotification.FromCache<TData>> => {
       const data = diff.result;
@@ -1600,7 +1615,8 @@ export class QueryManager {
       }
 
       const toResult = (
-        data: TData | DeepPartial<TData> | undefined
+        data: TData | DeepPartial<TData> | undefined,
+        dataState = diff.dataState
       ): ObservableQuery.Result<TData> => {
         // TODO: Eventually we should move this handling into
         // queryInfo.getDiff() directly. Since getDiff is updated to return null
@@ -1608,15 +1624,13 @@ export class QueryManager {
         // of having to patch it elsewhere.
         if (!diff.complete && !returnPartialData) {
           data = undefined;
+          dataState = "empty";
         }
 
         return {
           // TODO: Handle partial data
           data: data as TData | undefined,
-          dataState:
-            diff.complete ? "complete"
-            : data ? "partial"
-            : "empty",
+          dataState,
           loading: isNetworkRequestInFlight(networkStatus),
           networkStatus,
           partial: !diff.complete,
@@ -1666,7 +1680,12 @@ export class QueryManager {
           }).then(
             (resolved): QueryNotification.FromCache<TData> => ({
               kind: "N",
-              value: toResult(resolved.data || void 0),
+              value: toResult(
+                resolved.data || void 0,
+                diff.complete ? "complete"
+                : resolved.data ? "partial"
+                : "empty"
+              ),
               // Always attach the variables used for this fetch so @export
               // resolution can update ObservableQuery.options.variables and
               // resubscribe the cache watch under the correct variable set.

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1653,26 +1653,6 @@ export class QueryManager {
         }
         onCacheHit();
 
-        // Get the dataState from the cache without `@client(always: true)`
-        // fields applied since cache.diff doesn't know how those fields will be
-        // resolved. Local state is always guaranteed to return a "complete"
-        // result for all `@client` fields since it backfills nulls where
-        // appropriate, so local state can only change the dataState one way
-        // when the network cache diff is empty and we return a field from local
-        // state making the result partial, otherwise we keep the network
-        // dataState.
-        const { serverQuery } = this.getDocumentInfo(query);
-        let dataState = diff.dataState;
-
-        if (serverQuery) {
-          dataState = queryInfo.getDiff({
-            query: serverQuery,
-            variables,
-            returnPartialData: true,
-            optimistic: true,
-          }).dataState;
-        }
-
         return from(
           this.localState!.execute<TData>({
             client: this.client,
@@ -1688,7 +1668,9 @@ export class QueryManager {
               kind: "N",
               value: toResult(
                 resolved.data || void 0,
-                dataState === "empty" && resolved.data ? "partial" : dataState
+                diff.complete ? "complete"
+                : resolved.data ? "partial"
+                : "empty"
               ),
               // Always attach the variables used for this fetch so @export
               // resolution can update ObservableQuery.options.variables and

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -1653,6 +1653,26 @@ export class QueryManager {
         }
         onCacheHit();
 
+        // Get the dataState from the cache without `@client(always: true)`
+        // fields applied since cache.diff doesn't know how those fields will be
+        // resolved. Local state is always guaranteed to return a "complete"
+        // result for all `@client` fields since it backfills nulls where
+        // appropriate, so local state can only change the dataState one way
+        // when the network cache diff is empty and we return a field from local
+        // state making the result partial, otherwise we keep the network
+        // dataState.
+        const { serverQuery } = this.getDocumentInfo(query);
+        let dataState = diff.dataState;
+
+        if (serverQuery) {
+          dataState = queryInfo.getDiff({
+            query: serverQuery,
+            variables,
+            returnPartialData: true,
+            optimistic: true,
+          }).dataState;
+        }
+
         return from(
           this.localState!.execute<TData>({
             client: this.client,
@@ -1668,9 +1688,7 @@ export class QueryManager {
               kind: "N",
               value: toResult(
                 resolved.data || void 0,
-                diff.complete ? "complete"
-                : resolved.data ? "partial"
-                : "empty"
+                dataState === "empty" && resolved.data ? "partial" : dataState
               ),
               // Always attach the variables used for this fetch so @export
               // resolution can update ObservableQuery.options.variables and

--- a/src/core/__tests__/client.watchQuery/defer20220824.test.ts
+++ b/src/core/__tests__/client.watchQuery/defer20220824.test.ts
@@ -462,7 +462,7 @@ test("delivers cache updates written while a deferred response is still streamin
   expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
 });
 
-test.only("delivers cache updates written while a deferred response is still streaming with `returnPartialData: true`", async () => {
+test("delivers cache updates written while a deferred response is still streaming with `returnPartialData: true`", async () => {
   const query = gql`
     query PostQuery {
       post {
@@ -523,9 +523,6 @@ test.only("delivers cache updates written while a deferred response is still str
     partial: true,
   });
 
-  // `returnPartialData` means the partial cache result delivered by
-  // `reobserveCacheFirst` reaches the subscriber, so each write arrives twice:
-  // once as the partial cache read, then again as the streaming result.
   client.writeFragment({
     fragment: titleFragment,
     from: { __typename: "Post", id: "1" },
@@ -533,10 +530,10 @@ test.only("delivers cache updates written while a deferred response is still str
   });
 
   await expect(stream).toEmitTypedValue({
-    data: {
+    data: markAsStreaming({
       post: { __typename: "Post", id: "1", title: "title from write 1" },
-    },
-    dataState: "partial",
+    }),
+    dataState: "streaming",
     loading: true,
     networkStatus: NetworkStatus.loading,
     partial: true,
@@ -559,10 +556,10 @@ test.only("delivers cache updates written while a deferred response is still str
   });
 
   await expect(stream).toEmitTypedValue({
-    data: {
+    data: markAsStreaming({
       post: { __typename: "Post", id: "1", title: "title from write 2" },
-    },
-    dataState: "partial",
+    }),
+    dataState: "streaming",
     loading: true,
     networkStatus: NetworkStatus.loading,
     partial: true,

--- a/src/core/__tests__/client.watchQuery/defer20220824.test.ts
+++ b/src/core/__tests__/client.watchQuery/defer20220824.test.ts
@@ -348,3 +348,256 @@ it.each([["cache-first"], ["no-cache"]] as const)(
     await expect(stream).not.toEmitAnything();
   }
 );
+
+test("delivers cache updates written while a deferred response is still streaming", async () => {
+  const query = gql`
+    query PostQuery {
+      post {
+        id
+        title
+        ... @defer {
+          body
+        }
+      }
+    }
+  `;
+
+  const fragment = gql`
+    fragment PostTitle on Post {
+      title
+    }
+  `;
+
+  const outgoingRequestSpy = jest.fn(((operation, forward) =>
+    forward(operation)) satisfies ApolloLink.RequestHandler);
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: ApolloLink.from([new ApolloLink(outgoingRequestSpy), httpLink]),
+    incrementalHandler: new Defer20220824Handler(),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-and-network" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { post: { __typename: "Post", id: "1", title: "title from server" } },
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  client.writeFragment({
+    fragment,
+    from: { __typename: "Post", id: "1" },
+    data: { __typename: "Post", id: "1", title: "title from write 1" },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from write 1" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  client.writeFragment({
+    fragment,
+    from: { __typename: "Post", id: "1" },
+    data: { __typename: "Post", id: "1", title: "title from write 2" },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from write 2" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ data: { body: "body from server" }, path: ["post"] }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "1",
+        title: "title from write 2",
+        body: "body from server",
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+  expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
+});
+
+test.only("delivers cache updates written while a deferred response is still streaming with `returnPartialData: true`", async () => {
+  const query = gql`
+    query PostQuery {
+      post {
+        id
+        title
+        ... @defer {
+          body
+        }
+      }
+    }
+  `;
+
+  const titleFragment = gql`
+    fragment PostTitle on Post {
+      title
+    }
+  `;
+
+  const outgoingRequestSpy = jest.fn(((operation, forward) =>
+    forward(operation)) satisfies ApolloLink.RequestHandler);
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDefer20220824();
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: ApolloLink.from([new ApolloLink(outgoingRequestSpy), httpLink]),
+    incrementalHandler: new Defer20220824Handler(),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "cache-and-network",
+      returnPartialData: true,
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { post: { __typename: "Post", id: "1", title: "title from server" } },
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  // `returnPartialData` means the partial cache result delivered by
+  // `reobserveCacheFirst` reaches the subscriber, so each write arrives twice:
+  // once as the partial cache read, then again as the streaming result.
+  client.writeFragment({
+    fragment: titleFragment,
+    from: { __typename: "Post", id: "1" },
+    data: { __typename: "Post", id: "1", title: "title from write 1" },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: { __typename: "Post", id: "1", title: "title from write 1" },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from write 1" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  client.writeFragment({
+    fragment: titleFragment,
+    from: { __typename: "Post", id: "1" },
+    data: { __typename: "Post", id: "1", title: "title from write 2" },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: { __typename: "Post", id: "1", title: "title from write 2" },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from write 2" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ data: { body: "body from server" }, path: ["post"] }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "1",
+        title: "title from write 2",
+        body: "body from server",
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+  expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
+});

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10413,6 +10413,135 @@ test("delivers cache updates written while a deferred response is still streamin
   expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
 });
 
+test("keeps dataState streaming for an optimistic cache write while a deferred response is still streaming", async () => {
+  const query = gql`
+    query PostQuery {
+      post {
+        id
+        title
+        ... @defer {
+          body
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "cache-and-network",
+      returnPartialData: true,
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { post: { __typename: "Post", id: "1", title: "title from server" } },
+    pending: [{ id: "0", path: ["post"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  {
+    using _consoleSpy = spyOnConsole("error");
+    client.cache.recordOptimisticTransaction((cache) => {
+      cache.writeQuery({
+        query,
+        data: {
+          post: {
+            __typename: "Post",
+            id: "1",
+            title: "title from optimistic write",
+          },
+        },
+      });
+    }, "optimistic");
+  }
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: {
+        __typename: "Post",
+        id: "1",
+        title: "title from optimistic write",
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  client.cache.removeOptimistic("optimistic");
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ data: { body: "body from server" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "1",
+        title: "title from server",
+        body: "body from server",
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test("delivers cache updates written while a deferred response is still streaming with `returnPartialData: true`", async () => {
   const query = gql`
     query PostQuery {

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10542,6 +10542,121 @@ test("keeps dataState streaming for an optimistic cache write while a deferred r
   await expect(stream).not.toEmitAnything();
 });
 
+test("delivers an optimistic cache write while a deferred response is still streaming", async () => {
+  const query = gql`
+    query PostQuery {
+      post {
+        id
+        title
+        ... @defer {
+          body
+        }
+      }
+    }
+  `;
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: httpLink,
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-and-network" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { post: { __typename: "Post", id: "1", title: "title from server" } },
+    pending: [{ id: "0", path: ["post"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  {
+    using _consoleSpy = spyOnConsole("error");
+    client.cache.recordOptimisticTransaction((cache) => {
+      cache.writeQuery({
+        query,
+        data: {
+          post: {
+            __typename: "Post",
+            id: "1",
+            title: "title from optimistic write",
+          },
+        },
+      });
+    }, "optimistic");
+  }
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: {
+        __typename: "Post",
+        id: "1",
+        title: "title from optimistic write",
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  client.cache.removeOptimistic("optimistic");
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ data: { body: "body from server" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "1",
+        title: "title from server",
+        body: "body from server",
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});
+
 test("delivers cache updates written while a deferred response is still streaming with `returnPartialData: true`", async () => {
   const query = gql`
     query PostQuery {

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10495,3 +10495,81 @@ test("delivers cache updates written while a deferred response is still streamin
   await expect(stream).not.toEmitAnything();
   expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
 });
+
+test("reports dataState streaming when a forced resolver runs and the only holes are deferred fields with returnPartialData with a cache-only query", async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+      isLoggedIn @client(always: true)
+    }
+  `;
+
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _consoleSpy = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          message: "Cached hello",
+        },
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: ApolloLink.empty(),
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+    localState: new LocalState({
+      resolvers: {
+        Query: {
+          isLoggedIn: () => true,
+        },
+      },
+    }),
+  });
+
+  const stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "cache-only",
+      returnPartialData: true,
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      greeting: {
+        __typename: "Greeting",
+        message: "Cached hello",
+      },
+      isLoggedIn: true,
+    }),
+    dataState: "streaming",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: true,
+  });
+
+  await expect(stream).not.toEmitAnything();
+});

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -1534,13 +1534,13 @@ test('returns partial non-deferred cached data with a "cache-first" fetch policy
   );
 
   await expect(stream).toEmitTypedValue({
-    data: {
+    data: markAsStreaming({
       greeting: {
         __typename: "Greeting",
         message: "Cached hello",
       },
-    },
-    dataState: "partial",
+    }),
+    dataState: "streaming",
     loading: true,
     networkStatus: NetworkStatus.loading,
     partial: true,
@@ -9778,13 +9778,13 @@ test("applies field read functions to partial non-deferred cached data before an
   );
 
   await expect(stream).toEmitTypedValue({
-    data: {
+    data: markAsStreaming({
       greeting: {
         __typename: "Greeting",
         message: "CACHED HELLO",
       },
-    },
-    dataState: "partial",
+    }),
+    dataState: "streaming",
     loading: true,
     networkStatus: NetworkStatus.loading,
     partial: true,
@@ -10419,9 +10419,6 @@ test("delivers cache updates written while a deferred response is still streamin
     partial: true,
   });
 
-  // `returnPartialData` means the partial cache result delivered by
-  // `reobserveCacheFirst` reaches the subscriber, so each write arrives twice:
-  // once as the partial cache read, then again as the streaming result.
   client.writeFragment({
     fragment: titleFragment,
     from: { __typename: "Post", id: "1" },
@@ -10429,10 +10426,10 @@ test("delivers cache updates written while a deferred response is still streamin
   });
 
   await expect(stream).toEmitTypedValue({
-    data: {
+    data: markAsStreaming({
       post: { __typename: "Post", id: "1", title: "title from write 1" },
-    },
-    dataState: "partial",
+    }),
+    dataState: "streaming",
     loading: true,
     networkStatus: NetworkStatus.loading,
     partial: true,
@@ -10455,10 +10452,10 @@ test("delivers cache updates written while a deferred response is still streamin
   });
 
   await expect(stream).toEmitTypedValue({
-    data: {
+    data: markAsStreaming({
       post: { __typename: "Post", id: "1", title: "title from write 2" },
-    },
-    dataState: "partial",
+    }),
+    dataState: "streaming",
     loading: true,
     networkStatus: NetworkStatus.loading,
     partial: true,

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10237,3 +10237,264 @@ test("applies field read functions when complete cache data inside a defer bound
 
   await expect(stream).not.toEmitAnything();
 });
+
+test("delivers cache updates written while a deferred response is still streaming", async () => {
+  const query = gql`
+    query PostQuery {
+      post {
+        id
+        title
+        ... @defer {
+          body
+        }
+      }
+    }
+  `;
+
+  const titleFragment = gql`
+    fragment PostTitle on Post {
+      title
+    }
+  `;
+
+  const outgoingRequestSpy = jest.fn(((operation, forward) =>
+    forward(operation)) satisfies ApolloLink.RequestHandler);
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new ApolloLink(outgoingRequestSpy).concat(httpLink),
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({ query, fetchPolicy: "cache-and-network" })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { post: { __typename: "Post", id: "1", title: "title from server" } },
+    pending: [{ id: "0", path: ["post"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  // A cache write that lands while the stream is open needs to be delivered.
+  // The query must not fall back to the value the server sent, and must not go
+  // back to the network for data that is already on its way.
+  client.writeFragment({
+    fragment: titleFragment,
+    from: { __typename: "Post", id: "1" },
+    data: { __typename: "Post", id: "1", title: "title from write 1" },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from write 1" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  client.writeFragment({
+    fragment: titleFragment,
+    from: { __typename: "Post", id: "1" },
+    data: { __typename: "Post", id: "1", title: "title from write 2" },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from write 2" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ data: { body: "body from server" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  // The deferred payload fills in `body` without undoing either cache write.
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "1",
+        title: "title from write 2",
+        body: "body from server",
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+  expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
+});
+
+test("delivers cache updates written while a deferred response is still streaming with `returnPartialData: true`", async () => {
+  const query = gql`
+    query PostQuery {
+      post {
+        id
+        title
+        ... @defer {
+          body
+        }
+      }
+    }
+  `;
+
+  const titleFragment = gql`
+    fragment PostTitle on Post {
+      title
+    }
+  `;
+
+  const outgoingRequestSpy = jest.fn(((operation, forward) =>
+    forward(operation)) satisfies ApolloLink.RequestHandler);
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new ApolloLink(outgoingRequestSpy).concat(httpLink),
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  using stream = new ObservableStream(
+    client.watchQuery({
+      query,
+      fetchPolicy: "cache-and-network",
+      returnPartialData: true,
+    })
+  );
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  enqueueInitialChunk({
+    data: { post: { __typename: "Post", id: "1", title: "title from server" } },
+    pending: [{ id: "0", path: ["post"] }],
+    hasNext: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from server" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  // `returnPartialData` means the partial cache result delivered by
+  // `reobserveCacheFirst` reaches the subscriber, so each write arrives twice:
+  // once as the partial cache read, then again as the streaming result.
+  client.writeFragment({
+    fragment: titleFragment,
+    from: { __typename: "Post", id: "1" },
+    data: { __typename: "Post", id: "1", title: "title from write 1" },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: { __typename: "Post", id: "1", title: "title from write 1" },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from write 1" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  client.writeFragment({
+    fragment: titleFragment,
+    from: { __typename: "Post", id: "1" },
+    data: { __typename: "Post", id: "1", title: "title from write 2" },
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: { __typename: "Post", id: "1", title: "title from write 2" },
+    },
+    dataState: "partial",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: { __typename: "Post", id: "1", title: "title from write 2" },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  enqueueSubsequentChunk({
+    incremental: [{ data: { body: "body from server" }, id: "0" }],
+    completed: [{ id: "0" }],
+    hasNext: false,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "1",
+        title: "title from write 2",
+        body: "body from server",
+      },
+    },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  await expect(stream).not.toEmitAnything();
+  expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
+});

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10,6 +10,7 @@ import {
 import { InMemoryCache } from "@apollo/client/cache";
 import { GraphQL17Alpha9Handler } from "@apollo/client/incremental";
 import { ApolloLink } from "@apollo/client/link";
+import { LocalState } from "@apollo/client/local-state";
 import {
   executeSchemaGraphQL17Alpha9,
   friendListSchemaGraphQL17Alpha9,
@@ -1594,6 +1595,61 @@ test('returns partial non-deferred cached data with a "cache-first" fetch policy
   });
 
   await expect(stream).not.toEmitAnything();
+});
+
+test("reports dataState streaming from getCurrentResult when only deferred fields are missing with returnPartialData", async () => {
+  const query = gql`
+    query {
+      greeting {
+        message
+        ... on Greeting @defer {
+          recipient {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+  const cache = new InMemoryCache();
+
+  // We are intentionally writing partial data to the cache. Suppress console
+  // warnings to avoid unnecessary noise in the test.
+  {
+    using _consoleSpy = spyOnConsole("error");
+    cache.writeQuery({
+      query,
+      data: {
+        greeting: {
+          __typename: "Greeting",
+          message: "Cached hello",
+        },
+      },
+    });
+  }
+
+  const client = new ApolloClient({
+    cache,
+    link: ApolloLink.empty(),
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+
+  const observable = client.watchQuery({ query, returnPartialData: true });
+
+  // Called before subscribe so this goes through getInitialResult, not the
+  // fetchQueryByPolicy cache read.
+  expect(observable.getCurrentResult()).toStrictEqualTyped({
+    data: markAsStreaming({
+      greeting: {
+        __typename: "Greeting",
+        message: "Cached hello",
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
 });
 
 test('returns partial deferred cached data as "partial" while streaming with a "cache-first" fetch policy and returnPartialData', async () => {

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10796,80 +10796,94 @@ test("delivers cache updates written while a deferred response is still streamin
   expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
 });
 
-test("reports dataState streaming when a forced resolver runs and the only holes are deferred fields with returnPartialData with a cache-only query", async () => {
-  const query = gql`
-    query {
-      greeting {
-        message
-        ... on Greeting @defer {
-          recipient {
-            name
+// This results in an incorrect dataState reporting as "partial" instead of
+// "streaming" when the hole is just the defer fragment. To fix requires more
+// code than I think is worth at this point, especially because this is so niche
+// (requires @client(always: true) with `returnPartialData: true` and cache-only
+// fetch policy). To fix this would require us to analyze whether the missing
+// client fields in the cache were resolved by the local resolvers, and also
+// compare the dataState with a serverQuery dataState to see if the holes in the
+// query are just at @defer fragments. Thats a lot of work just to change
+// dataState for a combination of conditions that will almost never be used in
+// practice. This test serves as documentation that I've explored it and
+// determined the fix is not worth it.
+test.failing(
+  "reports dataState streaming when a forced resolver runs and the only holes are deferred fields with returnPartialData with a cache-only query",
+  async () => {
+    const query = gql`
+      query {
+        greeting {
+          message
+          ... on Greeting @defer {
+            recipient {
+              name
+            }
           }
         }
+        isLoggedIn @client(always: true)
       }
-      isLoggedIn @client(always: true)
+    `;
+
+    const cache = new InMemoryCache();
+
+    // We are intentionally writing partial data to the cache. Suppress console
+    // warnings to avoid unnecessary noise in the test.
+    {
+      using _consoleSpy = spyOnConsole("error");
+      cache.writeQuery({
+        query,
+        data: {
+          greeting: {
+            __typename: "Greeting",
+            message: "Cached hello",
+          },
+        },
+      });
     }
-  `;
 
-  const cache = new InMemoryCache();
+    const client = new ApolloClient({
+      cache,
+      link: ApolloLink.empty(),
+      incrementalHandler: new GraphQL17Alpha9Handler(),
+      localState: new LocalState({
+        resolvers: {
+          Query: {
+            isLoggedIn: () => true,
+          },
+        },
+      }),
+    });
 
-  // We are intentionally writing partial data to the cache. Suppress console
-  // warnings to avoid unnecessary noise in the test.
-  {
-    using _consoleSpy = spyOnConsole("error");
-    cache.writeQuery({
-      query,
-      data: {
+    const stream = new ObservableStream(
+      client.watchQuery({
+        query,
+        fetchPolicy: "cache-only",
+        returnPartialData: true,
+      })
+    );
+
+    await expect(stream).toEmitTypedValue({
+      data: undefined,
+      dataState: "empty",
+      loading: true,
+      networkStatus: NetworkStatus.loading,
+      partial: true,
+    });
+
+    await expect(stream).toEmitTypedValue({
+      data: markAsStreaming({
         greeting: {
           __typename: "Greeting",
           message: "Cached hello",
         },
-      },
+        isLoggedIn: true,
+      }),
+      dataState: "streaming",
+      loading: false,
+      networkStatus: NetworkStatus.ready,
+      partial: true,
     });
+
+    await expect(stream).not.toEmitAnything();
   }
-
-  const client = new ApolloClient({
-    cache,
-    link: ApolloLink.empty(),
-    incrementalHandler: new GraphQL17Alpha9Handler(),
-    localState: new LocalState({
-      resolvers: {
-        Query: {
-          isLoggedIn: () => true,
-        },
-      },
-    }),
-  });
-
-  const stream = new ObservableStream(
-    client.watchQuery({
-      query,
-      fetchPolicy: "cache-only",
-      returnPartialData: true,
-    })
-  );
-
-  await expect(stream).toEmitTypedValue({
-    data: undefined,
-    dataState: "empty",
-    loading: true,
-    networkStatus: NetworkStatus.loading,
-    partial: true,
-  });
-
-  await expect(stream).toEmitTypedValue({
-    data: markAsStreaming({
-      greeting: {
-        __typename: "Greeting",
-        message: "Cached hello",
-      },
-      isLoggedIn: true,
-    }),
-    dataState: "streaming",
-    loading: false,
-    networkStatus: NetworkStatus.ready,
-    partial: true,
-  });
-
-  await expect(stream).not.toEmitAnything();
-});
+);

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -77,6 +77,7 @@ export { shouldInclude } from "./shouldInclude.js";
 export { storeKeyNameFromField } from "./storeKeyNameFromField.js";
 export { StreamArrayState } from "./StreamArrayState.js";
 export { stringifyForDisplay } from "./stringifyForDisplay.js";
+export { toDiffWithDataState } from "./toDiffWithDataState.js";
 export { toQueryResult } from "./toQueryResult.js";
 export { filterMap } from "./filterMap.js";
 export { equalByQuery } from "./equalByQuery.js";

--- a/src/utilities/internal/toDiffWithDataState.ts
+++ b/src/utilities/internal/toDiffWithDataState.ts
@@ -1,5 +1,6 @@
 import type { Cache } from "@apollo/client/cache";
 
+/** @internal */
 export function toDiffWithDataState<TData>(
   diff: Cache.DiffResult<TData> | Cache.InternalDiffResultWithDataState<TData>
 ): Cache.InternalDiffResultWithDataState<TData> {

--- a/src/utilities/internal/toDiffWithDataState.ts
+++ b/src/utilities/internal/toDiffWithDataState.ts
@@ -1,0 +1,17 @@
+import type { Cache } from "@apollo/client/cache";
+
+export function toDiffWithDataState<TData>(
+  diff: Cache.DiffResult<TData> | Cache.InternalDiffResultWithDataState<TData>
+): Cache.InternalDiffResultWithDataState<TData> {
+  if ("dataState" in diff) {
+    return diff;
+  }
+
+  return {
+    ...diff,
+    dataState:
+      diff.complete ? "complete"
+      : diff.result === null ? "empty"
+      : "partial",
+  } as Cache.InternalDiffResultWithDataState<TData>;
+}


### PR DESCRIPTION
While working on an unrelated issue, I stumbled on this behavior that I thought should be fixed. We've done a lot in the 4.3 release to fix `dataState` for `@defer` queries where the only holes in the data are the `@defer` fragments themselves. We still had an issue however with the initial emit from `QueryManager` when `returnPartialData` was `true` where it reported that as `partial` instead of `streaming`. This is because the `cache.diff` run inside `QueryManager` did not set the `handleIncrementalSymbol`, so it was not able to get an accurate `dataState` from the cache. This, along with `getCurrentResult()` is now fixed to accurately report `streaming` when the only holes are at `@defer` boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query result classification when only deferred fields are missing: `dataState` now reports **“streaming”** instead of **“partial.”**
  * Improved handling of empty, partial, and complete results when cached data or local resolvers are involved.
  * Cache updates during deferred responses now appear correctly without triggering unnecessary refetches.

* **Tests**
  * Added coverage for deferred streaming, cache updates, partial data, and local resolver behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->