### PR TITLE
Add documentation for the TypeScript changes in 4.3

### DIFF
--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -169,6 +169,39 @@ As chunks arrive and replace existing data, data that cannot be merged, such as 
 
 If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for your codegen needs, you'll need to use the Codegen version v4.0.0 or higher.
 
+<MinVersion version="4.3">
+
+### GraphQL Codegen incremental types
+
+</MinVersion>
+
+GraphQL Codegen types deferred fields as a union of the present and absent values:
+
+```ts
+type MyQuery = {
+  field: boolean;
+} & (
+  | { deferredField: string } 
+  | { deferredField?: never }
+)
+```
+
+Apollo Client provides `GraphQLCodegenIncremental` type overrides that assemble the `@defer` types for [`dataState`](./typescript#type-narrowing-data-with-datastate). For example, when `dataState` is `"complete"`, every field in the selection set is present, so the `GraphQLCodegenIncremental` type overrides remove the `never` branches from the type. This avoids the need to check for a truthy value on each of the deferred fields to determine whether the query has completed or not.
+
+Create a TypeScript file and extend `TypeOverrides` with `GraphQLCodegenIncremental.TypeOverrides`:
+
+```ts title="apollo.d.ts"
+import "@apollo/client";
+import type { GraphQLCodegenIncremental } from "@apollo/client/incremental";
+
+declare module "@apollo/client" {
+  export interface TypeOverrides
+    extends GraphQLCodegenIncremental.TypeOverrides {}
+}
+```
+
+For more information about type overrides, see the [TypeScript guide](./typescript#overriding-type-implementations-for-built-in-types).
+
 ## Usage in React Native
 
 In order to use `@defer` in a React Native application, additional configuration is required. See the [React Native docs](../integrations/react-native#consuming-multipart-http-via-text-streaming) for more information.

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -180,7 +180,10 @@ GraphQL Codegen types deferred fields as a union of the present and absent value
 ```ts
 type MyQuery = {
   field: boolean;
-} & ({ deferredField: string } | { deferredField?: never });
+} & (
+  | { deferredFieldA: string; deferredFieldB: number }
+  | { deferredFieldA?: never; deferredFieldB?: never }
+);
 ```
 
 Apollo Client provides `GraphQLCodegenIncremental` type overrides that assemble the `@defer` types for [`dataState`](./typescript#type-narrowing-data-with-datastate). For example, when `dataState` is `"complete"`, every field in the selection set is present, so the `GraphQLCodegenIncremental` type overrides remove the `never` branches from the type. This avoids the need to check for a truthy value on each of the deferred fields to determine whether the query has completed or not.

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -186,7 +186,7 @@ type MyQuery = {
 );
 ```
 
-Apollo Client provides `GraphQLCodegenIncremental` type overrides that assemble the `@defer` types for [`dataState`](./typescript#type-narrowing-data-with-datastate). For example, when `dataState` is `"complete"`, every field in the selection set is present, so the `GraphQLCodegenIncremental` type overrides remove the `never` branches from the type. This avoids the need to check for a truthy value on each of the deferred fields to determine whether the query has completed or not.
+Apollo Client provides `GraphQLCodegenIncremental` type overrides that assemble the `@defer` types for [`dataState`](./typescript#type-narrowing-data-with-datastate). For example, when `dataState` is `"complete"`, every field in the selection set is present, so the `GraphQLCodegenIncremental` type overrides remove the `never` branches from the type.
 
 Create a TypeScript file and extend `TypeOverrides` with `GraphQLCodegenIncremental.TypeOverrides`:
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -175,7 +175,7 @@ If you currently use [GraphQL Code Generator](https://www.the-guild.dev/graphql/
 
 </MinVersion>
 
-GraphQL Codegen types deferred fields as a union of the present and absent values:
+GraphQL Codegen types deferred fields as a union of both present and absent values:
 
 ```ts
 type MyQuery = {
@@ -200,7 +200,7 @@ declare module "@apollo/client" {
 }
 ```
 
-For more information about type overrides, see the [TypeScript guide](./typescript#overriding-type-implementations-for-built-in-types).
+For more information about type overrides, reference the [TypeScript guide](./typescript#overriding-type-implementations-for-built-in-types).
 
 ## Usage in React Native
 

--- a/docs/source/data/defer.mdx
+++ b/docs/source/data/defer.mdx
@@ -180,10 +180,7 @@ GraphQL Codegen types deferred fields as a union of the present and absent value
 ```ts
 type MyQuery = {
   field: boolean;
-} & (
-  | { deferredField: string } 
-  | { deferredField?: never }
-)
+} & ({ deferredField: string } | { deferredField?: never });
 ```
 
 Apollo Client provides `GraphQLCodegenIncremental` type overrides that assemble the `@defer` types for [`dataState`](./typescript#type-narrowing-data-with-datastate). For example, when `dataState` is `"complete"`, every field in the selection set is present, so the `GraphQLCodegenIncremental` type overrides remove the `never` branches from the type. This avoids the need to check for a truthy value on each of the deferred fields to determine whether the query has completed or not.

--- a/docs/source/data/typescript.mdx
+++ b/docs/source/data/typescript.mdx
@@ -847,7 +847,6 @@ Using classic signatures after declaring `DeclareDefaultOptions` is not recommen
 
 </Caution>
 
-
 <MinVersion version="4.3">
 
 ## Declaring the cache type
@@ -858,7 +857,7 @@ By default, `client.cache`, or any API that provides access to the cache, is typ
 
 ```ts title="apollo.d.ts"
 import "@apollo/client";
-import type { InMemoryCache } from '@apollo/client';
+import type { InMemoryCache } from "@apollo/client";
 
 declare module "@apollo/client" {
   export interface TypeOverrides {
@@ -876,7 +875,7 @@ client.cache;
 client.mutate({
   update: (cache) => {
     //     ^? InMemoryCache
-  }
+  },
 });
 ```
 

--- a/docs/source/data/typescript.mdx
+++ b/docs/source/data/typescript.mdx
@@ -1067,6 +1067,7 @@ The following utility types are available to override:
 - `Complete<TData>` - Type returned when `dataState` is `"complete"`
 - `Streaming<TData>` - Type returned when `dataState` is `"streaming"` (for `@defer` queries)
 - `Partial<TData>` - Type returned when `dataState` is `"partial"`
+- `FromOptionValue<TData>` - Type used by the `from` option on cache APIs to limit the types of values that can be passed to it. Useful when you want to apply a stricter policy around what value types are accepted.
 - `AdditionalApolloLinkResultTypes<TData, TExtensions>` - Additional types that can be returned from Apollo Link operations
 
 For more information about data masking types specifically, see the [data masking guide](../data/fragments#defining-your-own-masking-types-using-higher-kinded-types).

--- a/docs/source/data/typescript.mdx
+++ b/docs/source/data/typescript.mdx
@@ -853,7 +853,7 @@ Using classic signatures after declaring `DeclareDefaultOptions` is not recommen
 
 </MinVersion>
 
-By default, `client.cache`, or any API that provides access to the cache, is typed as the generic `ApolloCache` regardless of what implementation you provide to `ApolloClient`. Declare the cache implementation used by the client by overriding the `cache` property in the `TypeOverrides` interface:
+By default, `client.cache`, as well as any API that provides access to the cache, is typed as the generic `ApolloCache` regardless of what implementation you provide to `ApolloClient`. Declare the cache implementation used by the client by overriding the `cache` property in the `TypeOverrides` interface:
 
 ```ts title="apollo.d.ts"
 import "@apollo/client";
@@ -1059,14 +1059,14 @@ And that's it! Now when `dataState` is `"complete"` or `"streaming"`, Apollo Cli
 
 The following utility types are available to override:
 
-- `cache` - The cache implementation passed to `ApolloClient` (e.g. `InMemoryCache`)
-- `FragmentType<TFragmentData>` - Type used with fragments to ensure parent objects contain the fragment spread
+- `cache` - The cache implementation passed to `ApolloClient` (for example, `InMemoryCache`)
+- `FragmentType<TFragmentData>` - The type used with fragments to ensure parent objects contain the fragment spread
 - `Unmasked<TData>` - Unwraps masked types into the full result type
-- `MaybeMasked<TData>` - Conditionally returns either masked or unmasked type
-- `Complete<TData>` - Type returned when `dataState` is `"complete"`
-- `Streaming<TData>` - Type returned when `dataState` is `"streaming"` (for `@defer` queries)
-- `Partial<TData>` - Type returned when `dataState` is `"partial"`
-- `FromOptionValue<TData>` - Type used by the `from` option on cache APIs to limit the types of values that can be passed to it. Use this when you want to apply a stricter policy around what value types are accepted.
+- `MaybeMasked<TData>` - Conditionally returns either a masked or unmasked type
+- `Complete<TData>` - The type returned when `dataState` is `"complete"`
+- `Streaming<TData>` - The type returned when `dataState` is `"streaming"` (for `@defer` queries)
+- `Partial<TData>` - The type returned when `dataState` is `"partial"`
+- `FromOptionValue<TData>` - The type used by the `from` option on cache APIs to limit the types of values that can be passed to it. Use this when you want to apply a stricter policy around what value types are accepted.
 - `AdditionalApolloLinkResultTypes<TData, TExtensions>` - Additional types that can be returned from Apollo Link operations
 
 For more information about data masking types specifically, see the [data masking guide](../data/fragments#defining-your-own-masking-types-using-higher-kinded-types).

--- a/docs/source/data/typescript.mdx
+++ b/docs/source/data/typescript.mdx
@@ -847,6 +847,45 @@ Using classic signatures after declaring `DeclareDefaultOptions` is not recommen
 
 </Caution>
 
+
+<MinVersion version="4.3">
+
+## Declaring the cache type
+
+</MinVersion>
+
+By default, `client.cache`, or any API that provides access to the cache, is typed as the generic `ApolloCache` regardless of what implementation you provide to `ApolloClient`. You can declare the cache implementation used by the client by overriding the `cache` property in the `TypeOverrides` interface:
+
+```ts title="apollo.d.ts"
+import "@apollo/client";
+import type { InMemoryCache } from '@apollo/client';
+
+declare module "@apollo/client" {
+  export interface TypeOverrides {
+    cache: InMemoryCache;
+  }
+}
+```
+
+Anywhere the cache is available, TypeScript uses the declared type:
+
+```ts
+client.cache;
+//     ^? InMemoryCache
+
+client.mutate({
+  update: (cache) => {
+    //     ^? InMemoryCache
+  }
+});
+```
+
+<Note>
+
+Setting a cache type also requires that cache type in the `ApolloClient` constructor.
+
+</Note>
+
 ## Declaring refetch event types
 
 Learn more about integrating TypeScript with refetch events in the [event-based refetching guide](./event-based-refetching#typescript).
@@ -1021,6 +1060,7 @@ And that's it! Now when `dataState` is `"complete"` or `"streaming"`, Apollo Cli
 
 The following utility types are available to override:
 
+- `cache` - The cache implementation used by `ApolloClient` (e.g. `InMemoryCache`)
 - `FragmentType<TFragmentData>` - Type used with fragments to ensure parent objects contain the fragment spread
 - `Unmasked<TData>` - Unwraps masked types into the full result type
 - `MaybeMasked<TData>` - Conditionally returns either masked or unmasked type

--- a/docs/source/data/typescript.mdx
+++ b/docs/source/data/typescript.mdx
@@ -853,7 +853,7 @@ Using classic signatures after declaring `DeclareDefaultOptions` is not recommen
 
 </MinVersion>
 
-By default, `client.cache`, or any API that provides access to the cache, is typed as the generic `ApolloCache` regardless of what implementation you provide to `ApolloClient`. You can declare the cache implementation used by the client by overriding the `cache` property in the `TypeOverrides` interface:
+By default, `client.cache`, or any API that provides access to the cache, is typed as the generic `ApolloCache` regardless of what implementation you provide to `ApolloClient`. Declare the cache implementation used by the client by overriding the `cache` property in the `TypeOverrides` interface:
 
 ```ts title="apollo.d.ts"
 import "@apollo/client";
@@ -881,7 +881,7 @@ client.mutate({
 
 <Note>
 
-Setting a cache type also requires that cache type in the `ApolloClient` constructor.
+Setting a cache type requires the same cache instance in the `ApolloClient` constructor.
 
 </Note>
 
@@ -1059,14 +1059,14 @@ And that's it! Now when `dataState` is `"complete"` or `"streaming"`, Apollo Cli
 
 The following utility types are available to override:
 
-- `cache` - The cache implementation used by `ApolloClient` (e.g. `InMemoryCache`)
+- `cache` - The cache implementation passed to `ApolloClient` (e.g. `InMemoryCache`)
 - `FragmentType<TFragmentData>` - Type used with fragments to ensure parent objects contain the fragment spread
 - `Unmasked<TData>` - Unwraps masked types into the full result type
 - `MaybeMasked<TData>` - Conditionally returns either masked or unmasked type
 - `Complete<TData>` - Type returned when `dataState` is `"complete"`
 - `Streaming<TData>` - Type returned when `dataState` is `"streaming"` (for `@defer` queries)
 - `Partial<TData>` - Type returned when `dataState` is `"partial"`
-- `FromOptionValue<TData>` - Type used by the `from` option on cache APIs to limit the types of values that can be passed to it. Useful when you want to apply a stricter policy around what value types are accepted.
+- `FromOptionValue<TData>` - Type used by the `from` option on cache APIs to limit the types of values that can be passed to it. Use this when you want to apply a stricter policy around what value types are accepted.
 - `AdditionalApolloLinkResultTypes<TData, TExtensions>` - Additional types that can be returned from Apollo Link operations
 
 For more information about data masking types specifically, see the [data masking guide](../data/fragments#defining-your-own-masking-types-using-higher-kinded-types).


### PR DESCRIPTION
Adds the necessary changes to the docs for the TypeScript changes in 4.3. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for typing deferred GraphQL fields with incremental code generation.
  * Documented how to customize generated types when deferred data is complete.
  * Added instructions for declaring the cache implementation type used by the client and cache callbacks.
  * Documented new type override options for cache values and `from` parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->