### PR TITLE
Make `variables` provided to mutation `update` function non-optional

### DIFF
--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -798,7 +798,7 @@ interface MutationStoreValue {
 // @public (undocumented)
 export type MutationUpdaterFunction<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation> = (cache: TCache, result: FormattedExecutionResult<Unmasked<TData>>, options: {
     context?: DefaultContext;
-    variables?: TVariables;
+    variables: TVariables;
 }) => void;
 
 // @public

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -2196,7 +2196,7 @@ interface MutationStoreValue {
 // @public (undocumented)
 export type MutationUpdaterFunction<TData, TVariables extends OperationVariables, TCache extends Cache_2.Implementation> = (cache: TCache, result: FormattedExecutionResult<Unmasked<TData>>, options: {
     context?: DefaultContext;
-    variables?: TVariables;
+    variables: TVariables;
 }) => void;
 
 // @public

--- a/.changeset/empty-pears-tell.md
+++ b/.changeset/empty-pears-tell.md
@@ -2,4 +2,4 @@
 "@apollo/client": patch
 ---
 
-Remove the optional from the `variables` property provided to the `update` function in `client.mutate` and `useMutation`. `variables` is always an non-undefined object, even when variables are not provided to the mutation.
+Remove the optional modifier from the `variables` property provided to the `update` function in `client.mutate` and `useMutation`. `variables` is always a defined object, even when variables are not provided to the mutation.

--- a/.changeset/empty-pears-tell.md
+++ b/.changeset/empty-pears-tell.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Remove the optional from the `variables` property provided to the `update` function in `client.mutate` and `useMutation`. `variables` is always an non-undefined object, even when variables are not provided to the mutation.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -381,7 +381,7 @@ export type MutationUpdaterFunction<
   result: FormattedExecutionResult<Unmasked<TData>>,
   options: {
     context?: DefaultContext;
-    variables?: TVariables;
+    variables: TVariables;
   }
 ) => void;
 


### PR DESCRIPTION
`variables` is always provided to the `update` function, regardless of whether `variables` is provided to `client.mutate` or `useMutation`. Under the hood, we call `this.getVariables` which returns an object, so we can guarantee that `variables` is always a non-undefined value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mutation callbacks so the `variables` value provided to `client.mutate` and `useMutation` is always available as an object.

* **Documentation**
  * Updated the public type definitions and release metadata to reflect that mutation variables are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->