### PR TITLE
Add GraphQL Codegen incremental type overrides for `Partial`, `Streaming`, and `Complete`

### DIFF
--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -23,7 +23,7 @@ import { StreamInfoTrie } from '@apollo/client/utilities/internal';
 // Warning: (ae-forgotten-export) The symbol "ContainsNeverishFieldsInObject" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type ContainsNeverishFields<TData, Seen = never> = true extends (IsAny<TData>) ? false : true extends IsScalarType<TData> ? false : TData extends ReadonlyArray<infer TItem> ? true extends IsScalarType<TItem> ? false : ContainsNeverishFields<TItem, Seen> : keyof TData extends never ? TData : TData extends object ? string extends keyof TData ? false : [Seen] extends [never] ? ContainsNeverishFieldsInObject<TData, Exact<TData>> : Exact<TData> extends Seen ? false : ContainsNeverishFieldsInObject<TData, Seen | Exact<TData>> : false;
+type ContainsNeverishFields<TData, Seen = never> = true extends (IsAny<TData>) ? false : true extends IsScalarType<TData> ? false : TData extends ReadonlyArray<infer TItem> ? true extends IsScalarType<TItem> ? false : ContainsNeverishFields<TItem, Seen> : keyof TData extends never ? false : TData extends object ? string extends keyof TData ? false : [Seen] extends [never] ? ContainsNeverishFieldsInObject<TData, Exact<TData>> : Exact<TData> extends Seen ? false : ContainsNeverishFieldsInObject<TData, Seen | Exact<TData>> : false;
 
 // Warning: (ae-forgotten-export) The symbol "HasNeverishField" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ContainsNeverishFields" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -4,14 +4,37 @@
 
 ```ts
 
+import type { ApolloCache } from '@apollo/client/cache';
 import type { ApolloLink } from '@apollo/client/link';
 import type { DeepPartial } from '@apollo/client/utilities';
 import type { DocumentNode } from 'graphql';
 import { DocumentTransform } from '@apollo/client/utilities';
+import type { Exact } from '@apollo/client/utilities/internal';
 import type { FormattedExecutionResult } from 'graphql';
 import type { GraphQLFormattedError } from 'graphql';
 import type { HKT } from '@apollo/client/utilities';
+import type { IsAny } from '@apollo/client/utilities/internal';
+import type { IsNeverish } from '@apollo/client/utilities/internal';
+import type { Prettify } from '@apollo/client/utilities/internal';
+import type { Primitive } from '@apollo/client/utilities/internal';
 import { StreamInfoTrie } from '@apollo/client/utilities/internal';
+
+// Warning: (ae-forgotten-export) The symbol "IsScalarType" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsNeverishFieldsInObject" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ContainsNeverishFields<TData, Seen = never> = true extends (IsAny<TData>) ? false : true extends IsScalarType<TData> ? false : TData extends ReadonlyArray<infer TItem> ? true extends IsScalarType<TItem> ? false : ContainsNeverishFields<TItem, Seen> : keyof TData extends never ? TData : TData extends object ? string extends keyof TData ? false : [Seen] extends [never] ? ContainsNeverishFieldsInObject<TData, Exact<TData>> : Exact<TData> extends Seen ? false : ContainsNeverishFieldsInObject<TData, Seen | Exact<TData>> : false;
+
+// Warning: (ae-forgotten-export) The symbol "HasNeverishField" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainsNeverishFields" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ContainsNeverishFieldsInObject<TData, Seen> = HasNeverishField<TData> extends true ? true : ContainsNeverishFields<TData[keyof TData], Seen>;
+
+// @public (undocumented)
+type CustomScalarTypes = {
+    [K in keyof ApolloCache.Scalars]: ApolloCache.Scalars[K]["serialized"] | ApolloCache.Scalars[K]["parsed"];
+}[keyof ApolloCache.Scalars];
 
 // @public (undocumented)
 namespace Defer20220824Handler {
@@ -186,6 +209,52 @@ export class GraphQL17Alpha9Handler implements Incremental.Handler<GraphQL17Alph
 }
 
 // @public (undocumented)
+export namespace GraphQLCodegenIncremental {
+    // Warning: (ae-forgotten-export) The symbol "RemoveNeverishFields" needs to be exported by the entry point index.d.ts
+    export type Complete<TData> = TData extends any ? true extends IsAny<TData> ? TData : TData extends object ? true extends ContainsNeverishFields<TData> ? RemoveNeverishFields<TData> : TData : TData : never;
+    // (undocumented)
+    export namespace HKTImplementation {
+        // (undocumented)
+        export interface Complete extends HKT {
+            // (undocumented)
+            arg1: unknown;
+            // (undocumented)
+            return: GraphQLCodegenIncremental.Complete<this["arg1"]>;
+        }
+        // (undocumented)
+        export interface Partial extends HKT {
+            // (undocumented)
+            arg1: unknown;
+            // (undocumented)
+            return: GraphQLCodegenIncremental.Partial<this["arg1"]>;
+        }
+        // (undocumented)
+        export interface Streaming extends HKT {
+            // (undocumented)
+            arg1: unknown;
+            // (undocumented)
+            return: GraphQLCodegenIncremental.Streaming<this["arg1"]>;
+        }
+    }
+    export type Partial<TData> = DeepPartial<Complete<TData>>;
+    export type Streaming<TData> = TData;
+    // (undocumented)
+    export interface TypeOverrides {
+        // (undocumented)
+        Complete: HKTImplementation.Complete;
+        // (undocumented)
+        Partial: HKTImplementation.Partial;
+        // (undocumented)
+        Streaming: HKTImplementation.Streaming;
+    }
+}
+
+// @public (undocumented)
+type HasNeverishField<T> = true extends {
+    [K in keyof T]: IsNeverish<T[K]>;
+}[keyof T] ? true : false;
+
+// @public (undocumented)
 export namespace Incremental {
     // @internal @deprecated (undocumented)
     export interface Handler<Chunk extends Record<string, unknown> = Record<string, unknown>> {
@@ -278,6 +347,11 @@ class IncrementalRequest<TData> implements Incremental.IncrementalRequest<GraphQ
     get streamInfo(): StreamInfoTrie | undefined;
 }
 
+// Warning: (ae-forgotten-export) The symbol "ScalarType" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type IsScalarType<TData> = Exact<TData> extends Exact<Extract<ScalarType, TData>> ? true : false;
+
 // @public (undocumented)
 export namespace NotImplementedHandler {
     // (undocumented)
@@ -307,6 +381,16 @@ export class NotImplementedHandler implements Incremental.Handler<never> {
     // (undocumented)
     startRequest: any;
 }
+
+// @public (undocumented)
+type RemoveNeverishFields<TData> = true extends IsAny<TData> ? TData : true extends IsScalarType<TData> ? TData : TData extends Array<infer TItem> ? Array<RemoveNeverishFields<TItem>> : TData extends ReadonlyArray<infer TItem> ? ReadonlyArray<RemoveNeverishFields<TItem>> : string extends keyof TData ? TData : keyof TData extends never ? TData : TData extends object ? HasNeverishField<TData> extends true ? never : Prettify<{
+    [K in keyof TData]: RemoveNeverishFields<TData[K]>;
+}> : TData;
+
+// Warning: (ae-forgotten-export) The symbol "CustomScalarTypes" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type ScalarType = CustomScalarTypes extends any ? true extends IsAny<CustomScalarTypes> ? Primitive : unknown extends CustomScalarTypes ? Primitive : Primitive | CustomScalarTypes : never;
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -383,7 +383,7 @@ export class NotImplementedHandler implements Incremental.Handler<never> {
 }
 
 // @public (undocumented)
-type RemoveNeverishFields<TData> = true extends IsAny<TData> ? TData : true extends IsScalarType<TData> ? TData : TData extends Array<infer TItem> ? Array<RemoveNeverishFields<TItem>> : TData extends ReadonlyArray<infer TItem> ? ReadonlyArray<RemoveNeverishFields<TItem>> : string extends keyof TData ? TData : keyof TData extends never ? TData : TData extends object ? HasNeverishField<TData> extends true ? never : Prettify<{
+type RemoveNeverishFields<TData> = true extends IsAny<TData> ? TData : true extends IsScalarType<TData> ? TData : TData extends ReadonlyArray<infer TItem> ? TItem[] extends (TData) ? TData extends Array<infer TItem> ? Array<RemoveNeverishFields<TItem>> : ReadonlyArray<RemoveNeverishFields<TItem>> : TData : string extends keyof TData ? TData : keyof TData extends never ? TData : TData extends object ? HasNeverishField<TData> extends true ? never : Prettify<{
     [K in keyof TData]: RemoveNeverishFields<TData[K]>;
 }> : TData;
 

--- a/.api-reports/api-report-masking.api.md
+++ b/.api-reports/api-report-masking.api.md
@@ -8,6 +8,7 @@ import type { ApolloCache } from '@apollo/client';
 import type { ApplyHKTImplementationWithDefault } from '@apollo/client/utilities/internal';
 import type { DocumentNode } from '@apollo/client';
 import type { DocumentTypeDecoration } from '@graphql-typed-document-node/core';
+import type { Exact } from '@apollo/client/utilities/internal';
 import type { HKT } from '@apollo/client/utilities';
 import type { IsAny } from '@apollo/client/utilities/internal';
 import type { Prettify } from '@apollo/client/utilities/internal';
@@ -35,8 +36,6 @@ type CombineIntersection<T> = Exclude<T, {
     __typename?: string;
 }>>;
 
-// Warning: (ae-forgotten-export) The symbol "Exact" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 type ContainsFragmentsRefs<TData, Seen = never> = true extends (IsAny<TData>) ? false : TData extends object ? Exact<TData> extends Seen ? false : " $fragmentRefs" extends keyof RemoveIndexSignature<TData> ? true : ContainsFragmentsRefs<TData[keyof TData], Seen | Exact<TData>> : false;
 
@@ -50,9 +49,6 @@ export const disableWarningsSlot: {
 
 // @public (undocumented)
 type DistributedRequiredExclude<T, U> = T extends any ? Required<T> extends Required<U> ? Required<U> extends Required<T> ? never : T : T : T;
-
-// @public (undocumented)
-type Exact<in out T> = (x: T) => T;
 
 // @public
 type ExtractByMatchingTypeNames<Union extends {

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -226,6 +226,9 @@ export namespace DocumentationTypes {
 // @public (undocumented)
 export function equalByQuery(query: DocumentNode, { data: aData, ...aRest }: Partial<ObservableQuery.Result<unknown>>, { data: bData, ...bRest }: Partial<ObservableQuery.Result<unknown>>, variables?: OperationVariables): boolean;
 
+// @public (undocumented)
+export type Exact<in out T> = (x: T) => T;
+
 // @internal @deprecated
 export const extensionsSymbol: unique symbol;
 
@@ -409,6 +412,11 @@ A
 ] extends [B] ? [
 B
 ] extends [A] ? true : false : false;
+
+// @public (undocumented)
+export type IsNeverish<V> = [
+Exclude<V, undefined>
+] extends [never] ? true : false;
 
 // @internal @deprecated (undocumented)
 export function isNonEmptyArray<T>(value: ArrayLike<T> | null | undefined): value is Array<T>;

--- a/.changeset/incremental-codegen-complete.md
+++ b/.changeset/incremental-codegen-complete.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": minor
+---
+
+Add `GraphQLCodegenIncremental` type overrides that assemble GraphQL Codegen `@defer` operation types when `dataState` is `"complete"`.

--- a/src/incremental/GraphQLCodegenIncremental.ts
+++ b/src/incremental/GraphQLCodegenIncremental.ts
@@ -1,0 +1,59 @@
+import type { HKT } from "@apollo/client/utilities";
+
+export declare namespace GraphQLCodegenIncremental {
+  export interface TypeOverrides {
+    Complete: HKTImplementation.Complete;
+    Streaming: HKTImplementation.Streaming;
+    Partial: HKTImplementation.Partial;
+  }
+
+  namespace HKTImplementation {
+    export interface Complete extends HKT {
+      arg1: unknown; // TData
+      return: GraphQLCodegenIncremental.Complete<this["arg1"]>;
+    }
+
+    export interface Streaming extends HKT {
+      arg1: unknown; // TData
+      return: GraphQLCodegenIncremental.Streaming<this["arg1"]>;
+    }
+
+    export interface Partial extends HKT {
+      arg1: unknown; // TData
+      return: GraphQLCodegenIncremental.Partial<this["arg1"]>;
+    }
+  }
+
+  /**
+   * Returns the complete representation of `TData` when `dataState` is
+   * `"complete"`.
+   *
+   * @remarks
+   * GraphQL Codegen types deferred fields as a union of the present value and
+   * `{ field?: never }`. `complete` `dataState` means every field in the
+   * selection set is reachable, so this type drops the `never` branches.
+   *
+   * Operations without `@defer` are returned unchanged.
+   */
+  export type Complete<TData> = TData;
+
+  /**
+   * Returns the streaming representation of `TData` when `dataState` is
+   * `"streaming"`.
+   *
+   * @remarks
+   * GraphQLCodegen assembles the type in the streaming format so this is an
+   * identity type.
+   */
+  export type Streaming<TData> = TData;
+
+  /**
+   * Returns the partial representation of `TData` when `dataState` is
+   * `"partial"`.
+   *
+   * @remarks
+   * Applies `DeepPartial` to the assembled `Complete` type so
+   * `returnPartialData` does not preserve deferred `{ field?: never }` types.
+   */
+  export type Partial<TData> = DeepPartial<Complete<TData>>;
+}

--- a/src/incremental/GraphQLCodegenIncremental.ts
+++ b/src/incremental/GraphQLCodegenIncremental.ts
@@ -1,4 +1,10 @@
-import type { HKT } from "@apollo/client/utilities";
+import type { DeepPartial, HKT } from "@apollo/client/utilities";
+import type { IsAny } from "@apollo/client/utilities/internal";
+
+import type {
+  ContainsNeverishFields,
+  RemoveNeverishFields,
+} from "./internal/types.js";
 
 export declare namespace GraphQLCodegenIncremental {
   export interface TypeOverrides {
@@ -35,8 +41,15 @@ export declare namespace GraphQLCodegenIncremental {
    *
    * Operations without `@defer` are returned unchanged.
    */
-  export type Complete<TData> = TData;
-
+  export type Complete<TData> =
+    TData extends any ?
+      true extends IsAny<TData> ? TData
+      : TData extends object ?
+        true extends ContainsNeverishFields<TData> ?
+          RemoveNeverishFields<TData>
+        : TData
+      : TData
+    : never;
   /**
    * Returns the streaming representation of `TData` when `dataState` is
    * `"streaming"`.

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -578,7 +578,7 @@ test("is an identity for operations without @defer", (prefix) => {
 test("Complete handles odd types", (prefix) => {
   bench(prefix + "empty type instantiations", () => {
     attest<{}, GraphQLCodegenIncremental.Complete<{}>>();
-  }).types([131, "instantiations"]);
+  }).types([97, "instantiations"]);
 
   bench(prefix + "empty type functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<{}>>().toEqualTypeOf<{}>();
@@ -589,7 +589,7 @@ test("Complete handles odd types", (prefix) => {
       Record<string, any>,
       GraphQLCodegenIncremental.Complete<Record<string, any>>
     >();
-  }).types([140, "instantiations"]);
+  }).types([71, "instantiations"]);
 
   bench(prefix + "generic record type functionality", () => {
     expectTypeOf<
@@ -617,7 +617,7 @@ test("Complete handles odd types", (prefix) => {
     return {} as GraphQLCodegenIncremental.Complete<{
       coords: [long: number, lat: number];
     }>;
-  }).types([198, "instantiations"]);
+  }).types([126, "instantiations"]);
 
   bench(prefix + "tuple functionality", () => {
     expectTypeOf<

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -644,6 +644,45 @@ test("Complete handles odd types", (prefix) => {
   }
 });
 
+test("preserves tuple fields when a sibling field is deferred", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     coords
+  //     ... @defer {
+  //       name
+  //     }
+  //   }
+  // }
+  type Source = {
+    user:
+      | ({
+          __typename: "User";
+          id: string;
+          coords: [long: number, lat: number];
+        } & (
+          | { __typename: "User"; name: string }
+          | { __typename: "User"; name?: never }
+        ))
+      | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([6, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: {
+        __typename: "User";
+        id: string;
+        coords: [long: number, lat: number];
+        name: string;
+      } | null;
+    }>();
+  });
+});
+
 test("Partial is DeepPartial of the assembled complete type", (prefix) => {
   // query {
   //   user {

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -1,5 +1,4 @@
-import { attest, bench } from "@ark/attest";
-import { setup } from "@ark/attest";
+import { attest, bench, setup } from "@ark/attest";
 import { expectTypeOf } from "expect-type";
 
 import type { GraphQLCodegenIncremental } from "@apollo/client/incremental";

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -576,56 +576,73 @@ test("is an identity for operations without @defer", (prefix) => {
 });
 
 test("Complete handles odd types", (prefix) => {
-  bench(prefix + "empty type instantiations", () => {
-    attest<{}, GraphQLCodegenIncremental.Complete<{}>>();
-  }).types([93, "instantiations"]);
+  {
+    type Source = {};
 
-  bench(prefix + "empty type functionality", () => {
-    expectTypeOf<GraphQLCodegenIncremental.Complete<{}>>().toEqualTypeOf<{}>();
-  });
+    bench(prefix + "empty type instantiations", () => {
+      return {} as GraphQLCodegenIncremental.Complete<Source>;
+    }).types([6, "instantiations"]);
 
-  bench(prefix + "generic record type instantiations", () => {
-    attest<
-      Record<string, any>,
-      GraphQLCodegenIncremental.Complete<Record<string, any>>
-    >();
-  }).types([71, "instantiations"]);
+    bench(prefix + "empty type functionality", () => {
+      expectTypeOf<
+        GraphQLCodegenIncremental.Complete<Source>
+      >().toEqualTypeOf<{}>();
+    });
+  }
 
-  bench(prefix + "generic record type functionality", () => {
-    expectTypeOf<
-      GraphQLCodegenIncremental.Complete<Record<string, any>>
-    >().toEqualTypeOf<Record<string, any>>();
-  });
+  {
+    type Source = Record<string, any>;
 
-  bench(prefix + "unknown instantiations", () => {
-    attest<unknown, GraphQLCodegenIncremental.Complete<unknown>>();
-  }).types([48, "instantiations"]);
+    bench(prefix + "generic record type instantiations", () => {
+      return {} as GraphQLCodegenIncremental.Complete<Source>;
+    }).types([6, "instantiations"]);
 
-  bench(prefix + "unknown functionality", () => {
-    expectTypeOf<GraphQLCodegenIncremental.Complete<unknown>>().toBeUnknown();
-  });
+    bench(prefix + "generic record type functionality", () => {
+      expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<
+        Record<string, any>
+      >();
+    });
+  }
 
-  bench(prefix + "any instantiations", () => {
-    attest<any, GraphQLCodegenIncremental.Complete<any>>();
-  }).types([49, "instantiations"]);
+  {
+    type Source = unknown;
 
-  bench(prefix + "any functionality", () => {
-    expectTypeOf<GraphQLCodegenIncremental.Complete<any>>().toBeAny();
-  });
+    bench(prefix + "unknown instantiations", () => {
+      return {} as GraphQLCodegenIncremental.Complete<Source>;
+    }).types([6, "instantiations"]);
 
-  bench(prefix + "tuple instantiations", () => {
-    return {} as GraphQLCodegenIncremental.Complete<{
+    bench(prefix + "unknown functionality", () => {
+      expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toBeUnknown();
+    });
+  }
+
+  {
+    type Source = any;
+
+    bench(prefix + "any instantiations", () => {
+      return {} as GraphQLCodegenIncremental.Complete<Source>;
+    }).types([6, "instantiations"]);
+
+    bench(prefix + "any functionality", () => {
+      expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toBeAny();
+    });
+  }
+
+  {
+    type Source = {
       coords: [long: number, lat: number];
-    }>;
-  }).types([120, "instantiations"]);
+    };
 
-  bench(prefix + "tuple functionality", () => {
-    expectTypeOf<
-      GraphQLCodegenIncremental.Complete<{
+    bench(prefix + "tuple instantiations", () => {
+      return {} as GraphQLCodegenIncremental.Complete<Source>;
+    }).types([6, "instantiations"]);
+
+    bench(prefix + "tuple functionality", () => {
+      expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
         coords: [long: number, lat: number];
-      }>
-    >().toEqualTypeOf<{ coords: [long: number, lat: number] }>();
-  });
+      }>();
+    });
+  }
 });
 
 test("Partial is DeepPartial of the assembled complete type", (prefix) => {

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -42,7 +42,7 @@ test("assembles inline single-field @defer", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -73,7 +73,7 @@ test("assembles named fragment @defer", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -120,7 +120,7 @@ test("assembles inline multi-field @defer split per field", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -174,7 +174,7 @@ test("assembles multiple independent @defer fragments", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -216,7 +216,7 @@ test("assembles @defer nested inside arrays", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -266,7 +266,7 @@ test("assembles @defer nested inside nullable and optional arrays", (prefix) => 
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -307,7 +307,7 @@ test("assembles @defer inside ReadonlyArray", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -333,7 +333,7 @@ test("leaves @skip/@include optionals in place", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<
@@ -364,7 +364,7 @@ test("does not treat GraphQL interface/union result unions as incremental", (pre
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<
@@ -400,7 +400,7 @@ test("assembles @defer on one member of a GraphQL union", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -452,7 +452,7 @@ test("collapses Incremental<T> on masked deferred fragment refs", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -519,7 +519,7 @@ test("assembles deeply nested mixed @defer", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
@@ -555,7 +555,7 @@ test("is an identity for operations without @defer", (prefix) => {
 
   bench(prefix + "instantiations", () => {
     return {} as GraphQLCodegenIncremental.Complete<Source>;
-  }).types([7, "instantiations"]);
+  }).types([6, "instantiations"]);
 
   bench(prefix + "functionality", () => {
     type NoDefer = { __typename: "User"; id: string; name: string };
@@ -578,7 +578,7 @@ test("is an identity for operations without @defer", (prefix) => {
 test("Complete handles odd types", (prefix) => {
   bench(prefix + "empty type instantiations", () => {
     attest<{}, GraphQLCodegenIncremental.Complete<{}>>();
-  }).types([122, "instantiations"]);
+  }).types([131, "instantiations"]);
 
   bench(prefix + "empty type functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<{}>>().toEqualTypeOf<{}>();
@@ -589,7 +589,7 @@ test("Complete handles odd types", (prefix) => {
       Record<string, any>,
       GraphQLCodegenIncremental.Complete<Record<string, any>>
     >();
-  }).types([130, "instantiations"]);
+  }).types([140, "instantiations"]);
 
   bench(prefix + "generic record type functionality", () => {
     expectTypeOf<
@@ -599,7 +599,7 @@ test("Complete handles odd types", (prefix) => {
 
   bench(prefix + "unknown instantiations", () => {
     attest<unknown, GraphQLCodegenIncremental.Complete<unknown>>();
-  }).types([49, "instantiations"]);
+  }).types([48, "instantiations"]);
 
   bench(prefix + "unknown functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<unknown>>().toBeUnknown();
@@ -607,7 +607,7 @@ test("Complete handles odd types", (prefix) => {
 
   bench(prefix + "any instantiations", () => {
     attest<any, GraphQLCodegenIncremental.Complete<any>>();
-  }).types([50, "instantiations"]);
+  }).types([49, "instantiations"]);
 
   bench(prefix + "any functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<any>>().toBeAny();
@@ -617,7 +617,7 @@ test("Complete handles odd types", (prefix) => {
     return {} as GraphQLCodegenIncremental.Complete<{
       coords: [long: number, lat: number];
     }>;
-  }).types([133, "instantiations"]);
+  }).types([198, "instantiations"]);
 
   bench(prefix + "tuple functionality", () => {
     expectTypeOf<
@@ -670,7 +670,7 @@ test("distributed members on Complete", (prefix) => {
         [GraphQLCodegenIncremental.Complete<T> | null | undefined],
         [GraphQLCodegenIncremental.Complete<T | null | undefined>]
       >();
-    }).types([55, "instantiations"]);
+    }).types([53, "instantiations"]);
   })();
 
   (function unresolvedGenerics<T, V>() {
@@ -682,6 +682,6 @@ test("distributed members on Complete", (prefix) => {
         ],
         [GraphQLCodegenIncremental.Complete<T | V>]
       >();
-    }).types([62, "instantiations"]);
+    }).types([59, "instantiations"]);
   })();
 });

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -578,7 +578,7 @@ test("is an identity for operations without @defer", (prefix) => {
 test("Complete handles odd types", (prefix) => {
   bench(prefix + "empty type instantiations", () => {
     attest<{}, GraphQLCodegenIncremental.Complete<{}>>();
-  }).types([97, "instantiations"]);
+  }).types([93, "instantiations"]);
 
   bench(prefix + "empty type functionality", () => {
     expectTypeOf<GraphQLCodegenIncremental.Complete<{}>>().toEqualTypeOf<{}>();
@@ -617,7 +617,7 @@ test("Complete handles odd types", (prefix) => {
     return {} as GraphQLCodegenIncremental.Complete<{
       coords: [long: number, lat: number];
     }>;
-  }).types([126, "instantiations"]);
+  }).types([120, "instantiations"]);
 
   bench(prefix + "tuple functionality", () => {
     expectTypeOf<

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -694,8 +694,8 @@ test("distributed members on Complete", (prefix) => {
       prefix + "one unresolved generic mixed with null|undefined functionality",
       () => {
         attest<
-          [GraphQLCodegenIncremental.Complete<T> | null | undefined],
-          [GraphQLCodegenIncremental.Complete<T | null | undefined>]
+          [GraphQLCodegenIncremental.Complete<T | null | undefined>],
+          [GraphQLCodegenIncremental.Complete<T> | null | undefined]
         >();
       }
     );
@@ -715,11 +715,11 @@ test("distributed members on Complete", (prefix) => {
         "two unresolved generics distribute instantiations functionality",
       () => {
         attest<
+          [GraphQLCodegenIncremental.Complete<T | V>],
           [
             | GraphQLCodegenIncremental.Complete<T>
             | GraphQLCodegenIncremental.Complete<V>,
-          ],
-          [GraphQLCodegenIncremental.Complete<T | V>]
+          ]
         >();
       }
     );

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -682,23 +682,46 @@ test("distributed members on Complete", (prefix) => {
   // Not a specific operation. Complete<T | U> must distribute to Complete<T> | Complete<U>
   // so hook result unions like TData | null stay intact.
   (function unresolvedGeneric<T>() {
-    bench(prefix + "one unresolved generic mixed with null|undefined", () => {
-      attest<
-        [GraphQLCodegenIncremental.Complete<T> | null | undefined],
-        [GraphQLCodegenIncremental.Complete<T | null | undefined>]
-      >();
-    }).types([53, "instantiations"]);
+    bench(
+      prefix +
+        "one unresolved generic mixed with null|undefined instantiations",
+      () => {
+        return {} as GraphQLCodegenIncremental.Complete<T | null | undefined>;
+      }
+    ).types([2, "instantiations"]);
+
+    bench(
+      prefix + "one unresolved generic mixed with null|undefined functionality",
+      () => {
+        attest<
+          [GraphQLCodegenIncremental.Complete<T> | null | undefined],
+          [GraphQLCodegenIncremental.Complete<T | null | undefined>]
+        >();
+      }
+    );
   })();
 
   (function unresolvedGenerics<T, V>() {
-    bench(prefix + "two unresolved generics distribute", () => {
-      attest<
-        [
-          | GraphQLCodegenIncremental.Complete<T>
-          | GraphQLCodegenIncremental.Complete<V>,
-        ],
-        [GraphQLCodegenIncremental.Complete<T | V>]
-      >();
-    }).types([59, "instantiations"]);
+    bench(
+      prefix +
+        "two unresolved generics distribute instantiations instantiations",
+      () => {
+        return {} as GraphQLCodegenIncremental.Complete<T | V>;
+      }
+    ).types([2, "instantiations"]);
+
+    bench(
+      prefix +
+        "two unresolved generics distribute instantiations functionality",
+      () => {
+        attest<
+          [
+            | GraphQLCodegenIncremental.Complete<T>
+            | GraphQLCodegenIncremental.Complete<V>,
+          ],
+          [GraphQLCodegenIncremental.Complete<T | V>]
+        >();
+      }
+    );
   })();
 });

--- a/src/incremental/__benches__/types.bench.ts
+++ b/src/incremental/__benches__/types.bench.ts
@@ -1,0 +1,687 @@
+import { attest, bench } from "@ark/attest";
+import { setup } from "@ark/attest";
+import { expectTypeOf } from "expect-type";
+
+import type { GraphQLCodegenIncremental } from "@apollo/client/incremental";
+import type { DeepPartial } from "@apollo/client/utilities";
+
+setup({
+  updateSnapshots: !process.env.CI,
+});
+
+function test(name: string, fn: (name: string) => void) {
+  fn(name + ": ");
+}
+
+type UnrelatedStreaming = { __typename: "Unrelated"; id: string } & (
+  | { __typename: "Unrelated"; extra: boolean }
+  | { __typename: "Unrelated"; extra?: never }
+);
+// @ts-ignore
+type _TypeCacheWarmup =
+  | GraphQLCodegenIncremental.Complete<UnrelatedStreaming>
+  | GraphQLCodegenIncremental.Partial<UnrelatedStreaming>;
+
+test("assembles inline single-field @defer", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     ... @defer {
+  //       name
+  //     }
+  //   }
+  // }
+  type Source = {
+    user:
+      | ({ __typename: "User"; id: string } & (
+          | { __typename: "User"; name: string }
+          | { __typename: "User"; name?: never }
+        ))
+      | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: { __typename: "User"; id: string; name: string } | null;
+    }>();
+  });
+});
+
+test("assembles named fragment @defer", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     ...UserDetails @defer
+  //   }
+  // }
+  // fragment UserDetails on User {
+  //   name
+  //   age
+  // }
+  type Source = {
+    user:
+      | ({ __typename: "User"; id: string } & (
+          | { __typename: "User"; name: string; age: number }
+          | { __typename: "User"; name?: never; age?: never }
+        ))
+      | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: {
+        __typename: "User";
+        id: string;
+        name: string;
+        age: number;
+      } | null;
+    }>();
+  });
+});
+
+test("assembles inline multi-field @defer split per field", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     ... @defer {
+  //       name
+  //       age
+  //       description
+  //     }
+  //   }
+  // }
+  //
+  // Note: Codegen emits independent present|never unions per field with inline
+  // @defer, not a single union for the fragment.
+  type Source = {
+    user:
+      | ({ __typename: "User"; id: string } & (
+          | { __typename: "User"; name: string }
+          | { __typename: "User"; name?: never }
+        ) &
+          (
+            | { __typename: "User"; age: number }
+            | { __typename: "User"; age?: never }
+          ) &
+          (
+            | { __typename: "User"; description: string | null }
+            | { __typename: "User"; description?: never }
+          ))
+      | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: {
+        __typename: "User";
+        id: string;
+        name: string;
+        age: number;
+        description: string | null;
+      } | null;
+    }>();
+  });
+});
+
+test("assembles multiple independent @defer fragments", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     ... @defer {
+  //       name
+  //     }
+  //     ... @defer {
+  //       description
+  //     }
+  //     ... @defer {
+  //       profile {
+  //         bio
+  //       }
+  //     }
+  //   }
+  // }
+  type Source = {
+    user:
+      | ({ __typename: "User"; id: string } & (
+          | { __typename: "User"; name: string }
+          | { __typename: "User"; name?: never }
+        ) &
+          (
+            | { __typename: "User"; description: string | null }
+            | { __typename: "User"; description?: never }
+          ) &
+          (
+            | {
+                __typename: "User";
+                profile: { __typename: "Profile"; bio: string };
+              }
+            | { __typename: "User"; profile?: never }
+          ))
+      | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: {
+        __typename: "User";
+        id: string;
+        name: string;
+        description: string | null;
+        profile: { __typename: "Profile"; bio: string };
+      } | null;
+    }>();
+  });
+});
+
+test("assembles @defer nested inside arrays", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     friends {
+  //       id
+  //       ... @defer {
+  //         name
+  //       }
+  //     }
+  //   }
+  // }
+  type Source = {
+    user: {
+      __typename: "User";
+      id: string;
+      friends: Array<
+        { __typename: "Friend"; id: string } & (
+          | { __typename: "Friend"; name: string }
+          | { __typename: "Friend"; name?: never }
+        )
+      >;
+    } | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: {
+        __typename: "User";
+        id: string;
+        friends: Array<{ __typename: "Friend"; id: string; name: string }>;
+      } | null;
+    }>();
+  });
+});
+
+test("assembles @defer nested inside nullable and optional arrays", (prefix) => {
+  // query {
+  //   user {
+  //     friends {
+  //       id
+  //       ... @defer {
+  //         name
+  //       }
+  //     }
+  //     blockedFriends @include(if: $withBlocked) {
+  //       id
+  //       ... @defer {
+  //         name
+  //       }
+  //     }
+  //   }
+  // }
+  type Source = {
+    user: {
+      __typename: "User";
+      friends: Array<
+        { __typename: "Friend"; id: string } & (
+          | { __typename: "Friend"; name: string }
+          | { __typename: "Friend"; name?: never }
+        )
+      > | null;
+      blockedFriends?: Array<
+        { __typename: "Friend"; id: string } & (
+          | { __typename: "Friend"; name: string }
+          | { __typename: "Friend"; name?: never }
+        )
+      > | null;
+    } | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: {
+        __typename: "User";
+        friends: Array<{
+          __typename: "Friend";
+          id: string;
+          name: string;
+        }> | null;
+        blockedFriends?: Array<{
+          __typename: "Friend";
+          id: string;
+          name: string;
+        }> | null;
+      } | null;
+    }>();
+  });
+});
+
+test("assembles @defer inside ReadonlyArray", (prefix) => {
+  // query {
+  //   friends {
+  //     id
+  //     ... @defer {
+  //       name
+  //     }
+  //   }
+  // }
+  type Source = {
+    friends: ReadonlyArray<
+      { __typename: "Friend"; id: string } & (
+        | { __typename: "Friend"; name: string }
+        | { __typename: "Friend"; name?: never }
+      )
+    >;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      friends: ReadonlyArray<{
+        __typename: "Friend";
+        id: string;
+        name: string;
+      }>;
+    }>();
+  });
+});
+
+test("leaves @skip/@include optionals in place", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     name @include(if: $withName)
+  //   }
+  // }
+  type Source = {
+    user: { __typename: "User"; id: string; name?: string | null } | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<
+      GraphQLCodegenIncremental.Complete<Source>
+    >().toEqualTypeOf<Source>();
+  });
+});
+
+test("does not treat GraphQL interface/union result unions as incremental", (prefix) => {
+  // query {
+  //   search {
+  //     ... on User {
+  //       id
+  //       name
+  //     }
+  //     ... on Post {
+  //       id
+  //       title
+  //     }
+  //   }
+  // }
+  type Source = {
+    search: Array<
+      | { __typename: "User"; id: string; name: string }
+      | { __typename: "Post"; id: string; title: string }
+    >;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<
+      GraphQLCodegenIncremental.Complete<Source>
+    >().toEqualTypeOf<Source>();
+  });
+});
+
+test("assembles @defer on one member of a GraphQL union", (prefix) => {
+  // query {
+  //   search {
+  //     ... on User {
+  //       id
+  //       ... @defer {
+  //         name
+  //       }
+  //     }
+  //     ... on Post {
+  //       id
+  //       title
+  //     }
+  //   }
+  // }
+  type Source = {
+    search: Array<
+      | ({ __typename: "User"; id: string } & (
+          | { __typename: "User"; name: string }
+          | { __typename: "User"; name?: never }
+        ))
+      | { __typename: "Post"; id: string; title: string }
+    >;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      search: Array<
+        | { __typename: "User"; id: string; name: string }
+        | { __typename: "Post"; id: string; title: string }
+      >;
+    }>();
+  });
+});
+
+test("collapses Incremental<T> on masked deferred fragment refs", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     ...UserDetails @defer
+  //   }
+  // }
+  // fragment UserDetails on User {
+  //   name
+  //   age
+  // }
+  //
+  // Note: with inlineFragmentTypes: "mask", codegen wraps the deferred fragment
+  // as Incremental<T>.
+  type Incremental<T> =
+    | T
+    | {
+        [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P]
+        : never;
+      };
+
+  type UserDetailsFragment = {
+    __typename: "User";
+    name: string;
+    age: number;
+    " $fragmentName"?: "UserDetailsFragment";
+  };
+
+  type Source = {
+    user:
+      | ({ __typename: "User"; id: string } & {
+          " $fragmentRefs"?: {
+            UserDetailsFragment: Incremental<UserDetailsFragment>;
+          };
+        })
+      | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: {
+        __typename: "User";
+        id: string;
+        " $fragmentRefs"?: {
+          UserDetailsFragment: UserDetailsFragment;
+        };
+      } | null;
+    }>();
+  });
+});
+
+test("assembles deeply nested mixed @defer", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     ... @defer {
+  //       name
+  //     }
+  //     friends {
+  //       id
+  //       ... @defer {
+  //         name
+  //       }
+  //       profile {
+  //         ... @defer {
+  //           bio
+  //           avatar
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
+  type Source = {
+    user:
+      | ({
+          __typename: "User";
+          id: string;
+          friends: Array<
+            { __typename: "Friend"; id: string } & (
+              | { __typename: "Friend"; name: string }
+              | { __typename: "Friend"; name?: never }
+            ) & {
+                profile:
+                  | ({ __typename: "Profile" } & (
+                      | { __typename: "Profile"; bio: string }
+                      | { __typename: "Profile"; bio?: never }
+                    ) &
+                      (
+                        | { __typename: "Profile"; avatar: string }
+                        | { __typename: "Profile"; avatar?: never }
+                      ))
+                  | null;
+              }
+          >;
+        } & (
+          | { __typename: "User"; name: string }
+          | { __typename: "User"; name?: never }
+        ))
+      | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<Source>>().toEqualTypeOf<{
+      user: {
+        __typename: "User";
+        id: string;
+        name: string;
+        friends: Array<{
+          __typename: "Friend";
+          id: string;
+          name: string;
+          profile: {
+            __typename: "Profile";
+            bio: string;
+            avatar: string;
+          } | null;
+        }>;
+      } | null;
+    }>();
+  });
+});
+
+test("is an identity for operations without @defer", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     name
+  //   }
+  // }
+  type Source = {
+    user: { __typename: "User"; id: string; name: string } | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<Source>;
+  }).types([7, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    type NoDefer = { __typename: "User"; id: string; name: string };
+
+    expectTypeOf<
+      GraphQLCodegenIncremental.Complete<Source>
+    >().toEqualTypeOf<Source>();
+    expectTypeOf<
+      GraphQLCodegenIncremental.Complete<NoDefer | null>
+    >().toEqualTypeOf<NoDefer | null>();
+    expectTypeOf<
+      GraphQLCodegenIncremental.Complete<NoDefer | undefined>
+    >().toEqualTypeOf<NoDefer | undefined>();
+    expectTypeOf<
+      GraphQLCodegenIncremental.Complete<NoDefer | null | undefined>
+    >().toEqualTypeOf<NoDefer | null | undefined>();
+  });
+});
+
+test("Complete handles odd types", (prefix) => {
+  bench(prefix + "empty type instantiations", () => {
+    attest<{}, GraphQLCodegenIncremental.Complete<{}>>();
+  }).types([122, "instantiations"]);
+
+  bench(prefix + "empty type functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<{}>>().toEqualTypeOf<{}>();
+  });
+
+  bench(prefix + "generic record type instantiations", () => {
+    attest<
+      Record<string, any>,
+      GraphQLCodegenIncremental.Complete<Record<string, any>>
+    >();
+  }).types([130, "instantiations"]);
+
+  bench(prefix + "generic record type functionality", () => {
+    expectTypeOf<
+      GraphQLCodegenIncremental.Complete<Record<string, any>>
+    >().toEqualTypeOf<Record<string, any>>();
+  });
+
+  bench(prefix + "unknown instantiations", () => {
+    attest<unknown, GraphQLCodegenIncremental.Complete<unknown>>();
+  }).types([49, "instantiations"]);
+
+  bench(prefix + "unknown functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<unknown>>().toBeUnknown();
+  });
+
+  bench(prefix + "any instantiations", () => {
+    attest<any, GraphQLCodegenIncremental.Complete<any>>();
+  }).types([50, "instantiations"]);
+
+  bench(prefix + "any functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Complete<any>>().toBeAny();
+  });
+
+  bench(prefix + "tuple instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Complete<{
+      coords: [long: number, lat: number];
+    }>;
+  }).types([133, "instantiations"]);
+
+  bench(prefix + "tuple functionality", () => {
+    expectTypeOf<
+      GraphQLCodegenIncremental.Complete<{
+        coords: [long: number, lat: number];
+      }>
+    >().toEqualTypeOf<{ coords: [long: number, lat: number] }>();
+  });
+});
+
+test("Partial is DeepPartial of the assembled complete type", (prefix) => {
+  // query {
+  //   user {
+  //     id
+  //     ... @defer {
+  //       name
+  //     }
+  //   }
+  // }
+  type Source = {
+    user:
+      | ({ __typename: "User"; id: string } & (
+          | { __typename: "User"; name: string }
+          | { __typename: "User"; name?: never }
+        ))
+      | null;
+  };
+
+  type ExpectedComplete = {
+    user: { __typename: "User"; id: string; name: string } | null;
+  };
+
+  bench(prefix + "instantiations", () => {
+    return {} as GraphQLCodegenIncremental.Partial<Source>;
+  }).types([9, "instantiations"]);
+
+  bench(prefix + "functionality", () => {
+    expectTypeOf<GraphQLCodegenIncremental.Partial<Source>>().toEqualTypeOf<
+      DeepPartial<ExpectedComplete>
+    >();
+  });
+});
+
+test("distributed members on Complete", (prefix) => {
+  // Not a specific operation. Complete<T | U> must distribute to Complete<T> | Complete<U>
+  // so hook result unions like TData | null stay intact.
+  (function unresolvedGeneric<T>() {
+    bench(prefix + "one unresolved generic mixed with null|undefined", () => {
+      attest<
+        [GraphQLCodegenIncremental.Complete<T> | null | undefined],
+        [GraphQLCodegenIncremental.Complete<T | null | undefined>]
+      >();
+    }).types([55, "instantiations"]);
+  })();
+
+  (function unresolvedGenerics<T, V>() {
+    bench(prefix + "two unresolved generics distribute", () => {
+      attest<
+        [
+          | GraphQLCodegenIncremental.Complete<T>
+          | GraphQLCodegenIncremental.Complete<V>,
+        ],
+        [GraphQLCodegenIncremental.Complete<T | V>]
+      >();
+    }).types([62, "instantiations"]);
+  })();
+});

--- a/src/incremental/index.ts
+++ b/src/incremental/index.ts
@@ -5,3 +5,4 @@ export {
   Defer20220824Handler as GraphQL17Alpha2Handler,
 } from "./handlers/defer20220824.js";
 export { GraphQL17Alpha9Handler } from "./handlers/graphql17Alpha9.js";
+export type { GraphQLCodegenIncremental } from "./GraphQLCodegenIncremental.js";

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -50,9 +50,10 @@ type IsScalarType<TData> =
 export type RemoveNeverishFields<TData> =
   true extends IsAny<TData> ? TData
   : true extends IsScalarType<TData> ? TData
-  : TData extends Array<infer TItem> ? Array<RemoveNeverishFields<TItem>>
   : TData extends ReadonlyArray<infer TItem> ?
-    ReadonlyArray<RemoveNeverishFields<TItem>>
+    TData extends Array<infer TItem> ?
+      Array<RemoveNeverishFields<TItem>>
+    : ReadonlyArray<RemoveNeverishFields<TItem>>
   : // Leave TData alone if it is Record<string, any> and not a specific shape
   string extends keyof TData ? TData
   : // short-circuit on empty object

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -32,7 +32,7 @@ export type ContainsNeverishFields<TData, Seen = never> = true extends (
   true extends IsScalarType<TItem> ?
     false
   : ContainsNeverishFields<TItem, Seen>
-: keyof TData extends never ? TData
+: keyof TData extends never ? false
 : TData extends object ?
   string extends keyof TData ? false
   : [Seen] extends [never] ? ContainsNeverishFieldsInObject<TData, Exact<TData>>

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -4,7 +4,6 @@ import type {
   IsNeverish,
   Prettify,
   Primitive,
-  RemoveIndexSignature,
 } from "@apollo/client/utilities/internal";
 
 type CustomScalarTypes = {
@@ -23,13 +22,10 @@ type ScalarType =
 type Exact<in out T> = (x: T) => T;
 
 type HasNeverishField<T> =
-  [T] extends [never] ? false
-  : true extends (
+  true extends (
     {
-      [K in keyof RemoveIndexSignature<T> & string]-?: IsNeverish<
-        RemoveIndexSignature<T>[K]
-      >;
-    }[keyof RemoveIndexSignature<T> & string]
+      [K in keyof T & string]-?: IsNeverish<T[K]>;
+    }[keyof T & string]
   ) ?
     true
   : false;
@@ -40,12 +36,19 @@ export type ContainsNeverishFields<TData, Seen = never> = true extends (
   false
 : TData extends ScalarType ? false
 : TData extends ReadonlyArray<infer TItem> ?
-  ContainsNeverishFields<TItem, Seen | Exact<TItem>>
+  [TItem] extends [ScalarType] ?
+    false
+  : ContainsNeverishFields<TItem, Seen>
 : TData extends object ?
-  Exact<TData> extends Seen ? false
-  : [HasNeverishField<TData>] extends [true] ? true
-  : ContainsNeverishFields<TData[keyof TData], Seen | Exact<TData>>
+  string extends keyof TData ? false
+  : [Seen] extends [never] ? ContainsNeverishFieldsInObject<TData, Exact<TData>>
+  : Exact<TData> extends Seen ? false
+  : ContainsNeverishFieldsInObject<TData, Seen | Exact<TData>>
 : false;
+
+type ContainsNeverishFieldsInObject<TData, Seen> =
+  [HasNeverishField<TData>] extends [true] ? true
+  : ContainsNeverishFields<TData[keyof TData], Seen>;
 
 export type RemoveNeverishFields<TData> =
   true extends IsAny<TData> ? TData

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -22,13 +22,7 @@ type ScalarType =
 type Exact<in out T> = (x: T) => T;
 
 type HasNeverishField<T> =
-  true extends (
-    {
-      [K in keyof T & string]: IsNeverish<T[K]>;
-    }[keyof T & string]
-  ) ?
-    true
-  : false;
+  true extends { [K in keyof T]: IsNeverish<T[K]> }[keyof T] ? true : false;
 
 export type ContainsNeverishFields<TData, Seen = never> = true extends (
   IsAny<TData>
@@ -47,7 +41,7 @@ export type ContainsNeverishFields<TData, Seen = never> = true extends (
 : false;
 
 type ContainsNeverishFieldsInObject<TData, Seen> =
-  [HasNeverishField<TData>] extends [true] ? true
+  HasNeverishField<TData> extends true ? true
   : ContainsNeverishFields<TData[keyof TData], Seen>;
 
 export type RemoveNeverishFields<TData> =

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -28,11 +28,12 @@ export type ContainsNeverishFields<TData, Seen = never> = true extends (
   IsAny<TData>
 ) ?
   false
-: TData extends ScalarType ? false
+: true extends IsScalarType<TData> ? false
 : TData extends ReadonlyArray<infer TItem> ?
-  [TItem] extends [ScalarType] ?
+  true extends IsScalarType<TItem> ?
     false
   : ContainsNeverishFields<TItem, Seen>
+: keyof TData extends never ? TData
 : TData extends object ?
   string extends keyof TData ? false
   : [Seen] extends [never] ? ContainsNeverishFieldsInObject<TData, Exact<TData>>
@@ -44,9 +45,12 @@ type ContainsNeverishFieldsInObject<TData, Seen> =
   HasNeverishField<TData> extends true ? true
   : ContainsNeverishFields<TData[keyof TData], Seen>;
 
+type IsScalarType<TData> =
+  Exact<TData> extends Exact<Extract<ScalarType, TData>> ? true : false;
+
 export type RemoveNeverishFields<TData> =
   true extends IsAny<TData> ? TData
-  : TData extends ScalarType ? TData
+  : true extends IsScalarType<TData> ? TData
   : TData extends Array<infer TItem> ? Array<RemoveNeverishFields<TItem>>
   : TData extends ReadonlyArray<infer TItem> ?
     ReadonlyArray<RemoveNeverishFields<TItem>>

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -51,9 +51,13 @@ export type RemoveNeverishFields<TData> =
   true extends IsAny<TData> ? TData
   : true extends IsScalarType<TData> ? TData
   : TData extends ReadonlyArray<infer TItem> ?
-    TData extends Array<infer TItem> ?
-      Array<RemoveNeverishFields<TItem>>
-    : ReadonlyArray<RemoveNeverishFields<TItem>>
+    TItem[] extends (
+      TData // Test for non-tuples
+    ) ?
+      TData extends Array<infer TItem> ?
+        Array<RemoveNeverishFields<TItem>>
+      : ReadonlyArray<RemoveNeverishFields<TItem>>
+    : TData
   : // Leave TData alone if it is Record<string, any> and not a specific shape
   string extends keyof TData ? TData
   : // short-circuit on empty object

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -24,7 +24,7 @@ type Exact<in out T> = (x: T) => T;
 type HasNeverishField<T> =
   true extends (
     {
-      [K in keyof T & string]-?: IsNeverish<T[K]>;
+      [K in keyof T & string]: IsNeverish<T[K]>;
     }[keyof T & string]
   ) ?
     true

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -1,0 +1,64 @@
+import type { ApolloCache } from "@apollo/client/cache";
+import type {
+  IsAny,
+  IsNeverish,
+  Prettify,
+  Primitive,
+  RemoveIndexSignature,
+} from "@apollo/client/utilities/internal";
+
+type CustomScalarTypes = {
+  [K in keyof ApolloCache.Scalars]:
+    | ApolloCache.Scalars[K]["serialized"]
+    | ApolloCache.Scalars[K]["parsed"];
+}[keyof ApolloCache.Scalars];
+
+type ScalarType =
+  CustomScalarTypes extends any ?
+    true extends IsAny<CustomScalarTypes> ? Primitive
+    : unknown extends CustomScalarTypes ? Primitive
+    : Primitive | CustomScalarTypes
+  : never;
+
+type Exact<in out T> = (x: T) => T;
+
+type HasNeverishField<T> =
+  [T] extends [never] ? false
+  : true extends (
+    {
+      [K in keyof RemoveIndexSignature<T> & string]-?: IsNeverish<
+        RemoveIndexSignature<T>[K]
+      >;
+    }[keyof RemoveIndexSignature<T> & string]
+  ) ?
+    true
+  : false;
+
+export type ContainsNeverishFields<TData, Seen = never> = true extends (
+  IsAny<TData>
+) ?
+  false
+: TData extends ScalarType ? false
+: TData extends ReadonlyArray<infer TItem> ?
+  ContainsNeverishFields<TItem, Seen | Exact<TItem>>
+: TData extends object ?
+  Exact<TData> extends Seen ? false
+  : [HasNeverishField<TData>] extends [true] ? true
+  : ContainsNeverishFields<TData[keyof TData], Seen | Exact<TData>>
+: false;
+
+export type RemoveNeverishFields<TData> =
+  true extends IsAny<TData> ? TData
+  : TData extends ScalarType ? TData
+  : TData extends Array<infer TItem> ? Array<RemoveNeverishFields<TItem>>
+  : TData extends ReadonlyArray<infer TItem> ?
+    ReadonlyArray<RemoveNeverishFields<TItem>>
+  : // Leave TData alone if it is Record<string, any> and not a specific shape
+  string extends keyof TData ? TData
+  : // short-circuit on empty object
+  keyof TData extends never ? TData
+  : TData extends object ?
+    HasNeverishField<TData> extends true ?
+      never
+    : Prettify<{ [K in keyof TData]: RemoveNeverishFields<TData[K]> }>
+  : TData;

--- a/src/incremental/internal/types.ts
+++ b/src/incremental/internal/types.ts
@@ -1,5 +1,6 @@
 import type { ApolloCache } from "@apollo/client/cache";
 import type {
+  Exact,
   IsAny,
   IsNeverish,
   Prettify,
@@ -18,8 +19,6 @@ type ScalarType =
     : unknown extends CustomScalarTypes ? Primitive
     : Primitive | CustomScalarTypes
   : never;
-
-type Exact<in out T> = (x: T) => T;
 
 type HasNeverishField<T> =
   true extends { [K in keyof T]: IsNeverish<T[K]> }[keyof T] ? true : false;

--- a/src/masking/__benches__/types.bench.ts
+++ b/src/masking/__benches__/types.bench.ts
@@ -326,13 +326,13 @@ test("distributed members on MaybeMasked", (prefix) => {
         [MaybeMasked<T> | null | undefined],
         [MaybeMasked<T | null | undefined>]
       >();
-    }).types([49, "instantiations"]);
+    }).types([47, "instantiations"]);
   })();
 
   (function unresolvedGenerics<T, V>() {
     bench(prefix + "two unresolved generics distribute", () => {
       attest<[MaybeMasked<T> | MaybeMasked<V>], [MaybeMasked<T | V>]>();
-    }).types([50, "instantiations"]);
+    }).types([48, "instantiations"]);
   })();
 });
 

--- a/src/masking/internal/types.ts
+++ b/src/masking/internal/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Exact,
   IsAny,
   Prettify,
   Primitive,
@@ -186,7 +187,6 @@ type MergeObjects<T, U> = Prettify<
 export type RemoveFragmentName<T> =
   T extends any ? Omit<T, " $fragmentName"> : T;
 
-type Exact<in out T> = (x: T) => T;
 export type ContainsFragmentsRefs<TData, Seen = never> = true extends (
   IsAny<TData>
 ) ?

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -1,5 +1,6 @@
 export type { DecoratedPromise } from "./types/DecoratedPromise.js";
 export type { DeepOmit } from "./types/DeepOmit.js";
+export type { Exact } from "./types/Exact.js";
 export type { ExtensionsWithStreamInfo } from "./types/ExtensionsWithStreamDetails.js";
 export type { FragmentMap } from "./types/FragmentMap.js";
 export type { FragmentMapFunction } from "./types/FragmentMapFunction.js";

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -6,6 +6,7 @@ export type { FragmentMapFunction } from "./types/FragmentMapFunction.js";
 export type { FulfilledPromise } from "./types/FulfilledPromise.js";
 export type { IsAny } from "./types/IsAny.js";
 export type { IsLooselyEqual } from "./types/IsLooselyEqual.js";
+export type { IsNeverish } from "./types/IsNeverish.js";
 export type { NoInfer } from "./types/NoInfer.js";
 export type { PendingPromise } from "./types/PendingPromise.js";
 export type { Prettify } from "./types/Prettify.js";

--- a/src/utilities/internal/types/Exact.ts
+++ b/src/utilities/internal/types/Exact.ts
@@ -1,0 +1,1 @@
+export type Exact<in out T> = (x: T) => T;

--- a/src/utilities/internal/types/IsNeverish.ts
+++ b/src/utilities/internal/types/IsNeverish.ts
@@ -1,0 +1,2 @@
+export type IsNeverish<V> =
+  [Exclude<V, undefined>] extends [never] ? true : false;


### PR DESCRIPTION
Adds an implementation for `dataState: "complete"` when GraphQL Codegen is used to create incremental types. Extends `GraphQLCodegenIncremental.TypeOverrides` to assemble the type to remove defer fields from the type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added type support for assembling GraphQL Codegen `@defer` results when data is complete, streaming, or partial.
  - Complete results now omit deferred fields that are unavailable, while partial results support deeply partial data.
  - Exported the new incremental data-state types for use in applications.

- **Tests**
  - Added comprehensive type coverage and benchmarks for deferred fragments, nested structures, arrays, unions, and nullable fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->