### PR TITLE
🤖🤖🤖 fix: ensure refetches supersede older in-flight queries

### DIFF
--- a/.changeset/fresh-refetch-results.md
+++ b/.changeset/fresh-refetch-results.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Ensure refetches start a fresh network request when an older query operation is in flight and prevent the older result from replacing the refetch result.

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -1379,9 +1379,12 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
 
     // track query and variables from the start of the operation
     const { query, variables } = this;
+    let subscription: Subscription | undefined;
+    let abortRequested = false;
     const operation: TrackedOperation = {
       abort: () => {
-        subscription.unsubscribe();
+        abortRequested = true;
+        subscription?.unsubscribe();
       },
       query,
       variables,
@@ -1392,7 +1395,7 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       networkStatus == NetworkStatus.refetch ||
       networkStatus == NetworkStatus.setVariables;
     observable = observable.pipe(operator, share());
-    const subscription = observable
+    const activeSubscription = observable
       .pipe(
         tap({
           next: (notification) => {
@@ -1439,8 +1442,13 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
           this.input.next({ ...value, query, variables, meta });
         },
       });
+    subscription = activeSubscription;
 
-    return { fromLink, subscription, observable };
+    if (abortRequested) {
+      activeSubscription.unsubscribe();
+    }
+
+    return { fromLink, subscription: activeSubscription, observable };
   }
 
   // Turns polling on or off based on this.options.pollInterval.

--- a/src/core/ObservableQuery.ts
+++ b/src/core/ObservableQuery.ts
@@ -783,6 +783,17 @@ export class ObservableQuery<
       pollInterval: 0,
     };
 
+    if (
+      isNetworkRequestInFlight(this.networkStatus) &&
+      this.networkStatus !== NetworkStatus.refetch
+    ) {
+      // Do not deduplicate a refetch with an older in-flight operation.
+      reobserveOptions.context = {
+        ...this.options.context,
+        queryDeduplication: false,
+      };
+    }
+
     // Unless the provided fetchPolicy always consults the network
     // (no-cache, network-only, or cache-and-network), override it with
     // network-only to force the refetch for this fetchQuery call.
@@ -1400,6 +1411,20 @@ Did you mean to call refetch(variables) instead of refetch({ variables })?`,
       .subscribe({
         next: (value) => {
           const meta: Meta = {};
+
+          if (
+            networkStatus === NetworkStatus.refetch &&
+            value.source === "network" &&
+            (value.kind !== "N" || !value.value.loading)
+          ) {
+            // A settled refetch supersedes older requests for the same query.
+            for (const activeOperation of this.activeOperations) {
+              if (activeOperation === operation) break;
+              if (isEqualQuery(activeOperation, operation)) {
+                activeOperation.abort();
+              }
+            }
+          }
 
           if (
             forceFirstValueEmit &&

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2196,7 +2196,9 @@ describe("ObservableQuery", () => {
 
     it("does not throw when a synchronous result reentrantly refetches", async () => {
       let observableQuery: ObservableQuery<typeof dataOne>;
-      let refetchPromise: Promise<ApolloQueryResult<typeof dataOne>> | undefined;
+      let refetchPromise:
+        | ReturnType<ObservableQuery<typeof dataOne>["refetch"]>
+        | undefined;
       let requestCount = 0;
       const client = new ApolloClient({
         cache: new InMemoryCache(),

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2194,6 +2194,41 @@ describe("ObservableQuery", () => {
       client.stop();
     });
 
+    it("does not throw when a synchronous result reentrantly refetches", async () => {
+      let observableQuery: ObservableQuery<typeof dataOne>;
+      let refetchPromise: Promise<ApolloQueryResult<typeof dataOne>> | undefined;
+      let requestCount = 0;
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new ApolloLink(
+          () =>
+            new Observable((observer) => {
+              requestCount += 1;
+              observer.next({ data: requestCount === 1 ? dataOne : dataTwo });
+              observer.complete();
+            })
+        ),
+      });
+      observableQuery = client.watchQuery({ query, variables });
+
+      const stream = new ObservableStream(observableQuery);
+      await expect(stream).toEmitTypedValue({
+        data: dataOne,
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+
+      refetchPromise = observableQuery.refetch();
+      await expect(refetchPromise).resolves.toStrictEqualTyped({
+        data: dataTwo,
+      });
+
+      stream.unsubscribe();
+      client.stop();
+    });
+
     it("calling refetch multiple times with different variables will return only results for the most recent variables", async () => {
       const observers: Observer<ApolloLink.Result<typeof dataOne>>[] = [];
       const client = new ApolloClient({

--- a/src/core/__tests__/ObservableQuery.ts
+++ b/src/core/__tests__/ObservableQuery.ts
@@ -2121,6 +2121,79 @@ describe("ObservableQuery", () => {
       await expect(stream).not.toEmitAnything();
     });
 
+    it("starts a new request when refetching while the initial request is still in flight", async () => {
+      const observers: Observer<ApolloLink.Result<typeof dataOne>>[] = [];
+      const operationContexts: Array<Record<string, unknown>> = [];
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new ApolloLink(
+          (operation) =>
+            new Observable((observer) => {
+              operationContexts.push(operation.getContext());
+              observers.push(observer);
+            })
+        ),
+      });
+      const observableQuery = client.watchQuery({
+        query,
+        variables,
+        context: { requestId: "initial" },
+      });
+      const stream = new ObservableStream(observableQuery);
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
+
+      const refetchPromise = observableQuery.refetch();
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        partial: true,
+      });
+      expect(observers).toHaveLength(2);
+      expect(operationContexts[1]).toMatchObject({
+        queryDeduplication: false,
+        requestId: "initial",
+      });
+
+      observers[1].next({ data: dataTwo });
+      observers[1].complete();
+
+      await expect(refetchPromise).resolves.toStrictEqualTyped({
+        data: dataTwo,
+      });
+      await expect(stream).toEmitTypedValue({
+        data: dataTwo,
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+
+      observers[0].next({ data: dataOne });
+      observers[0].complete();
+
+      await expect(stream).not.toEmitAnything();
+      expect(observableQuery.getCurrentResult()).toStrictEqualTyped({
+        data: dataTwo,
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+
+      stream.unsubscribe();
+      client.stop();
+    });
+
     it("calling refetch multiple times with different variables will return only results for the most recent variables", async () => {
       const observers: Observer<ApolloLink.Result<typeof dataOne>>[] = [];
       const client = new ApolloClient({

--- a/src/react/hooks/__tests__/useQuery.test.tsx
+++ b/src/react/hooks/__tests__/useQuery.test.tsx
@@ -7723,6 +7723,95 @@ describe("useQuery Hook", () => {
 
       await expect(takeSnapshot).not.toRerender();
     });
+
+    it("delivers a completed refetch result while the initial query is still in flight", async () => {
+      const query = gql`
+        query GetGreeting {
+          greeting
+        }
+      `;
+      const mutation = gql`
+        mutation UpdateGreeting {
+          updateGreeting
+        }
+      `;
+      const queryResolvers: Array<(data: { greeting: string }) => void> = [];
+      let resolveMutation!: () => void;
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new ApolloLink(
+          (operation) =>
+            new Observable((observer) => {
+              if (operation.operationName === "GetGreeting") {
+                queryResolvers.push((data) => {
+                  observer.next({ data });
+                  observer.complete();
+                });
+              } else if (operation.operationName === "UpdateGreeting") {
+                resolveMutation = () => {
+                  observer.next({ data: { updateGreeting: true } });
+                  observer.complete();
+                };
+              } else {
+                observer.error(new Error("Unexpected operation"));
+              }
+            })
+        ),
+      });
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <ApolloProvider client={client}>{children}</ApolloProvider>
+      );
+
+      using _disabledAct = disableActEnvironment();
+      const { takeSnapshot, unmount } = await renderHookToSnapshotStream(
+        () => useQuery(query),
+        { wrapper }
+      );
+
+      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        previousData: undefined,
+        variables: {},
+      });
+
+      const mutationPromise = client.mutate({
+        mutation,
+        refetchQueries: [query],
+        awaitRefetchQueries: true,
+      });
+      resolveMutation();
+
+      await waitFor(() => expect(queryResolvers).toHaveLength(2));
+      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.refetch,
+        previousData: undefined,
+        variables: {},
+      });
+
+      queryResolvers[1]({ greeting: "Goodbye" });
+      await mutationPromise;
+
+      await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+        data: { greeting: "Goodbye" },
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        previousData: undefined,
+        variables: {},
+      });
+
+      queryResolvers[0]({ greeting: "Hello" });
+      await expect(takeSnapshot).not.toRerender();
+
+      unmount();
+      client.stop();
+    });
   });
 
   describe("Optimistic data", () => {

--- a/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery.test.tsx
@@ -4456,6 +4456,82 @@ describe("useSuspenseQuery", () => {
     ]);
   });
 
+  it("delivers a completed refetch result while the initial query is still in flight", async () => {
+    const query = gql`
+      query GetGreeting {
+        greeting
+      }
+    `;
+    const mutation = gql`
+      mutation UpdateGreeting {
+        updateGreeting
+      }
+    `;
+    const queryResolvers: Array<(data: { greeting: string }) => void> = [];
+    let resolveMutation!: () => void;
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new ApolloLink(
+        (operation) =>
+          new Observable((observer) => {
+            if (operation.operationName === "GetGreeting") {
+              queryResolvers.push((data) => {
+                observer.next({ data });
+                observer.complete();
+              });
+            } else if (operation.operationName === "UpdateGreeting") {
+              resolveMutation = () => {
+                observer.next({ data: { updateGreeting: true } });
+                observer.complete();
+              };
+            } else {
+              observer.error(new Error("Unexpected operation"));
+            }
+          })
+      ),
+    });
+
+    const { result, renders, unmount } = await renderSuspenseHook(
+      () => useSuspenseQuery(query),
+      { client }
+    );
+
+    expect(renders.suspenseCount).toBe(1);
+
+    const mutationPromise = client.mutate({
+      mutation,
+      refetchQueries: [query],
+      awaitRefetchQueries: true,
+    });
+    await act(async () => resolveMutation());
+
+    await waitFor(() => expect(queryResolvers).toHaveLength(2));
+    await act(async () => {
+      queryResolvers[1]({ greeting: "Goodbye" });
+      await mutationPromise;
+    });
+
+    await waitFor(() =>
+      expect(result.current).toStrictEqualTyped({
+        data: { greeting: "Goodbye" },
+        dataState: "complete",
+        error: undefined,
+        networkStatus: NetworkStatus.ready,
+      })
+    );
+
+    await act(async () => queryResolvers[0]({ greeting: "Hello" }));
+    expect(result.current).toStrictEqualTyped({
+      data: { greeting: "Goodbye" },
+      dataState: "complete",
+      error: undefined,
+      networkStatus: NetworkStatus.ready,
+    });
+
+    unmount();
+    client.stop();
+  });
+
   it("properly resolves `refetch` when returning a result that is deeply equal to data in the cache", async () => {
     type Variables = {
       id: string;


### PR DESCRIPTION
> Alternative approach to #13462. Both implementations are retained for comparison.

## Summary

A mutation-triggered `refetchQueries` call now starts a fresh request when an older query operation is still in flight. The completed refetch remains authoritative even if the older operation finishes later.

Fixes #13429

## Root cause

The failure has two related races:

1. If a mutation finishes before the initial query, its refetch can deduplicate against the initial link request. The promise resolves with the initial response, but no request is made for the newer server state.
2. After a separate refetch request completes, the older operation can keep the observable loading or replace the new result when it finishes later.

A failing trace has only one `GetItems` request. The `a,b,c` refetch mock is never consumed:

```text
start GetItems
start AddItem
complete AddItem
next GetItems {"items":["a","b"]}
observable refetch/loading {"items":["a","b"]}
observable ready {"items":["a","b"]}
```

## Reproduction scenarios

### 1. Mutation refetches a suspended initial query

The button is outside the Suspense boundary, so the mutation can finish before the initial query.

```jsx
const ITEMS_QUERY = gql`query GetItems { items }`;
const ADD_ITEM_MUTATION = gql`mutation AddItem { addItem }`;

function Items() {
  const { data } = useSuspenseQuery(ITEMS_QUERY);
  return <ul>{data.items.map((item) => <li key={item}>{item}</li>)}</ul>;
}

function App() {
  const [addItem] = useMutation(ADD_ITEM_MUTATION, {
    refetchQueries: [ITEMS_QUERY],
  });
  return <>
    <button onClick={() => addItem()}>Add</button>
    <Suspense fallback="Loading..."><Items /></Suspense>
  </>;
}

const mocks = [
  { request: { query: ITEMS_QUERY }, result: { data: { items: ["a", "b"] } } },
  { request: { query: ADD_ITEM_MUTATION }, result: { data: { addItem: true } } },
  { request: { query: ITEMS_QUERY }, result: { data: { items: ["a", "b", "c"] } } },
];

render(<MockedProvider mocks={mocks}><App /></MockedProvider>);
fireEvent.click(screen.getByText("Add"));
await waitFor(() => expect(screen.getByText("c")).toBeInTheDocument());
```

Before this change, repeated runs can remain on `a,b` indefinitely. See [dh-seanmurphy/apollo-refetch-repro](https://github.com/dh-seanmurphy/apollo-refetch-repro).

### 2. The same overlap with `useQuery`

The race is not Suspense-specific. Use the same mutation and mocks with this consumer:

```jsx
function Items() {
  const { data, loading, networkStatus } = useQuery(ITEMS_QUERY);
  if (loading && !data) return "Loading...";
  return <>
    <output>{networkStatus}</output>
    <ul>{data.items.map((item) => <li key={item}>{item}</li>)}</ul>
  </>;
}

fireEvent.click(screen.getByText("Add"));
await waitFor(() => {
  expect(screen.getByText("c")).toBeInTheDocument();
  expect(screen.getByText(String(NetworkStatus.ready))).toBeInTheDocument();
});
```

### 3. Deterministic operation ordering

A controlled `ApolloLink` makes the refetch finish first, then attempts to deliver an older stale result.

```ts
const observers: Observer<ApolloLink.Result<Data>>[] = [];
const client = new ApolloClient({
  cache: new InMemoryCache(),
  link: new ApolloLink(() => new Observable((observer) => {
    observers.push(observer);
  })),
});

const observable = client.watchQuery({ query, variables });
const subscription = observable.subscribe(() => {});
const refetchPromise = observable.refetch();

expect(observers).toHaveLength(2);

observers[1].next({ data: newData });
observers[1].complete();
await refetchPromise;

expect(observable.getCurrentResult()).toMatchObject({
  data: newData,
  loading: false,
  networkStatus: NetworkStatus.ready,
});

observers[0].next({ data: staleData });
observers[0].complete();

expect(observable.getCurrentResult()).toMatchObject({
  data: newData,
  loading: false,
  networkStatus: NetworkStatus.ready,
});

subscription.unsubscribe();
```

## Behavior after this change

- Refetch bypasses deduplication only while an older non-refetch operation is in flight.
- The existing request context is preserved.
- Concurrent refetch calls retain their previous deduplication behavior.
- A settled refetch cancels older operations with the same query and variables; newer operations remain active.

## Validation

- Public reproduction with the built package: 50/50 passes, then a fresh 20/20 pass run. The unpatched package failed 8/20 runs in the same environment.
- Deterministic tests cover `ObservableQuery`, `useQuery`, and `useSuspenseQuery`, including a stale initial result arriving after the refetch.
- `ObservableQuery`: 414 passed, 24 skipped across three projects.
- `useQuery`: 480 passed across React 17, 18, and 19.
- `useSuspenseQuery`: 320 passed across React 18 and 19.
- Fetch-policy, mutation-refetch, watchQuery-refetch, and QueryReference suites: 87 passed, 3 skipped.
- Build, typecheck, lint, and formatting checks pass.

## Checklist

- [x] Includes a patch changeset.
- [x] Covers the core behavior and both React query consumers.
- [x] Preserves unrelated fetch policy, fetchMore, polling, and concurrent-refetch behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refetches now always start a fresh network request when the original query is still in progress.
  * Prevented stale responses from overwriting newer refetch results.
  * Improved consistency for standard and suspense-based query experiences.

* **Tests**
  * Added coverage for refetch behavior during in-flight requests, including mutation-triggered refetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Alternative implementation

Related: #13462 explores restarting pending shared requests while keeping deduplication enabled. Both implementations target `main` independently and are retained for comparison.


