### PR TITLE
Add custom scalars documentation

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -1060,11 +1060,8 @@ type SafeReadonly<T> = T extends object ? Readonly<T> : T;
 export namespace Scalar {
     // (undocumented)
     export interface Options<TSerialized, TParsed> {
-        // (undocumented)
         is?(value: TSerialized | TParsed): boolean;
-        // (undocumented)
         parse(serializedValue: TSerialized): NoInfer<TParsed>;
-        // (undocumented)
         serialize(parsedValue: TParsed): NoInfer<TSerialized>;
     }
 }

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2974,11 +2974,8 @@ type SafeReadonly<T> = T extends object ? Readonly<T> : T;
 export namespace Scalar {
     // (undocumented)
     export interface Options<TSerialized, TParsed> {
-        // (undocumented)
         is?(value: TSerialized | TParsed): boolean;
-        // (undocumented)
         parse(serializedValue: TSerialized): NoInfer<TParsed>;
-        // (undocumented)
         serialize(parsedValue: TParsed): NoInfer<TSerialized>;
     }
 }

--- a/docs/source/_sidebar.yaml
+++ b/docs/source/_sidebar.yaml
@@ -29,6 +29,8 @@ items:
         href: ./data/typescript
       - label: Refetching
         href: ./data/refetching
+      - label: Custom scalars
+        href: ./data/custom-scalars
       - label: Event-based refetching
         href: ./data/event-based-refetching
       - label: Subscriptions

--- a/docs/source/caching/advanced-topics.mdx
+++ b/docs/source/caching/advanced-topics.mdx
@@ -16,6 +16,12 @@ const { loading, error, data } = useQuery(GET_DOGS, {
 
 Operations that use this fetch policy don't write their result to the cache, and they also don't check the cache for data before sending a request to your server. [See all available fetch policies.](../data/queries/#setting-a-fetch-policy)
 
+<Note>
+
+If you use [custom scalars](../data/custom-scalars), Apollo Client parses those scalar fields on `no-cache` operations. The `no-cache` fetch policy skips the cache, not scalar conversion.
+
+</Note>
+
 ## Persisting the cache
 
 You can persist and rehydrate the `InMemoryCache` from a storage provider like `AsyncStorage` or `localStorage`. To do so, use the [`apollo3-cache-persist`](https://github.com/apollographql/apollo-cache-persist) library. This library works with a variety of [storage providers](https://github.com/apollographql/apollo-cache-persist/blob/master/docs/storage-providers.md).

--- a/docs/source/caching/cache-configuration.mdx
+++ b/docs/source/caching/cache-configuration.mdx
@@ -127,7 +127,7 @@ Each key in the object is the `__typename` of a type to customize, and the corre
 
 A map of GraphQL scalar names to [`Scalar`](../data/custom-scalars#define-a-scalar) instances. Apollo Client uses these implementations to parse and serialize scalar values.
 
-You must [declare each scalar](../data/custom-scalars#typescript) on `ApolloCache.Scalars` before you configure it here.
+You must [declare each scalar](../data/custom-scalars#typescript) on `ApolloCache.Scalars` before you configure it.
 
 For setup instructions, see [Custom scalars](../data/custom-scalars).
 

--- a/docs/source/caching/cache-configuration.mdx
+++ b/docs/source/caching/cache-configuration.mdx
@@ -25,6 +25,7 @@ You can configure the cache's behavior to better suit your application. For exam
 
 - Customize the format of a particular type's [cache ID](#customizing-cache-ids)
 - Customize the storage and retrieval of [individual fields](./cache-field-behavior/)
+- Parse and serialize [custom scalars](../data/custom-scalars/)
 - Define polymorphic type relationships for [fragment matching](#possibletypes)
 - Define patterns for [pagination](../pagination/overview/)
 - Manage client-side [local state](../local-state/local-state-management/)
@@ -106,6 +107,50 @@ For an example, see [Defining `possibleTypes` manually](../data/fragments/#defin
 Include this object to customize the cache's behavior on a type-by-type basis.
 
 Each key in the object is the `__typename` of a type to customize, and the corresponding value is a [`TypePolicy` object](#typepolicy-fields).
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+<MinVersion version="4.3">
+
+###### `scalars`
+
+</MinVersion>
+
+`Object`
+
+</td>
+<td>
+
+A map of GraphQL scalar names to [`Scalar`](../data/custom-scalars#define-a-scalar) instances. Apollo Client uses these implementations to parse and serialize scalar values.
+
+You must [declare each scalar](../data/custom-scalars#typescript) on `ApolloCache.Scalars` before you configure it here.
+
+For setup instructions, see [Custom scalars](../data/custom-scalars).
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+<MinVersion version="4.3">
+
+###### `inputObjects`
+
+</MinVersion>
+
+`Object`
+
+</td>
+<td>
+
+A map that tells the cache which nested fields of input object types contain custom scalars (or other input objects). Apollo Client uses this map to serialize those fields in operation variables.
+
+For setup instructions, see [Variable serialization](../data/custom-scalars#variable-serialization).
 
 </td>
 </tr>

--- a/docs/source/caching/cache-configuration.mdx
+++ b/docs/source/caching/cache-configuration.mdx
@@ -129,7 +129,7 @@ A map of GraphQL scalar names to [`Scalar`](../data/custom-scalars#define-a-scal
 
 You must [declare each scalar](../data/custom-scalars#typescript) on `ApolloCache.Scalars` before you configure the `scalars` option.
 
-For setup instructions, see [Custom scalars](../data/custom-scalars).
+For setup instructions, go to [Custom scalars](../data/custom-scalars).
 
 </td>
 </tr>
@@ -148,9 +148,9 @@ For setup instructions, see [Custom scalars](../data/custom-scalars).
 </td>
 <td>
 
-A map that tells the cache which nested fields of input object types contain custom scalars (or other input objects). Apollo Client uses this map to serialize those fields in operation variables.
+A map that tells the cache what nested fields of input object types contain custom scalars (or other input objects). Apollo Client uses this map to serialize those fields in operation variables.
 
-For setup instructions, see [Variable serialization](../data/custom-scalars#variable-serialization).
+For setup instructions, go to [Variable serialization](../data/custom-scalars#variable-serialization).
 
 </td>
 </tr>

--- a/docs/source/caching/cache-configuration.mdx
+++ b/docs/source/caching/cache-configuration.mdx
@@ -127,7 +127,7 @@ Each key in the object is the `__typename` of a type to customize, and the corre
 
 A map of GraphQL scalar names to [`Scalar`](../data/custom-scalars#define-a-scalar) instances. Apollo Client uses these implementations to parse and serialize scalar values.
 
-You must [declare each scalar](../data/custom-scalars#typescript) on `ApolloCache.Scalars` before you configure it.
+You must [declare each scalar](../data/custom-scalars#typescript) on `ApolloCache.Scalars` before you configure the `scalars` option.
 
 For setup instructions, see [Custom scalars](../data/custom-scalars).
 

--- a/docs/source/caching/cache-field-behavior.mdx
+++ b/docs/source/caching/cache-field-behavior.mdx
@@ -6,7 +6,7 @@ You can customize how a particular field in your Apollo Client cache is read and
 
 - A [`read` function](#the-read-function) that specifies what happens when the field's cached value is read
 - A [`merge` function](#the-merge-function) that specifies what happens when field's cached value is written
-- A [`scalar`](#the-scalar-option) that tells the cache which custom GraphQL scalar to use when it parses or serializes the field
+- A [`scalar`](#the-scalar-option) that tells the cache what custom GraphQL scalar to use when it parses or serializes the field
 - An array of [key arguments](#specifying-key-arguments) that help the cache avoid storing unnecessary duplicate data.
 
 You provide field policies to the constructor of `InMemoryCache`. Each field policy is defined inside whichever [`TypePolicy` object](./cache-configuration/#typepolicy-fields) corresponds to the field's parent type.
@@ -666,7 +666,7 @@ For details, see `KeyArgsFunction` in the [API reference](#fieldpolicy-api-refer
 
 </MinVersion>
 
-Set `scalar` to tell the cache which [custom scalar](../data/custom-scalars) to use when it parses or serializes the field.
+Set `scalar` to tell the cache what [custom scalar](../data/custom-scalars) to use when parsing or serializing the field.
 
 ```ts
 import { Scalar } from "@apollo/client";

--- a/docs/source/caching/cache-field-behavior.mdx
+++ b/docs/source/caching/cache-field-behavior.mdx
@@ -6,6 +6,7 @@ You can customize how a particular field in your Apollo Client cache is read and
 
 - A [`read` function](#the-read-function) that specifies what happens when the field's cached value is read
 - A [`merge` function](#the-merge-function) that specifies what happens when field's cached value is written
+- A [`scalar`](#the-scalar-option) that tells the cache which custom GraphQL scalar to use when it parses or serializes the field
 - An array of [key arguments](#specifying-key-arguments) that help the cache avoid storing unnecessary duplicate data.
 
 You provide field policies to the constructor of `InMemoryCache`. Each field policy is defined inside whichever [`TypePolicy` object](./cache-configuration/#typepolicy-fields) corresponds to the field's parent type.
@@ -659,6 +660,51 @@ If you need more control over a particular field's `keyArgs`, you can pass a fun
 
 For details, see `KeyArgsFunction` in the [API reference](#fieldpolicy-api-reference) below.
 
+<MinVersion version="4.3">
+
+## The `scalar` option
+
+</MinVersion>
+
+Set `scalar` to tell the cache which [custom scalar](../data/custom-scalars) to use when it parses or serializes the field.
+
+```ts
+import { Scalar } from "@apollo/client";
+
+const cache = new InMemoryCache({
+  scalars: {
+    DateTime: new Scalar({
+      parse: (dateString) => new Date(dateString),
+      serialize: (date) => date.toISOString(),
+      is: (value) => value instanceof Date,
+    }),
+  },
+  typePolicies: {
+    Event: {
+      fields: {
+        startTime: {
+          scalar: "DateTime",
+        },
+      },
+    },
+  },
+});
+```
+
+Apollo Client uses that scalar for cache reads and writes.
+
+<Caution>
+
+If a field policy sets `scalar`, Apollo Client ignores `read` and `merge` functions on that field and emits a development-only warning.
+
+</Caution>
+
+<Tip>
+
+You can generate `scalar` field policies from your schema with the [`@apollo/client-graphql-codegen/custom-scalars`](../data/custom-scalars#generate-scalar-configuration) plugin.
+
+</Tip>
+
 ## `FieldPolicy` API reference
 
 Here are the definitions for the `FieldPolicy` type and its related types:
@@ -670,6 +716,7 @@ type FieldPolicy<TExisting, TIncoming = TExisting, TReadResult = TExisting> = {
   keyArgs?: KeySpecifier | KeyArgsFunction | false;
   read?: FieldReadFunction<TExisting, TReadResult>;
   merge?: FieldMergeFunction<TExisting, TIncoming> | boolean;
+  scalar?: string;
 };
 
 type KeySpecifier = (string | KeySpecifier)[];

--- a/docs/source/data/custom-scalars.mdx
+++ b/docs/source/data/custom-scalars.mdx
@@ -6,7 +6,7 @@ minVersion: 4.3
 
 {/* @import {MDXProvidedComponents} from '../../shared/MdxProvidedComponents.js' */}
 
-GraphQL schemas often define custom scalar types to add semantic meaning for fields in the schema. For example, a schema might define a custom `DateTime` scalar to use for a `createdAt` field rather than declaring it as a `String` type. Apollo Client can use these custom scalars to enable you to perform your own data transformations into more suitable runtime values.
+GraphQL schemas often define custom scalar types to add semantic meaning to a field that a built-in type can't convey. For example, a `createdAt` field might be defined as a `DateTime` scalar instead of a `String`. Apollo Client can parse those values into types that are easier to work with in your application, such as `Date` objects.
 
 This guide walks through using custom scalars in your own applications.
 
@@ -35,18 +35,15 @@ const dateTimeScalar = new Scalar<string, Date>({
 
 The `is` function determines whether a value is in its parsed or serialized form. Apollo Client uses this method to coerce values as needed during the lifetime of your application. When `is` returns `true`, Apollo Client treats the value as the parsed type. When `is` returns `false`, Apollo Client treats the value as the serialized type.
 
-If you omit `is`, Apollo Client treats any non-null object as a parsed value:
+<Note>
 
-```ts
-// Default `is` implementation
-typeof value === "object" && value !== null;
-```
+If you omit `is`, Apollo Client treats any non-null object as a parsed value. That default might be enough, but it is typically better to pass your own `is`.
+
+</Note>
 
 ### Create a `Scalar` from a GraphQL.js `GraphQLScalarType`
 
 If you have a [`GraphQLScalarType`](https://graphql.org/graphql-js/type/#graphqlscalartype) instance from `graphql`, you can use it to create an Apollo Client compatible `Scalar` using `Scalar.fromGraphQLScalarType`. Apollo Client uses `parseValue` and `serialize` from the GraphQL.js scalar.
-
-Provide `is` since GraphQL.js scalars don't include an equivalent check:
 
 ```ts
 import { GraphQLScalarType } from "graphql";
@@ -75,38 +72,41 @@ const dateTimeScalar = Scalar.fromGraphQLScalarType(GraphQLDateTimeISO, {
 
 <Note>
 
-`graphql-scalars` is a package published primarily for GraphQL servers. Check that the scalars you use are compatible with your environment and provide the transforms you need.
+`graphql-scalars` is published primarily for GraphQL servers, but you can use it on the client. Some scalars may depend on Node APIs. Use only scalars that work in your environment, such as the browser or React Native.
 
 </Note>
 
 ## Configure the cache
 
-Scalars are passed to `InMemoryCache` via the `scalars` option. Map each `Scalar` instance to the name associated with the scalar definition:
+Pass your `Scalar` instances to the `scalars` option on `InMemoryCache`. Map each instance to the name of the scalar in your schema:
 
 ```ts
 new InMemoryCache({
   scalars: {
     DateTime: dateTimeScalar,
     URL: urlScalar,
-    // etc
+    // ...
   },
 });
 ```
 
+The `scalars` option registers the implementations. You still need to tell the cache which fields and input object fields use those scalars.
+
 <Note>
 
-To provide type safety, please see the [TypeScript](#typescript) section to learn how to declare custom scalar types.
+To type-check this configuration, see the [TypeScript](#typescript) section to declare your custom scalar types.
 
 </Note>
 
 ### Map fields to scalars
 
-Passing `scalars` to `InMemoryCache` isn't enough for the cache to know which fields should be associated with the scalars because `InMemoryCache` has no schema knowledge. Set the `scalar` property for a field policy to tell the cache how to associate the field to the scalar type:
+Passing `scalars` to `InMemoryCache` isn't enough for the cache to know which fields should be associated with the scalars because `InMemoryCache` has no schema knowledge. Set the `scalar` property on a field policy to associate the field with the scalar type:
 
 ```ts
 new InMemoryCache({
   scalars: {
-    // ...
+    DateTime: dateTimeScalar,
+    URL: urlScalar,
   },
   typePolicies: {
     Event: {
@@ -132,9 +132,9 @@ If a field policy sets `scalar`, Apollo Client ignores `read` and `merge` functi
 
 </Caution>
 
-Each field associated with a custom scalar needs a field policy with a `scalar` property. If you want to avoid writing these by hand, see the [generate scalar configuration](#generate-scalar-configuration) section to learn how you can generate this configuration automatically from your schema.
+Each field associated with a custom scalar needs a field policy with a `scalar` property. If you want to avoid writing these by hand, see the [generate scalar configuration](#generate-scalar-configuration) section to generate this configuration from your schema.
 
-With the field policies in place, querying these fields returns the parsed values:
+With the field policies in place, query, mutation, and subscription results return parsed values for mapped fields.
 
 ```ts
 const QUERY = gql`
@@ -149,16 +149,16 @@ const QUERY = gql`
   }
 `;
 
-// ...
-
 const { data } = useQuery(QUERY, { variables: { id } });
-
-data.event.siteLink;
-//         ^? URL
-data.event.createdAt;
-//         ^? Date
-data.event.updatedAt;
-//         ^? Date
+// => {
+//   event: {
+//     id: "1",
+//     name: "GraphQL Conf",
+//     siteLink: URL,
+//     createdAt: Date,
+//     updatedAt: Date,
+//   },
+// }
 
 const MUTATION = gql`
   mutation CreateEvent($input: CreateEventInput!) {
@@ -175,27 +175,38 @@ const { data } = client.mutate({
     /*...*/
   },
 });
-
-data.createEvent.createdAt;
-//               ^? Date
+// => {
+//   createEvent: {
+//     id: "1",
+//     createdAt: Date,
+//   },
+// }
 ```
 
-Parsed scalar values are also returned by cache read APIs, such as `readQuery`:
+<Note>
+
+Even though scalar configuration is defined in the cache, you can safely use `no-cache` fetch policies. Apollo Client converts scalar fields before returning the result.
+
+</Note>
+
+Cache read and write APIs also use parsed values, including `readQuery`, `readFragment`, `writeQuery`, and `writeFragment`:
 
 ```ts
 const data = client.readQuery({ query: QUERY, variables: { id } });
-
-data.event.siteLink;
-//         ^? URL
-data.event.createdAt;
-//         ^? Date
-data.event.updatedAt;
-//         ^? Date
+// => {
+//   event: {
+//     id: "1",
+//     name: "GraphQL Conf",
+//     siteLink: URL,
+//     createdAt: Date,
+//     updatedAt: Date,
+//   },
+// }
 ```
 
 ## Variable serialization
 
-Along with scalar parsing, Apollo Client also performs variable serialization to parsed scalar values provided to `variables`. This allows you to pass parsed values as valid `variables` values:
+Apollo Client serializes parsed scalar values in `variables` before it sends the request to your server and before it reads or writes the cache with those variables. You can pass parsed values in any API that accepts a `variables` option:
 
 ```ts
 const QUERY = gql`
@@ -208,7 +219,18 @@ const QUERY = gql`
 `;
 
 const { data } = useQuery(QUERY, {
-  variables: { date: new Date("2026-01-01T00:00:00.00Z") },
+  variables: { date: new Date("2026-01-01T00:00:00.000Z") },
+});
+
+// The link receives `{ date: "2026-01-01T00:00:00.000Z" }`
+```
+
+Cache APIs that take `variables` serialize them the same way:
+
+```ts
+client.readQuery({
+  query: QUERY,
+  variables: { date: new Date("2026-01-01T00:00:00.000Z") },
 });
 
 client.writeQuery({
@@ -216,15 +238,15 @@ client.writeQuery({
   data: {
     /* ... */
   },
-  variables: { date: new Date("2026-01-01T00:00:00.00Z") },
+  variables: { date: new Date("2026-01-01T00:00:00.000Z") },
 });
 ```
 
-Apollo Client infers the type of the `date` variable as a `DateTime` scalar from its variable definition and calls the appropriate `serialize` function on the configured `DateTime` scalar.
+Apollo Client reads the GraphQL type from the variable definition (`$date: DateTime!`) and calls `serialize` on the configured `DateTime` scalar.
 
 ### Input objects
 
-Custom scalars might be used by input objects to represent more complex inputs. Input objects make it more difficult for Apollo Client to infer custom scalars from the variable definition alone. For example, the following query has a `$dateRange` variable that is defined as a `DateRangeFilter` type:
+Input objects can contain custom scalar fields. Those nested fields are not visible from the variable definition alone. For example, the following query has a `$dateRange` variable of type `DateRangeFilter`:
 
 ```graphql
 query GetEventsInRange($dateRange: DateRangeFilter!) {
@@ -235,7 +257,7 @@ query GetEventsInRange($dateRange: DateRangeFilter!) {
 }
 ```
 
-To perform serialization for custom scalars in input objects, `InMemoryCache` needs additional configuration to map input object types to custom scalars. Pass an `inputObjects` option to map the input object's fields to the associated custom scalar type:
+To serialize custom scalars in input objects, pass an `inputObjects` option that maps each input object's fields to the associated custom scalar type:
 
 ```ts
 new InMemoryCache({
@@ -250,7 +272,7 @@ new InMemoryCache({
 });
 ```
 
-Now you can safely pass parsed scalar values to `variables`:
+You can then pass parsed scalar values in `variables`:
 
 ```ts
 const QUERY = gql`
@@ -265,8 +287,8 @@ const QUERY = gql`
 const { data } = useQuery(QUERY, {
   variables: {
     dateRange: {
-      start: new Date("2026-01-01T00:00:00.00Z"),
-      end: new Date("2026-02-01T00:00:00.00Z"),
+      start: new Date("2026-01-01T00:00:00.000Z"),
+      end: new Date("2026-02-01T00:00:00.000Z"),
     },
   },
 });
@@ -274,7 +296,7 @@ const { data } = useQuery(QUERY, {
 
 #### Deeply nested input objects
 
-Input objects might be composed of other input objects which map their own custom scalars. When the input object is more than one level deep, pass the name of the input object for the field that references it:
+Input objects can contain other input objects that map their own custom scalars. When the input object is more than one level deep, pass the name of the nested input object for the field that references it:
 
 ```ts
 new InMemoryCache({
@@ -299,7 +321,7 @@ new InMemoryCache({
 });
 ```
 
-Now you can safely pass parsed scalar values to `variables`:
+You can then pass parsed scalar values in `variables`:
 
 ```ts
 const QUERY = gql`
@@ -322,14 +344,14 @@ const { data } = useQuery(QUERY, {
   variables: {
     eventFilter: {
       dateRange: {
-        start: new Date("2026-01-01T00:00:00.00Z"),
-        end: new Date("2026-02-01T00:00:00.00Z"),
+        start: new Date("2026-01-01T00:00:00.000Z"),
+        end: new Date("2026-02-01T00:00:00.000Z"),
       },
     },
     conferenceFilter: {
       when: {
-        start: new Date("2026-01-01T00:00:00.00Z"),
-        end: new Date("2026-02-01T00:00:00.00Z"),
+        start: new Date("2026-01-01T00:00:00.000Z"),
+        end: new Date("2026-02-01T00:00:00.000Z"),
       },
     },
   },
@@ -338,25 +360,146 @@ const { data } = useQuery(QUERY, {
 
 <Tip>
 
-Instead of generating this configuration by hand, you can automatically generate it with GraphQL Codegen. See the [generate scalar configuration](#generate-scalar-configuration) section to learn how to generate the configuration for you.
+Instead of writing this configuration by hand, you can generate it with GraphQL Codegen. See the [generate scalar configuration](#generate-scalar-configuration) section.
 
 </Tip>
 
+## Convert values outside of Apollo Client
+
+Sometimes you need to convert a value with a `Scalar` you already configured. You can access the scalar instance with `cache.getScalar()`, which takes a key that matches a scalar you passed to the `scalars` option and returns the `Scalar` instance that matches that name.
+
+Use it when you have a raw value from outside Apollo Client that you want to transform with that `Scalar`. For example, a query param:
+
+```ts
+const dateTime = client.cache.getScalar("DateTime");
+
+const start = dateTime.parse(searchParams.get("start"));
+
+url.searchParams.set("start", dateTime.serialize(event.createdAt));
+```
+
+<Note>
+
+You do not need `cache.getScalar()` for values provided to Apollo Client APIs. Apollo Client already parses or serializes scalar values as needed.
+
+</Note>
+
+### Coerce parsed and serialized values
+
+If you aren't sure whether a value is parsed or serialized, use `coerceToParsed` or `coerceToSerialized`. These methods use `is` to check the form of the value, then parse or serialize only when needed.
+
+```ts
+function formatDate(date: string | Date) {
+  const dateTimeScalar = client.cache.getScalar("DateTime");
+
+  return dateTimeScalar.coerceToParsed(date).toLocaleDateString();
+}
+```
+
+## A note about server-side rendering
+
+Custom scalars are safe to use with [server-side rendering](../performance/server-side-rendering). `cache.extract()` serializes parsed values to JSON so you can send the cache to the client. `cache.restore()` parses those values again, so both the server and the client keep working with the parsed types.
+
+```ts
+// On the server
+const initialState = cache.extract();
+// => {
+//   ROOT_QUERY: {
+//     __typename: "Query",
+//     event: { __ref: "Event:1" },
+//   },
+//   "Event:1": {
+//     __typename: "Event",
+//     id: "1",
+//     name: "GraphQL Conf",
+//     siteLink: "https://graphqlconf.org/",
+//     createdAt: "2026-01-01T00:00:00.000Z",
+//     updatedAt: "2026-01-01T00:00:00.000Z",
+//   },
+// }
+
+// On the client
+new InMemoryCache({
+  scalars: {
+    DateTime: dateTimeScalar,
+    URL: urlScalar,
+  },
+}).restore(initialState);
+```
+
+## TypeScript
+
+Register custom scalars with TypeScript to add type safety for the `scalars` option on `InMemoryCache` and the `cache.getScalar()` API. Declare your custom scalars using TypeScript's [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) with the `ApolloCache.Scalars` interface.
+
+```ts title="apollo.d.ts"
+// This import is necessary to ensure all Apollo Client imports
+// are still available to the rest of the application.
+import "@apollo/client";
+
+declare module "@apollo/client" {
+  namespace ApolloCache {
+    interface Scalars {
+      DateTime: { serialized: string; parsed: Date };
+    }
+  }
+}
+```
+
+<Note>
+
+You don't need to declare built-in GraphQL scalars such as `String`, `Int`, `Float`, `Boolean`, or `ID`. Apollo Client already handles those types.
+
+</Note>
+
+TypeScript checks the `scalars` option when you create `InMemoryCache`:
+
+```ts
+// ❌ invalid: missing `scalars` option
+new InMemoryCache();
+// ❌ invalid: missing `DateTime` scalar
+new InMemoryCache({ scalars: {} });
+
+new InMemoryCache({
+  scalars: {
+    // ❌ invalid: unknown scalar "Unknown"
+    Unknown: new Scalar(/*...*/),
+
+    // ❌ invalid: Scalar<number, string> not assignable to Scalar<string, Date>
+    DateTime: new Scalar<number, string>(/*...*/),
+
+    // ✅ valid
+    DateTime: new Scalar<string, Date>(/*...*/),
+  },
+});
+```
+
+<Note>
+
+When `serialized` and `parsed` are the same type, the entry in `scalars` is optional. For example, a `Year` scalar might define both the `parsed` and `serialized` types as a `number`. In that case, your app doesn't need a `Scalar` instance for it.
+
+</Note>
+
+<Note>
+
+This declaration types the `scalars` option on `InMemoryCache`. It doesn't affect the types set for scalar fields returned by operation `data`. See the [Generate scalar configuration](#generate-scalar-configuration) section for more information.
+
+</Note>
+
 ## Generate scalar configuration
 
-Writing a field policy or input object entry for every custom scalar field is tedious and error prone. Use the `@apollo/client-graphql-codegen/custom-scalars` plugin to automatically generate the type policies and input objects configuration from your schema.
+Writing a field policy or input object entry for every custom scalar field is tedious and error prone. Use the `@apollo/client-graphql-codegen/custom-scalars` plugin to generate the type policies and input objects configuration from your schema.
 
 ### Installation
 
 Install the Apollo Client GraphQL Codegen package:
 
 ```sh showLineNumbers=false
-npm install @apollo/client-graphql-codegen
+npm install -D @apollo/client-graphql-codegen
 ```
 
 <Tip>
 
-Please see the [GraphQL Codegen](../development-testing/graphql-codegen) guide to learn how to use GraphQL Codegen with Apollo Client if you don't have it set up.
+See the [GraphQL Codegen](../development-testing/graphql-codegen) guide to learn how to use GraphQL Codegen with Apollo Client if you don't have it set up.
 
 </Tip>
 
@@ -384,19 +527,54 @@ const config: CodegenConfig = {
 export default config;
 ```
 
-To make sure the operation types are created using the parsed scalar type, provide a `scalars` mapping to the configuration that creates your operation types:
+The generated file exports `inputObjects` and `scalarTypePolicies`.
+
+<details>
+<summary>Example generated file</summary>
 
 ```ts
+import type { InputObjectsOption, TypePolicies } from "@apollo/client/cache";
+
+export const inputObjects: InputObjectsOption = {
+  DateRangeFilter: {
+    fields: {
+      start: "DateTime",
+      end: "DateTime",
+    },
+  },
+};
+
+export const scalarTypePolicies: TypePolicies = {
+  Event: {
+    fields: {
+      createdAt: {
+        scalar: "DateTime",
+      },
+      updatedAt: {
+        scalar: "DateTime",
+      },
+      siteLink: {
+        scalar: "URL",
+      },
+    },
+  },
+};
+```
+
+</details>
+<br/>
+
+This plugin generates cache configuration only. It does not change the TypeScript types for your operations. To type operation results as parsed values, add a `scalars` mapping to the configuration that creates your operation types:
+
+```ts title="codegen.ts"
 const config: CodegenConfig = {
-  // ... your existing configuration
   generates: {
-    // ... your existing configuration
     "./src/types/__generated__/graphql.ts": {
       plugins: ["typescript-operations"],
       config: {
         scalars: {
           DateTime: "Date",
-          // ... other scalars
+          URL: "URL",
         },
         // ...other options
       },
@@ -405,9 +583,11 @@ const config: CodegenConfig = {
 };
 ```
 
+See the [GraphQL Codegen scalars documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#scalars) for more information.
+
 ### Configure `InMemoryCache` from codegen
 
-Once the custom scalars file is generated, import the `inputObjects` and `scalarTypePolicies` objects from the generated file and pass them to `InMemoryCache`.
+Import the generated `inputObjects` and `scalarTypePolicies` objects and pass them to `InMemoryCache`.
 
 ```ts
 import {
@@ -417,7 +597,8 @@ import {
 
 const cache = new InMemoryCache({
   scalars: {
-    /* ... */
+    DateTime: dateTimeScalar,
+    URL: urlScalar,
   },
   inputObjects,
 });
@@ -427,13 +608,13 @@ cache.policies.addTypePolicies(scalarTypePolicies);
 
 <Tip>
 
-We recommend passing `scalarTypePolicies` to `cache.policies.addTypePolicies()` which deep merges the scalar configuration with your existing `typePolicies` for you.
+We recommend passing `scalarTypePolicies` to `cache.policies.addTypePolicies()`, which merges the generated `scalar` options with any other field policies you define, such as `keyArgs` or `keyFields`.
 
 </Tip>
 
 ### Plugin options
 
-The GraphQL Codegen plugin accepts the following options:
+By default, the plugin includes only custom scalar fields and input objects that your GraphQL documents use. You can change this behavior with the following plugin options:
 
 <table class="field-table api-ref">
   <thead>
@@ -496,59 +677,8 @@ This option is mutually exclusive with `includeScalars`.
 </tbody>
 </table>
 
-## TypeScript
+## See also
 
-Register custom scalars with TypeScript to provide type safety for scalar APIs. Declare your custom scalars using TypeScript's [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) with the `ApolloCache.Scalars` interface.
-
-```ts title="apollo.d.ts"
-import "@apollo/client";
-
-declare module "@apollo/client" {
-  namespace ApolloCache {
-    interface Scalars {
-      DateTime: { serialized: string; parsed: Date };
-    }
-  }
-}
-```
-
-By providing this declaration, you add type safety when initializing `InMemoryCache` to ensure:
-
-- `InMemoryCache` is initialized with a `Scalar` instance for each declared scalar to avoid runtime mismatches
-- Each `Scalar` instance matches its declared type in `ApolloCache.Scalars`
-
-```ts
-// ❌ invalid: missing `scalars` option
-new InMemoryCache();
-// ❌ invalid: missing `DateTime` scalar
-new InMemoryCache({ scalars: {} });
-
-new InMemoryCache({
-  scalars: {
-    // ❌ invalid: unknown scalar "Unknown"
-    Unknown: new Scalar(/*...*/),
-
-    // ❌ invalid: Scalar<number, string> not assignable to Scalar<string, Date>
-    DateTime: new Scalar<number, string>(/*...*/),
-
-    // ✅ valid
-    DateTime: new Scalar<string, Date>(/*...*/),
-  },
-});
-```
-
-<Note>
-
-When you declare custom scalars with the same `serialized` and `parsed` types, the scalar instance provided to the `scalars` option becomes optional because it is considered type safe.
-
-</Note>
-
-The type declarations also drive the scalars available to the `cache.getScalar(...)` API, which returns the `Scalar` instance assigned for a given name.
-
-```ts
-const dateTimeScalar = cache.getScalar("DateTime");
-//    ^? Scalar<string, Date>;
-
-const unknownScalar = cache.getScalar("Unknown");
-// ❌ invalid "Unknown" key
-```
+- [TypeScript with Apollo Client](./typescript#declaring-custom-scalar-types)
+- [Customizing field behavior](../caching/cache-field-behavior)
+- [GraphQL Codegen](../development-testing/graphql-codegen#custom-scalars)

--- a/docs/source/data/custom-scalars.mdx
+++ b/docs/source/data/custom-scalars.mdx
@@ -10,7 +10,7 @@ GraphQL schemas often define custom scalar types to add semantic meaning for fie
 
 This guide walks through using custom scalars in your own applications.
 
-## Define a custom scalar
+## Define a `Scalar`
 
 Define custom scalars with the `Scalar` class. A `Scalar` describes how to convert a value between the JSON serialized value and the parsed value:
 
@@ -31,11 +31,16 @@ const dateTimeScalar = new Scalar<string, Date>({
   idPrefix="scalaroptions-interface"
 />
 
-<Note>
+### The `is` function
 
-`is` provides a default implementation that returns `true` when the value is a non-null object.
+The `is` function determines whether a value is in its parsed or serialized form. Apollo Client uses this method to coerce values as needed during the lifetime of your application. When `is` returns `true`, Apollo Client treats the value as the parsed type. When `is` returns `false`, Apollo Client treats the value as the serialized type.
 
-</Note>
+If you omit `is`, Apollo Client treats any non-null object as a parsed value:
+
+```ts
+// Default `is` implementation
+typeof value === "object" && value !== null;
+```
 
 ### Create a `Scalar` from a GraphQL.js `GraphQLScalarType`
 

--- a/docs/source/data/custom-scalars.mdx
+++ b/docs/source/data/custom-scalars.mdx
@@ -44,17 +44,26 @@ typeof value === "object" && value !== null;
 
 ### Create a `Scalar` from a GraphQL.js `GraphQLScalarType`
 
-If you have a [`GraphQLScalarType`](https://www.graphql-js.org/api-v16/type/#graphqlscalartype) from `graphql`, you can create an Apollo Client compatible `Scalar` instance from it with `Scalar.fromGraphQLScalarType`:
+If you have a [`GraphQLScalarType`](https://graphql.org/graphql-js/type/#graphqlscalartype) instance from `graphql`, you can use it to create an Apollo Client compatible `Scalar` using `Scalar.fromGraphQLScalarType`. Apollo Client uses `parseValue` and `serialize` from the GraphQL.js scalar.
+
+Provide `is` since GraphQL.js scalars don't include an equivalent check:
 
 ```ts
-const dateTime = new GraphQLScalarType(/*...*/);
+import { GraphQLScalarType } from "graphql";
+import { Scalar } from "@apollo/client";
+
+const dateTime = new GraphQLScalarType({
+  name: "DateTime",
+  parseValue: (value) => new Date(value),
+  serialize: (value) => value.toISOString(),
+});
 
 const dateTimeScalar = Scalar.fromGraphQLScalarType(dateTime, {
   is: (value) => value instanceof Date,
 });
 ```
 
-This is most useful when you want to use scalar types from shared NPM packages such as [`graphql-scalars`](https://the-guild.dev/graphql/scalars) which provide many useful scalar implementations out of the box:
+This is most useful when you want to use scalar types from shared NPM packages such as [`graphql-scalars`](https://the-guild.dev/graphql/scalars), which provide many useful scalar implementations out of the box:
 
 ```ts
 import { GraphQLDateTimeISO } from "graphql-scalars";
@@ -66,7 +75,7 @@ const dateTimeScalar = Scalar.fromGraphQLScalarType(GraphQLDateTimeISO, {
 
 <Note>
 
-`graphql-scalars` is a package published primarily for GraphQL servers. Please check to make sure the scalars you use are compatible with your environment and provide the right transforms for your needs.
+`graphql-scalars` is a package published primarily for GraphQL servers. Check that the scalars you use are compatible with your environment and provide the transforms you need.
 
 </Note>
 

--- a/docs/source/data/custom-scalars.mdx
+++ b/docs/source/data/custom-scalars.mdx
@@ -1,0 +1,540 @@
+---
+title: Custom scalars
+description: Parse and serialize GraphQL scalar values in Apollo Client
+minVersion: 4.3
+---
+
+{/* @import {MDXProvidedComponents} from '../../shared/MdxProvidedComponents.js' */}
+
+GraphQL schemas often define custom scalar types to add semantic meaning for fields in the schema. For example, a schema might define a custom `DateTime` scalar to use for a `createdAt` field rather than declaring it as a `String` type. Apollo Client can use these custom scalars to enable you to perform your own data transformations into more suitable runtime values.
+
+This guide walks through using custom scalars in your own applications.
+
+## Define a custom scalar
+
+Define custom scalars with the `Scalar` class. A `Scalar` describes how to convert a value between the JSON serialized value and the parsed value:
+
+```ts
+import { Scalar } from "@apollo/client";
+
+const dateTimeScalar = new Scalar<string, Date>({
+  parse: (dateString) => new Date(dateString),
+  serialize: (date) => date.toISOString(),
+  is: (value) => value instanceof Date,
+});
+```
+
+`Scalar` accepts the following options:
+
+<PropertySignatureTable
+  canonicalReference="@apollo/client/cache!Scalar.Options:interface"
+  idPrefix="scalaroptions-interface"
+/>
+
+<Note>
+
+`is` provides a default implementation that returns `true` when the value is a non-null object.
+
+</Note>
+
+### Create a `Scalar` from a GraphQL.js `GraphQLScalarType`
+
+If you have a [`GraphQLScalarType`](https://www.graphql-js.org/api-v16/type/#graphqlscalartype) from `graphql`, you can create an Apollo Client compatible `Scalar` instance from it with `Scalar.fromGraphQLScalarType`:
+
+```ts
+const dateTime = new GraphQLScalarType(/*...*/);
+
+const dateTimeScalar = Scalar.fromGraphQLScalarType(dateTime, {
+  is: (value) => value instanceof Date,
+});
+```
+
+This is most useful when you want to use scalar types from shared NPM packages such as [`graphql-scalars`](https://the-guild.dev/graphql/scalars) which provide many useful scalar implementations out of the box:
+
+```ts
+import { GraphQLDateTimeISO } from "graphql-scalars";
+
+const dateTimeScalar = Scalar.fromGraphQLScalarType(GraphQLDateTimeISO, {
+  is: (value) => value instanceof Date,
+});
+```
+
+<Note>
+
+`graphql-scalars` is a package published primarily for GraphQL servers. Please check to make sure the scalars you use are compatible with your environment and provide the right transforms for your needs.
+
+</Note>
+
+## Configure the cache
+
+Scalars are passed to `InMemoryCache` via the `scalars` option. Map each `Scalar` instance to the name associated with the scalar definition:
+
+```ts
+new InMemoryCache({
+  scalars: {
+    DateTime: dateTimeScalar,
+    URL: urlScalar,
+    // etc
+  },
+});
+```
+
+<Note>
+
+To provide type safety, please see the [TypeScript](#typescript) section to learn how to declare custom scalar types.
+
+</Note>
+
+### Map fields to scalars
+
+Passing `scalars` to `InMemoryCache` isn't enough for the cache to know which fields should be associated with the scalars because `InMemoryCache` has no schema knowledge. Set the `scalar` property for a field policy to tell the cache how to associate the field to the scalar type:
+
+```ts
+new InMemoryCache({
+  scalars: {
+    // ...
+  },
+  typePolicies: {
+    Event: {
+      fields: {
+        createdAt: {
+          scalar: "DateTime",
+        },
+        updatedAt: {
+          scalar: "DateTime",
+        },
+        siteLink: {
+          scalar: "URL",
+        },
+      },
+    },
+  },
+});
+```
+
+<Caution>
+
+If a field policy sets `scalar`, Apollo Client ignores `read` and `merge` functions on that field and emits a development-only warning.
+
+</Caution>
+
+Each field associated with a custom scalar needs a field policy with a `scalar` property. If you want to avoid writing these by hand, see the [generate scalar configuration](#generate-scalar-configuration) section to learn how you can generate this configuration automatically from your schema.
+
+With the field policies in place, querying these fields returns the parsed values:
+
+```ts
+const QUERY = gql`
+  query GetEvent($id: ID!) {
+    event(id: $id) {
+      id
+      name
+      siteLink
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+// ...
+
+const { data } = useQuery(QUERY, { variables: { id } });
+
+data.event.siteLink;
+//         ^? URL
+data.event.createdAt;
+//         ^? Date
+data.event.updatedAt;
+//         ^? Date
+
+const MUTATION = gql`
+  mutation CreateEvent($input: CreateEventInput!) {
+    createEvent(input: $input) {
+      id
+      createdAt
+    }
+  }
+`;
+
+const { data } = client.mutate({
+  mutation: MUTATION,
+  variables: {
+    /*...*/
+  },
+});
+
+data.createEvent.createdAt;
+//               ^? Date
+```
+
+Parsed scalar values are also returned by cache read APIs, such as `readQuery`:
+
+```ts
+const data = client.readQuery({ query: QUERY, variables: { id } });
+
+data.event.siteLink;
+//         ^? URL
+data.event.createdAt;
+//         ^? Date
+data.event.updatedAt;
+//         ^? Date
+```
+
+## Variable serialization
+
+Along with scalar parsing, Apollo Client also performs variable serialization to parsed scalar values provided to `variables`. This allows you to pass parsed values as valid `variables` values:
+
+```ts
+const QUERY = gql`
+  query GetEventsOnDate($date: DateTime!) {
+    events(on: $date) {
+      id
+      name
+    }
+  }
+`;
+
+const { data } = useQuery(QUERY, {
+  variables: { date: new Date("2026-01-01T00:00:00.00Z") },
+});
+
+client.writeQuery({
+  query: QUERY,
+  data: {
+    /* ... */
+  },
+  variables: { date: new Date("2026-01-01T00:00:00.00Z") },
+});
+```
+
+Apollo Client infers the type of the `date` variable as a `DateTime` scalar from its variable definition and calls the appropriate `serialize` function on the configured `DateTime` scalar.
+
+### Input objects
+
+Custom scalars might be used by input objects to represent more complex inputs. Input objects make it more difficult for Apollo Client to infer custom scalars from the variable definition alone. For example, the following query has a `$dateRange` variable that is defined as a `DateRangeFilter` type:
+
+```graphql
+query GetEventsInRange($dateRange: DateRangeFilter!) {
+  events(filter: $dateRange) {
+    id
+    name
+  }
+}
+```
+
+To perform serialization for custom scalars in input objects, `InMemoryCache` needs additional configuration to map input object types to custom scalars. Pass an `inputObjects` option to map the input object's fields to the associated custom scalar type:
+
+```ts
+new InMemoryCache({
+  inputObjects: {
+    DateRangeFilter: {
+      fields: {
+        start: "DateTime",
+        end: "DateTime",
+      },
+    },
+  },
+});
+```
+
+Now you can safely pass parsed scalar values to `variables`:
+
+```ts
+const QUERY = gql`
+  query GetEventsInRange($dateRange: DateRangeFilter!) {
+    events(filter: $dateRange) {
+      id
+      name
+    }
+  }
+`;
+
+const { data } = useQuery(QUERY, {
+  variables: {
+    dateRange: {
+      start: new Date("2026-01-01T00:00:00.00Z"),
+      end: new Date("2026-02-01T00:00:00.00Z"),
+    },
+  },
+});
+```
+
+#### Deeply nested input objects
+
+Input objects might be composed of other input objects which map their own custom scalars. When the input object is more than one level deep, pass the name of the input object for the field that references it:
+
+```ts
+new InMemoryCache({
+  inputObjects: {
+    DateRangeFilter: {
+      fields: {
+        start: "DateTime",
+        end: "DateTime",
+      },
+    },
+    EventFilter: {
+      fields: {
+        dateRange: "DateRangeFilter",
+      },
+    },
+    ConferenceFilter: {
+      fields: {
+        when: "DateRangeFilter",
+      },
+    },
+  },
+});
+```
+
+Now you can safely pass parsed scalar values to `variables`:
+
+```ts
+const QUERY = gql`
+  query GetData(
+    $eventFilter: EventFilter!
+    $conferenceFilter: ConferenceFilter!
+  ) {
+    events(filter: $eventFilter) {
+      id
+      name
+    }
+    conferences(filter: $conferenceFilter) {
+      id
+      name
+    }
+  }
+`;
+
+const { data } = useQuery(QUERY, {
+  variables: {
+    eventFilter: {
+      dateRange: {
+        start: new Date("2026-01-01T00:00:00.00Z"),
+        end: new Date("2026-02-01T00:00:00.00Z"),
+      },
+    },
+    conferenceFilter: {
+      when: {
+        start: new Date("2026-01-01T00:00:00.00Z"),
+        end: new Date("2026-02-01T00:00:00.00Z"),
+      },
+    },
+  },
+});
+```
+
+<Tip>
+
+Instead of generating this configuration by hand, you can automatically generate it with GraphQL Codegen. See the [generate scalar configuration](#generate-scalar-configuration) section to learn how to generate the configuration for you.
+
+</Tip>
+
+## Generate scalar configuration
+
+Writing a field policy or input object entry for every custom scalar field is tedious and error prone. Use the `@apollo/client-graphql-codegen/custom-scalars` plugin to automatically generate the type policies and input objects configuration from your schema.
+
+### Installation
+
+Install the Apollo Client GraphQL Codegen package:
+
+```sh showLineNumbers=false
+npm install @apollo/client-graphql-codegen
+```
+
+<Tip>
+
+Please see the [GraphQL Codegen](../development-testing/graphql-codegen) guide to learn how to use GraphQL Codegen with Apollo Client if you don't have it set up.
+
+</Tip>
+
+### Configuration
+
+Add the `custom-scalars` plugin to your `codegen.ts` configuration:
+
+```ts title="codegen.ts"
+import type { CodegenConfig } from "@graphql-codegen/cli";
+import type { CustomScalarsPluginConfig } from "@apollo/client-graphql-codegen/custom-scalars";
+
+const config: CodegenConfig = {
+  // ... your existing configuration
+  generates: {
+    // ... your existing generates
+    "./src/__generated__/custom-scalars.ts": {
+      plugins: ["@apollo/client-graphql-codegen/custom-scalars"],
+      config: {
+        // Optional. See plugin options below.
+      } satisfies CustomScalarsPluginConfig,
+    },
+  },
+};
+
+export default config;
+```
+
+To make sure the operation types are created using the parsed scalar type, provide a `scalars` mapping to the configuration that creates your operation types:
+
+```ts
+const config: CodegenConfig = {
+  // ... your existing configuration
+  generates: {
+    // ... your existing configuration
+    "./src/types/__generated__/graphql.ts": {
+      plugins: ["typescript-operations"],
+      config: {
+        scalars: {
+          DateTime: "Date",
+          // ... other scalars
+        },
+        // ...other options
+      },
+    },
+  },
+};
+```
+
+### Configure `InMemoryCache` from codegen
+
+Once the custom scalars file is generated, import the `inputObjects` and `scalarTypePolicies` objects from the generated file and pass them to `InMemoryCache`.
+
+```ts
+import {
+  inputObjects,
+  scalarTypePolicies,
+} from "./path/to/__generated__/custom-scalars";
+
+const cache = new InMemoryCache({
+  scalars: {
+    /* ... */
+  },
+  inputObjects,
+});
+
+cache.policies.addTypePolicies(scalarTypePolicies);
+```
+
+<Tip>
+
+We recommend passing `scalarTypePolicies` to `cache.policies.addTypePolicies()` which deep merges the scalar configuration with your existing `typePolicies` for you.
+
+</Tip>
+
+### Plugin options
+
+The GraphQL Codegen plugin accepts the following options:
+
+<table class="field-table api-ref">
+  <thead>
+    <tr>
+      <th>Name /<br/>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+<tr>
+<td>
+
+###### `filterByDocuments`
+
+`boolean`
+
+</td>
+<td>
+
+If `true`, the generated config includes only custom scalar fields selected by your documents and input objects reachable from those documents' variables.<br/><br/>
+
+The default value is `true`. Set this option to `false` to generate config for every custom scalar field in the schema.
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `includeScalars`
+
+`string[]`
+
+</td>
+<td>
+
+Allowed list of scalars that should be included in the config objects. You can reduce the size of the config objects by omitting fields with scalars that won't have an associated scalar transform.<br/><br/>
+
+This option is mutually exclusive with `ignoreScalars`.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+###### `ignoreScalars`
+
+`string[]`
+
+</td>
+<td>
+
+List of scalars that should be ignored when generating the config objects. You can reduce the size of the config objects by omitting fields with scalars that won't have an associated scalar transform.<br/><br/>
+
+This option is mutually exclusive with `includeScalars`.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+## TypeScript
+
+Register custom scalars with TypeScript to provide type safety for scalar APIs. Declare your custom scalars using TypeScript's [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) with the `ApolloCache.Scalars` interface.
+
+```ts title="apollo.d.ts"
+import "@apollo/client";
+
+declare module "@apollo/client" {
+  namespace ApolloCache {
+    interface Scalars {
+      DateTime: { serialized: string; parsed: Date };
+    }
+  }
+}
+```
+
+By providing this declaration, you add type safety when initializing `InMemoryCache` to ensure:
+
+- `InMemoryCache` is initialized with a `Scalar` instance for each declared scalar to avoid runtime mismatches
+- Each `Scalar` instance matches its declared type in `ApolloCache.Scalars`
+
+```ts
+// ❌ invalid: missing `scalars` option
+new InMemoryCache();
+// ❌ invalid: missing `DateTime` scalar
+new InMemoryCache({ scalars: {} });
+
+new InMemoryCache({
+  scalars: {
+    // ❌ invalid: unknown scalar "Unknown"
+    Unknown: new Scalar(/*...*/),
+
+    // ❌ invalid: Scalar<number, string> not assignable to Scalar<string, Date>
+    DateTime: new Scalar<number, string>(/*...*/),
+
+    // ✅ valid
+    DateTime: new Scalar<string, Date>(/*...*/),
+  },
+});
+```
+
+<Note>
+
+When you declare custom scalars with the same `serialized` and `parsed` types, the scalar instance provided to the `scalars` option becomes optional because it is considered type safe.
+
+</Note>
+
+The type declarations also drive the scalars available to the `cache.getScalar(...)` API, which returns the `Scalar` instance assigned for a given name.
+
+```ts
+const dateTimeScalar = cache.getScalar("DateTime");
+//    ^? Scalar<string, Date>;
+
+const unknownScalar = cache.getScalar("Unknown");
+// ❌ invalid "Unknown" key
+```

--- a/docs/source/data/custom-scalars.mdx
+++ b/docs/source/data/custom-scalars.mdx
@@ -204,6 +204,120 @@ const data = client.readQuery({ query: QUERY, variables: { id } });
 // }
 ```
 
+### Lists of scalars
+
+Some fields return a list of custom scalar values, such as `[DateTime!]`. Use GraphQL list syntax so Apollo Client parses and serializes each element as that scalar:
+
+```ts
+new InMemoryCache({
+  scalars: {
+    DateTime: dateTimeScalar,
+  },
+  typePolicies: {
+    Event: {
+      fields: {
+        createdAt: {
+          scalar: "DateTime",
+        },
+        meetingTimes: {
+          scalar: "[DateTime]",
+        },
+        availabilitySlots: {
+          scalar: "[[DateTime]]",
+        },
+      },
+    },
+  },
+});
+```
+
+Use one pair of brackets per list level so Apollo Client iterates each item at the right depth.
+
+<Caution>
+
+Do not include the GraphQL non-null marker (`!`) in the value because it won't match. Write `"[DateTime]"`, not `"[DateTime!]!"`
+
+</Caution>
+
+Query results then return parsed values for each element:
+
+```ts
+const QUERY = gql`
+  query GetEvent($id: ID!) {
+    event(id: $id) {
+      id
+      createdAt
+      meetingTimes
+      availabilitySlots
+    }
+  }
+`;
+
+const { data } = useQuery(QUERY, { variables: { id } });
+// => {
+//   event: {
+//     id: "1",
+//     createdAt: Date,
+//     meetingTimes: [Date, Date],
+//     availabilitySlots: [[Date, Date], [Date]],
+//   },
+// }
+```
+
+The same list syntax applies to [`inputObjects`](#input-objects) field mappings.
+
+<Note>
+
+If a field is configured as a list type such as `"[DateTime]"` but the value is not an array, Apollo Client still coerces the value as `DateTime` and emits a development-only warning.
+
+</Note>
+
+#### Scalars that serialize as arrays
+
+Some custom scalars use a JSON array as the serialized form, even though the GraphQL field is not a list. For example, a `DateTimeRange` scalar might serialize as `["2026-01-01T00:00:00.000Z", "2026-06-01T00:00:00.000Z"]`.
+
+Do not wrap that scalar in list syntax. Pass the scalar name so Apollo Client gives the whole array to `parse` and `serialize`:
+
+```ts
+const dateTimeRangeScalar = new Scalar<
+  [string, string],
+  { start: Date; end: Date }
+>({
+  parse: ([start, end]) => ({
+    start: new Date(start),
+    end: new Date(end),
+  }),
+  serialize: (range) => [range.start.toISOString(), range.end.toISOString()],
+  is: (value) => !Array.isArray(value),
+});
+
+new InMemoryCache({
+  scalars: {
+    DateTimeRange: dateTimeRangeScalar,
+  },
+  typePolicies: {
+    Event: {
+      fields: {
+        dateRange: {
+          scalar: "DateTimeRange",
+        },
+        dateRanges: {
+          scalar: "[DateTimeRange]",
+        },
+      },
+    },
+  },
+});
+```
+
+`"[DateTimeRange]"` is a list of `DateTimeRange` values. Apollo Client iterates the outer array, then passes each inner array to the `DateTimeRange` `Scalar` instance.
+
+<Caution>
+
+If you omit `is`, Apollo Client treats any non-null object as a parsed value, including JSON arrays. Provide an `is` function that returns `false` for the serialized array so Apollo Client still calls `parse`.
+
+</Caution>
+
 ## Variable serialization
 
 Apollo Client serializes parsed scalar values in `variables` before it sends the request to your server and before it reads or writes the cache with those variables. You can pass parsed values in any API that accepts a `variables` option:
@@ -243,6 +357,30 @@ client.writeQuery({
 ```
 
 Apollo Client reads the GraphQL type from the variable definition (`$date: DateTime!`) and calls `serialize` on the configured `DateTime` scalar.
+
+Apollo Client also reads list types from the variable definition. You do not need extra cache configuration for a `[DateTime]` variable. Apollo Client serializes each element:
+
+```ts
+const QUERY = gql`
+  query GetEventsOnDates($dates: [DateTime!]!) {
+    events(on: $dates) {
+      id
+      name
+    }
+  }
+`;
+
+const { data } = useQuery(QUERY, {
+  variables: {
+    dates: [
+      new Date("2026-01-01T00:00:00.000Z"),
+      new Date("2026-01-02T00:00:00.000Z"),
+    ],
+  },
+});
+
+// The link receives `{ dates: ["2026-01-01T00:00:00.000Z", "2026-01-02T00:00:00.000Z"] }`
+```
 
 ### Input objects
 
@@ -289,6 +427,21 @@ const { data } = useQuery(QUERY, {
     dateRange: {
       start: new Date("2026-01-01T00:00:00.000Z"),
       end: new Date("2026-02-01T00:00:00.000Z"),
+    },
+  },
+});
+```
+
+Input object fields can also be lists of custom scalars. Use the same GraphQL list syntax described in [Lists of scalars](#lists-of-scalars):
+
+```ts
+new InMemoryCache({
+  inputObjects: {
+    AvailabilityInput: {
+      fields: {
+        dates: "[DateTime]",
+        slots: "[[DateTime]]",
+      },
     },
   },
 });
@@ -542,6 +695,11 @@ export const inputObjects: InputObjectsOption = {
       end: "DateTime",
     },
   },
+  AvailabilityInput: {
+    fields: {
+      dates: "[DateTime]",
+    },
+  },
 };
 
 export const scalarTypePolicies: TypePolicies = {
@@ -552,6 +710,12 @@ export const scalarTypePolicies: TypePolicies = {
       },
       updatedAt: {
         scalar: "DateTime",
+      },
+      meetingTimes: {
+        scalar: "[DateTime]",
+      },
+      availabilitySlots: {
+        scalar: "[[DateTime]]",
       },
       siteLink: {
         scalar: "URL",

--- a/docs/source/data/typescript.mdx
+++ b/docs/source/data/typescript.mdx
@@ -891,7 +891,7 @@ Learn more about integrating TypeScript with refetch events in the [event-based 
 
 ## Declaring custom scalar types
 
-Learn more about integrating TypeScript with custom scalars in the [custom scalars guide](./custom-scalars#typescript).
+Learn more about integrating TypeScript with custom scalars from the [custom scalars guide](./custom-scalars#typescript).
 
 ## Data masking
 

--- a/docs/source/data/typescript.mdx
+++ b/docs/source/data/typescript.mdx
@@ -889,6 +889,10 @@ Setting a cache type requires the same cache instance in the `ApolloClient` cons
 
 Learn more about integrating TypeScript with refetch events in the [event-based refetching guide](./event-based-refetching#typescript).
 
+## Declaring custom scalar types
+
+Learn more about integrating TypeScript with custom scalars in the [custom scalars guide](./custom-scalars#typescript).
+
 ## Data masking
 
 Learn more about integrating TypeScript with data masking in the [data masking docs](../data/fragments#using-with-typescript).

--- a/docs/source/development-testing/graphql-codegen.mdx
+++ b/docs/source/development-testing/graphql-codegen.mdx
@@ -486,4 +486,4 @@ function MyComponent() {
 
 ### Custom scalars
 
-To learn how to use GraphQL Codegen to generate custom scalars configuration, please see the [custom scalars](../data/custom-scalars#generate-scalar-configuration) guide.
+To learn how to use GraphQL Codegen to generate custom scalars configuration, reference the [custom scalars](../data/custom-scalars#generate-scalar-configuration) guide.

--- a/docs/source/development-testing/graphql-codegen.mdx
+++ b/docs/source/development-testing/graphql-codegen.mdx
@@ -483,3 +483,7 @@ function MyComponent() {
   // ...
 }
 ```
+
+### Custom scalars
+
+To learn how to use GraphQL Codegen to generate custom scalars configuration, please see the [custom scalars](../data/custom-scalars#generate-scalar-configuration) guide.

--- a/src/cache/core/Scalar.ts
+++ b/src/cache/core/Scalar.ts
@@ -6,8 +6,48 @@ export declare namespace Scalar {
     // users declare scalars using
     // `extends Record<string, { serialized: unknown; parsed: unknown }>` while
     // allowing specific scalar overrides.
+
+    /**
+     * A function that transforms the JSON serialized value into its parsed value.
+     *
+     * @example
+     *
+     * ```ts
+     * new Scalar<string, Date>({
+     *   parse: (dateString) => new Date(dateString),
+     * });
+     * ```
+     */
     parse(serializedValue: TSerialized): NoInfer<TParsed>;
+
+    /**
+     * A function that transforms the parsed value into its JSON serialized value.
+     *
+     * @example
+     *
+     * ```ts
+     * new Scalar<string, Date>({
+     *   serialize: (date) => date.toISOString(),
+     * });
+     * ```
+     */
     serialize(parsedValue: TParsed): NoInfer<TSerialized>;
+
+    /**
+     * A [predicate function](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) that determines whether the value
+     * is the parsed value. Return `true` when the value is the parsed value.
+     *
+     * @defaultValue
+     * Function that returns `true` when the value is a non-null object type.
+     *
+     * @example
+     *
+     * ```ts
+     * new Scalar<string, Date>({
+     *   is: (value) => value instanceof Date,
+     * });
+     * ```
+     */
     is?(value: TSerialized | TParsed): boolean;
   }
 }


### PR DESCRIPTION
Adds a new `Custom scalars` documentation page that demonstrates how to use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for defining, parsing, serializing, and configuring GraphQL custom scalars.
  - Documented custom scalar cache configuration, field policies, variables, input objects, SSR, TypeScript integration, and code generation.
  - Added navigation links to the new custom scalars guide across relevant documentation sections.
  - Clarified that `no-cache` operations still parse custom scalar fields.
  - Added examples and API guidance for scalar field policies and scalar behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->