### PR TITLE
Mark `skip` as deprecated in `useQuery` and `useSubscription`

### DIFF
--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1112,6 +1112,7 @@ export namespace useQuery {
             refetchOn?: RefetchOn.Option;
             refetchWritePolicy?: RefetchWritePolicy;
             returnPartialData?: boolean;
+            // @deprecated
             skip?: boolean;
             skipPollAttempt?: () => boolean;
             ssr?: boolean;
@@ -1367,6 +1368,7 @@ export namespace useSubscription {
             onData?: (options: OnDataOptions<TData>) => any;
             onError?: (error: ErrorLike) => void;
             shouldResubscribe?: boolean | ((options: Options<TData, TVariables>) => boolean);
+            // @deprecated
             skip?: boolean;
         }
     }

--- a/.changeset/short-kids-retire.md
+++ b/.changeset/short-kids-retire.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Mark `skip` as deprecated in `useQuery` and `useSubscription` now that both of these hooks support `skipToken`.

--- a/src/react/hooks/useBackgroundQuery.ts
+++ b/src/react/hooks/useBackgroundQuery.ts
@@ -76,7 +76,7 @@ export declare namespace useBackgroundQuery {
        * @example Recommended usage of `skipToken`:
        *
        * ```ts
-       * import { skipToken, useBackgroundQuery } from "@apollo/client";
+       * import { skipToken, useBackgroundQuery } from "@apollo/client/react";
        *
        * const [queryRef] = useBackgroundQuery(
        *   query,

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -108,7 +108,17 @@ export declare namespace useQuery {
       /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#context:member} */
       context?: DefaultContext;
 
-      /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#skip:member} */
+      /**
+       * {@inheritDoc @apollo/client!QueryOptionsDocumentation#skip_deprecated:member}
+       *
+       * @example Recommended usage of `skipToken`:
+       *
+       * ```ts
+       * import { skipToken, useQuery } from "@apollo/client/react";
+       *
+       * const { data } = useQuery(query, id ? { variables: { id } } : skipToken);
+       * ```
+       */
       skip?: boolean;
 
       /** {@inheritDoc @apollo/client!QueryOptionsDocumentation#refetchOn:member} */

--- a/src/react/hooks/useSubscription.ts
+++ b/src/react/hooks/useSubscription.ts
@@ -44,7 +44,20 @@ export declare namespace useSubscription {
       /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#client:member} */
       client?: ApolloClient;
 
-      /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#skip:member} */
+      /**
+       * {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#skip_deprecated:member}
+       *
+       * @example Recommended usage of `skipToken`:
+       *
+       * ```ts
+       * import { skipToken, useSubscription } from "@apollo/client/react";
+       *
+       * const { data } = useSubscription(
+       *   subscription,
+       *   id ? { variables: { id } } : skipToken
+       * );
+       * ```
+       */
       skip?: boolean;
 
       /** {@inheritDoc @apollo/client!SubscriptionOptionsDocumentation#context:member} */

--- a/src/react/hooks/useSuspenseQuery.ts
+++ b/src/react/hooks/useSuspenseQuery.ts
@@ -85,7 +85,7 @@ export declare namespace useSuspenseQuery {
        * @example Recommended usage of `skipToken`:
        *
        * ```ts
-       * import { skipToken, useSuspenseQuery } from "@apollo/client";
+       * import { skipToken, useSuspenseQuery } from "@apollo/client/react";
        *
        * const { data } = useSuspenseQuery(
        *   query,
@@ -248,7 +248,7 @@ export declare namespace useSuspenseQuery {
        *
        * ```jsx
        * import { Suspense } from "react";
-       * import { useSuspenseQuery } from "@apollo/client";
+       * import { useSuspenseQuery } from "@apollo/client/react";
        *
        * const listQuery = gql`
        *   query {

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -121,7 +121,7 @@ export interface QueryOptionsDocumentation {
    * @deprecated We recommend using `skipToken` in place of the `skip` option as
    * it is more type-safe.
    *
-   * This option is deprecated and only supported to ease the migration from `useQuery`. It will be removed in a future release.
+   * This option is deprecated and will be removed in a future release.
    * Please use [`skipToken`](https://www.apollographql.com/docs/react/api/react/hooks#skiptoken) instead of the `skip` option as it is more type-safe.
    *
    * @docGroup 1. Operation options

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -549,6 +549,18 @@ export interface SubscriptionOptionsDocumentation {
   skip: unknown;
 
   /**
+   * Determines if the current subscription should be skipped. Useful if, for
+   * example, variables depend on previous queries and are not ready yet.
+   *
+   * @deprecated We recommend using `skipToken` in place of the `skip` option as
+   * it is more type-safe.
+   *
+   * This option is deprecated and will be removed in a future release.
+   * Please use [`skipToken`](https://www.apollographql.com/docs/react/api/react/hooks#skiptoken) instead of the `skip` option as it is more type-safe.
+   */
+  skip_deprecated: unknown;
+
+  /**
    * Shared context between your component and your network interface (Apollo Link).
    */
   context: unknown;


### PR DESCRIPTION
Now that `useQuery` and `useSubscription` both support `skipToken`, this PR marks `skip` as deprecated to encourage the use of `skipToken` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Marked the `skip` option as deprecated for query and subscription hooks.
  - Added examples recommending `skipToken` for conditional execution.
  - Updated React import paths in documentation examples.
  - Clarified deprecation guidance across query and subscription option documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->