### PR TITLE
Adding a new error policy: "localized"

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -151,7 +151,7 @@ export abstract class ApolloCache {
     // (undocumented)
     abstract write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(write: Cache_2.WriteOptions<TData, TVariables>): Reference | undefined;
     writeFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ data, fragment, fragmentName, variables, overwrite, id, from, broadcast, }: Cache_2.WriteFragmentOptions<TData, TVariables>): Reference | undefined;
-    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ data, query, variables, overwrite, id, broadcast, }: Cache_2.WriteQueryOptions<TData, TVariables>): Reference | undefined;
+    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ data, query, variables, overwrite, id, broadcast, skipPaths, }: Cache_2.WriteQueryOptions<TData, TVariables>): Reference | undefined;
 }
 
 // @public (undocumented)
@@ -290,6 +290,7 @@ namespace Cache_2 {
         query: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
         // (undocumented)
         result: Unmasked<TData>;
+        skipPaths?: ReadonlyArray<ReadonlyArray<string | number>>;
         variables?: TVariables;
     }
     // (undocumented)
@@ -300,6 +301,7 @@ namespace Cache_2 {
         id?: string;
         overwrite?: boolean;
         query: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
+        skipPaths?: ReadonlyArray<ReadonlyArray<string | number>>;
         variables?: TVariables;
     }
 }

--- a/.api-reports/api-report-core.api.md
+++ b/.api-reports/api-report-core.api.md
@@ -309,6 +309,10 @@ export namespace ApolloClient {
             data: TData | undefined;
             error?: never;
         };
+        localized: {
+            data: TData | undefined;
+            error?: ErrorLike;
+        };
         undefined: {
             data: TData | undefined;
             error?: ErrorLike;
@@ -408,6 +412,10 @@ export namespace ApolloClient {
         ignore: {
             data: TData | undefined;
             error?: never;
+        };
+        localized: {
+            data: TData | undefined;
+            error?: ErrorLike;
         };
         undefined: {
             data: TData | undefined;
@@ -645,7 +653,7 @@ export interface ErrorLike {
 }
 
 // @public
-export type ErrorPolicy = "none" | "ignore" | "all";
+export type ErrorPolicy = "none" | "ignore" | "all" | "localized";
 
 export { execute }
 
@@ -1397,7 +1405,7 @@ export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 
 // Warnings were encountered during analysis:
 //
-// src/core/ApolloClient.ts:667:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:681:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 

--- a/.api-reports/api-report-react.api.md
+++ b/.api-reports/api-report-react.api.md
@@ -1045,6 +1045,10 @@ export namespace useMutation {
             data: MaybeMasked<TData> | null | undefined;
             error: undefined;
         };
+        localized: {
+            data: MaybeMasked<TData> | null | undefined;
+            error: ErrorLike | undefined;
+        };
         undefined: {
             data: MaybeMasked<TData> | null | undefined;
             error: ErrorLike | undefined;

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -151,7 +151,7 @@ export abstract class ApolloCache {
     // (undocumented)
     abstract write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(write: Cache_2.WriteOptions<TData, TVariables>): Reference | undefined;
     writeFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ data, fragment, fragmentName, variables, overwrite, id, from, broadcast, }: Cache_2.WriteFragmentOptions<TData, TVariables>): Reference | undefined;
-    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ data, query, variables, overwrite, id, broadcast, }: Cache_2.WriteQueryOptions<TData, TVariables>): Reference | undefined;
+    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>({ data, query, variables, overwrite, id, broadcast, skipPaths, }: Cache_2.WriteQueryOptions<TData, TVariables>): Reference | undefined;
 }
 
 // @public (undocumented)
@@ -356,6 +356,10 @@ export namespace ApolloClient {
             data: TData | undefined;
             error?: never;
         };
+        localized: {
+            data: TData | undefined;
+            error?: ErrorLike;
+        };
         undefined: {
             data: TData | undefined;
             error?: ErrorLike;
@@ -462,6 +466,10 @@ export namespace ApolloClient {
         ignore: {
             data: TData | undefined;
             error?: never;
+        };
+        localized: {
+            data: TData | undefined;
+            error?: ErrorLike;
         };
         undefined: {
             data: TData | undefined;
@@ -900,6 +908,7 @@ namespace Cache_2 {
         query: DocumentNode | TypedDocumentNode<TData, TVariables>;
         // (undocumented)
         result: Unmasked<TData>;
+        skipPaths?: ReadonlyArray<ReadonlyArray<string | number>>;
         variables?: TVariables;
     }
     // (undocumented)
@@ -910,6 +919,7 @@ namespace Cache_2 {
         id?: string;
         overwrite?: boolean;
         query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+        skipPaths?: ReadonlyArray<ReadonlyArray<string | number>>;
         variables?: TVariables;
     }
 }
@@ -1259,7 +1269,7 @@ export interface ErrorLike {
 }
 
 // @public
-export type ErrorPolicy = "none" | "ignore" | "all";
+export type ErrorPolicy = "none" | "ignore" | "all" | "localized";
 
 // @public (undocumented)
 export const execute: typeof ApolloLink.execute;
@@ -3099,7 +3109,7 @@ interface WriteContext extends ReadMergeModifyContext {
 // src/cache/inmemory/policies.ts:173:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/types.ts:135:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
-// src/core/ApolloClient.ts:667:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
+// src/core/ApolloClient.ts:681:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:375:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts
 // src/core/QueryManager.ts:195:5 - (ae-forgotten-export) The symbol "MutationStoreValue" needs to be exported by the entry point index.d.ts
 // src/local-state/LocalState.ts:149:5 - (ae-forgotten-export) The symbol "LocalState" needs to be exported by the entry point index.d.ts

--- a/.changeset/sweet-pandas-listen.md
+++ b/.changeset/sweet-pandas-listen.md
@@ -2,6 +2,8 @@
 "@apollo/client": minor
 ---
 
-Add a `localized` error policy. With `errorPolicy: "localized"`, the operation receives the full response shape along with `error`, just like `all`, but the fields that GraphQL errors point at are left out of the cache write. Everything that resolved successfully is written and broadcast as usual, so a failing field no longer overwrites shared cache data with `null` for the rest of the app.
+Add a `localized` error policy. For GraphQL errors that name a field `path`, the operation receives the full response shape along with `error`, just like `all`, but those fields are left out of the cache write. Everything that resolved successfully is written and broadcast as usual, so a failing field no longer overwrites shared cache data with `null` for the rest of the app.
+
+An error with no field to attribute it to — a network or transport failure — behaves like `none` instead, since there is no response shape to hand back and emitting an empty result would clear data the caller is already rendering.
 
 `Cache.WriteOptions` and `Cache.WriteQueryOptions` gain a matching `skipPaths` option for callers that write to the cache directly.

--- a/.changeset/sweet-pandas-listen.md
+++ b/.changeset/sweet-pandas-listen.md
@@ -2,8 +2,8 @@
 "@apollo/client": minor
 ---
 
-Add a `localized` error policy. For GraphQL errors that name a field `path`, the operation receives the full response shape along with `error`, just like `all`, but those fields are left out of the cache write. Everything that resolved successfully is written and broadcast as usual, so a failing field no longer overwrites shared cache data with `null` for the rest of the app.
+Add a `localized` error policy. For GraphQL errors in the response body the operation receives the full response shape along with `error`, just like `all`, but the fields those errors name in their `path` are left out of the cache write. Everything that resolved successfully is written and broadcast as usual, so a failing field no longer overwrites shared cache data with `null` for the rest of the app.
 
-An error with no field to attribute it to — a network or transport failure — behaves like `none` instead, since there is no response shape to hand back and emitting an empty result would clear data the caller is already rendering.
+A network or transport error — one that fails the whole operation rather than arriving in the response body — behaves like `none` instead, since there is no response shape to hand back and emitting an empty result would clear data the caller is already rendering.
 
 `Cache.WriteOptions` and `Cache.WriteQueryOptions` gain a matching `skipPaths` option for callers that write to the cache directly.

--- a/.changeset/sweet-pandas-listen.md
+++ b/.changeset/sweet-pandas-listen.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client": minor
+---
+
+Add a `localized` error policy. With `errorPolicy: "localized"`, the operation receives the full response shape along with `error`, just like `all`, but the fields that GraphQL errors point at are left out of the cache write. Everything that resolved successfully is written and broadcast as usual, so a failing field no longer overwrites shared cache data with `null` for the rest of the app.
+
+`Cache.WriteOptions` and `Cache.WriteQueryOptions` gain a matching `skipPaths` option for callers that write to the cache directly.

--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -147,7 +147,7 @@ Apollo Client supports the following error policies:
 | `none`      | If the response includes errors, they are returned in the `error` field and the response `data` is set to `undefined` even if the server returns `data` in its response. This means network errors and GraphQL errors result in a similar response shape. This is the default error policy. |
 | `ignore`    | Errors are ignored (`error` is _not_ populated), and any returned `data` is cached and rendered as if no errors occurred. Note: `data` may also be `undefined` in the event a network error occurs.                                                                                         |
 | `all`       | Both `data` and `error` are populated and any returned `data` is cached, enabling you to render both partial results and error information.                                                                                                                                                 |
-| `localized` | Both `data` and `error` are populated, and the fields the errors point at are left out of the cache write. The operation receives the whole response shape, while other parts of your app only see the fields that resolved successfully.                                                   |
+| `localized` | Like `all` for errors that name a field, with those fields left out of the cache write: the operation receives the whole response shape, while the rest of your app only sees the fields that resolved. A network error behaves like `none`.                                                |
 
 ### Setting an error policy
 
@@ -208,6 +208,8 @@ function Profile() {
 Because the errored field never reaches the cache, a later cache read for this query is incomplete and Apollo Client fetches from the network again rather than serving the failed field from the cache. A field that already held a value from an earlier successful response keeps that value.
 
 Errors without a `path` cannot be attributed to a field, so they do not restrict the cache write. An error inside a list omits the field on the affected list item, but the item itself stays in the list.
+
+A network error is not localized to anything — there is no `path` to attribute it to and no response shape to return — so `localized` handles it exactly as `none` does. That keeps a total failure from clearing data your components are already rendering.
 
 Use `localized` when a failing field should not poison shared cache data, and `all` when you want the response cached exactly as the server sent it.
 
@@ -284,7 +286,7 @@ console.log("Data (errors ignored):", result.data);
 
 ##### `errorPolicy: "localized"`
 
-The `localized` error policy resolves the promise the same way `all` does, and additionally keeps the errored fields out of the cache.
+For errors that name a field, the `localized` error policy resolves the promise the same way `all` does, and additionally keeps those fields out of the cache. A network error rejects, as it does under `none`.
 
 ```ts
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
@@ -370,7 +372,7 @@ observable.subscribe({
 
 ##### `errorPolicy: "localized"`
 
-Errors are included as part of the result object emitted to the `next` callback through the `error` field, and `data` holds the full response shape. The fields the errors point at are left out of the cache, so watchers of unrelated fields still receive their update.
+Field errors are included as part of the result object emitted to the `next` callback through the `error` field, and `data` holds the full response shape. The fields those errors point at are left out of the cache, so watchers of unrelated fields still receive their update. A network error is delivered the way `none` delivers it.
 
 ```ts
 const observable = client.watchQuery({

--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -142,11 +142,12 @@ By default, Apollo Client throws away partial data and populates the `error` fie
 
 Apollo Client supports the following error policies:
 
-| Policy   | Description                                                                                                                                                                                                                                                                                 |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `none`   | If the response includes errors, they are returned in the `error` field and the response `data` is set to `undefined` even if the server returns `data` in its response. This means network errors and GraphQL errors result in a similar response shape. This is the default error policy. |
-| `ignore` | Errors are ignored (`error` is _not_ populated), and any returned `data` is cached and rendered as if no errors occurred. Note: `data` may also be `undefined` in the event a network error occurs.                                                                                         |
-| `all`    | Both `data` and `error` are populated and any returned `data` is cached, enabling you to render both partial results and error information.                                                                                                                                                 |
+| Policy      | Description                                                                                                                                                                                                                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `none`      | If the response includes errors, they are returned in the `error` field and the response `data` is set to `undefined` even if the server returns `data` in its response. This means network errors and GraphQL errors result in a similar response shape. This is the default error policy. |
+| `ignore`    | Errors are ignored (`error` is _not_ populated), and any returned `data` is cached and rendered as if no errors occurred. Note: `data` may also be `undefined` in the event a network error occurs.                                                                                         |
+| `all`       | Both `data` and `error` are populated and any returned `data` is cached, enabling you to render both partial results and error information.                                                                                                                                                 |
+| `localized` | Both `data` and `error` are populated, and the fields the errors point at are left out of the cache write. The operation receives the whole response shape, while other parts of your app only see the fields that resolved successfully.                                                   |
 
 ### Setting an error policy
 
@@ -175,6 +176,40 @@ function ShowingSomeErrors() {
 ```
 
 This example uses the `all` error policy to render both partial data and error information whenever applicable.
+
+### Keeping errored fields out of the cache
+
+The `all` error policy writes the entire response to the cache, `null` values at errored fields included. Because the cache is shared, every other operation that reads one of those fields sees the `null` too.
+
+The `localized` error policy narrows that blast radius. Apollo Client reads the `path` of each GraphQL error in the response and leaves those fields out of the cache write. Everything that resolved successfully is written and broadcast as usual, so unrelated components still get their update.
+
+The operation that made the request receives the complete response shape, so a component written against your generated GraphQL types can rely on every field it selected being present:
+
+```jsx
+const MY_QUERY = gql`
+  query ProfileWithBadField {
+    profile {
+      id
+      name
+      badField # This field's resolver produces an error
+    }
+  }
+`;
+
+function Profile() {
+  const { data, error } = useQuery(MY_QUERY, { errorPolicy: "localized" });
+
+  // `data.profile.badField` is `null`, matching the server response, but the
+  // cache holds only `profile.id` and `profile.name`.
+  return <h2>{data?.profile.name}</h2>;
+}
+```
+
+Because the errored field never reaches the cache, a later cache read for this query is incomplete and Apollo Client fetches from the network again rather than serving the failed field from the cache. A field that already held a value from an earlier successful response keeps that value.
+
+Errors without a `path` cannot be attributed to a field, so they do not restrict the cache write. An error inside a list omits the field on the affected list item, but the item itself stays in the list.
+
+Use `localized` when a failing field should not poison shared cache data, and `all` when you want the response cached exactly as the server sent it.
 
 ### Error handling across API types
 
@@ -247,6 +282,26 @@ const result = await client.query({
 console.log("Data (errors ignored):", result.data);
 ```
 
+##### `errorPolicy: "localized"`
+
+The `localized` error policy resolves the promise the same way `all` does, and additionally keeps the errored fields out of the cache.
+
+```ts
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+
+const result = await client.query({
+  query: MY_QUERY,
+  errorPolicy: "localized",
+});
+
+if (result.error && CombinedGraphQLErrors.is(result.error)) {
+  // `result.data` has the full response shape, with `null` at each errored
+  // field. Those fields were not written to the cache.
+  console.log("GraphQL errors:", result.error.errors);
+  console.log("Response data:", result.data);
+}
+```
+
 #### Observable-based APIs
 
 Observable-based APIs like `client.watchQuery` and `client.subscribe` emit values and errors through the observer `next` callback. The error policy determines how the `data` and `error` properties are set:
@@ -309,6 +364,28 @@ const observable = client.watchQuery({
 observable.subscribe({
   next(result) {
     console.log("Result:", result.data);
+  },
+});
+```
+
+##### `errorPolicy: "localized"`
+
+Errors are included as part of the result object emitted to the `next` callback through the `error` field, and `data` holds the full response shape. The fields the errors point at are left out of the cache, so watchers of unrelated fields still receive their update.
+
+```ts
+const observable = client.watchQuery({
+  query: MY_QUERY,
+  errorPolicy: "localized",
+});
+
+observable.subscribe({
+  next(result) {
+    if (result.error) {
+      console.log("Got error:", result.error.message);
+      console.log("Response data", result.data);
+    } else {
+      console.log("Result:", result.data);
+    }
   },
 });
 ```

--- a/docs/source/data/error-handling.mdx
+++ b/docs/source/data/error-handling.mdx
@@ -147,7 +147,7 @@ Apollo Client supports the following error policies:
 | `none`      | If the response includes errors, they are returned in the `error` field and the response `data` is set to `undefined` even if the server returns `data` in its response. This means network errors and GraphQL errors result in a similar response shape. This is the default error policy. |
 | `ignore`    | Errors are ignored (`error` is _not_ populated), and any returned `data` is cached and rendered as if no errors occurred. Note: `data` may also be `undefined` in the event a network error occurs.                                                                                         |
 | `all`       | Both `data` and `error` are populated and any returned `data` is cached, enabling you to render both partial results and error information.                                                                                                                                                 |
-| `localized` | Like `all` for errors that name a field, with those fields left out of the cache write: the operation receives the whole response shape, while the rest of your app only sees the fields that resolved. A network error behaves like `none`.                                                |
+| `localized` | Like `all` for errors in the response body, with the fields they name in their `path` left out of the cache write: the operation receives the whole response shape, while the rest of your app only sees the fields that resolved. A network error behaves like `none`.                     |
 
 ### Setting an error policy
 
@@ -209,7 +209,7 @@ Because the errored field never reaches the cache, a later cache read for this q
 
 Errors without a `path` cannot be attributed to a field, so they do not restrict the cache write. An error inside a list omits the field on the affected list item, but the item itself stays in the list.
 
-A network error is not localized to anything — there is no `path` to attribute it to and no response shape to return — so `localized` handles it exactly as `none` does. That keeps a total failure from clearing data your components are already rendering.
+A **network** error is different in kind: it fails the whole operation, so there is no response shape to return and nothing to localize. `localized` handles that case exactly as `none` does, which keeps a total failure from clearing data your components are already rendering. Note this is about _how the error arrived_, not whether it has a `path` — a GraphQL error in the response body with no `path` is still delivered with `data`, it just doesn't restrict the cache write.
 
 Use `localized` when a failing field should not poison shared cache data, and `all` when you want the response cached exactly as the server sent it.
 
@@ -286,7 +286,7 @@ console.log("Data (errors ignored):", result.data);
 
 ##### `errorPolicy: "localized"`
 
-For errors that name a field, the `localized` error policy resolves the promise the same way `all` does, and additionally keeps those fields out of the cache. A network error rejects, as it does under `none`.
+For GraphQL errors in the response body, the `localized` error policy resolves the promise the same way `all` does, and additionally keeps the fields they name out of the cache. A network error rejects, as it does under `none`.
 
 ```ts
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
@@ -372,7 +372,7 @@ observable.subscribe({
 
 ##### `errorPolicy: "localized"`
 
-Field errors are included as part of the result object emitted to the `next` callback through the `error` field, and `data` holds the full response shape. The fields those errors point at are left out of the cache, so watchers of unrelated fields still receive their update. A network error is delivered the way `none` delivers it.
+GraphQL errors are included as part of the result object emitted to the `next` callback through the `error` field, and `data` holds the full response shape. The fields they name in their `path` are left out of the cache, so watchers of unrelated fields still receive their update. A network error is delivered the way `none` delivers it.
 
 ```ts
 const observable = client.watchQuery({

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -794,6 +794,7 @@ export abstract class ApolloCache {
     overwrite,
     id,
     broadcast,
+    skipPaths,
   }: Cache.WriteQueryOptions<TData, TVariables>): Reference | undefined;
   public writeQuery<
     TData = unknown,

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -84,6 +84,28 @@ export declare namespace Cache {
      * are available in `merge` functions.
      */
     extensions?: ExtensionsWithStreamInfo;
+
+    /**
+     * Response paths that should be left out of the write. Each path is a list
+     * of response keys and array indexes relative to the root of `result`, in
+     * the same format as the `path` of a GraphQL error.
+     *
+     * A field at one of these paths keeps whatever value it already had in the
+     * cache, and reading the field back reports it as missing when the cache
+     * never held a value for it.
+     *
+     * @example
+     *
+     * ```ts
+     * // Writes `user.name` but leaves `user.emails[0].address` untouched.
+     * cache.write({
+     *   query,
+     *   result,
+     *   skipPaths: [["user", "emails", 0, "address"]],
+     * });
+     * ```
+     */
+    skipPaths?: ReadonlyArray<ReadonlyArray<string | number>>;
   }
 
   export interface DiffOptions<
@@ -292,6 +314,9 @@ export declare namespace Cache {
      * are available in `merge` functions.
      */
     extensions?: ExtensionsWithStreamInfo;
+
+    /** {@inheritDoc @apollo/client/cache!Cache.WriteOptions#skipPaths:member} */
+    skipPaths?: ReadonlyArray<ReadonlyArray<string | number>>;
   }
 
   export type WriteFragmentOptions<

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -4078,4 +4078,374 @@ describe("writing to the store", () => {
       });
     });
   });
+
+  describe("skipPaths", () => {
+    it("omits a top level field", () => {
+      const query = gql`
+        query {
+          goodField
+          badField
+        }
+      `;
+
+      expect(
+        writeQueryToStore({
+          writer,
+          query,
+          result: { goodField: "good", badField: null },
+          skipPaths: [["badField"]],
+        }).toObject()
+      ).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          goodField: "good",
+        },
+      });
+    });
+
+    it("omits several fields at once", () => {
+      const query = gql`
+        query {
+          a
+          b
+          c
+        }
+      `;
+
+      expect(
+        writeQueryToStore({
+          writer,
+          query,
+          result: { a: null, b: "b", c: null },
+          skipPaths: [["a"], ["c"]],
+        }).toObject()
+      ).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          b: "b",
+        },
+      });
+    });
+
+    it("omits a nested field on a non-normalized object", () => {
+      const query = gql`
+        query {
+          nested {
+            goodField
+            badField
+          }
+        }
+      `;
+
+      expect(
+        writeQueryToStore({
+          writer,
+          query,
+          result: { nested: { goodField: "good", badField: null } },
+          skipPaths: [["nested", "badField"]],
+        }).toObject()
+      ).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          nested: { goodField: "good" },
+        },
+      });
+    });
+
+    it("omits a nested field on a normalized entity", () => {
+      const cache = new InMemoryCache();
+      const query = gql`
+        query {
+          user {
+            __typename
+            id
+            name
+            email
+          }
+        }
+      `;
+
+      cache.writeQuery({
+        query,
+        data: {
+          user: { __typename: "User", id: "1", name: "Alice", email: null },
+        },
+        skipPaths: [["user", "email"]],
+      });
+
+      expect(cache.extract()).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          user: { __ref: "User:1" },
+        },
+        "User:1": {
+          __typename: "User",
+          id: "1",
+          name: "Alice",
+        },
+      });
+    });
+
+    it("uses the response key rather than the field name when the field is aliased", () => {
+      const query = gql`
+        query {
+          renamed: badField
+          goodField
+        }
+      `;
+
+      expect(
+        writeQueryToStore({
+          writer,
+          query,
+          result: { renamed: null, goodField: "good" },
+          skipPaths: [["renamed"]],
+        }).toObject()
+      ).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          goodField: "good",
+        },
+      });
+    });
+
+    it("does not omit a field when the path matches the field name instead of the alias", () => {
+      const query = gql`
+        query {
+          renamed: badField
+        }
+      `;
+
+      expect(
+        writeQueryToStore({
+          writer,
+          query,
+          result: { renamed: null },
+          skipPaths: [["badField"]],
+        }).toObject()
+      ).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          badField: null,
+        },
+      });
+    });
+
+    it("omits a field on a single item of a list", () => {
+      const cache = new InMemoryCache();
+      const query = gql`
+        query {
+          users {
+            __typename
+            id
+            name
+          }
+        }
+      `;
+
+      cache.writeQuery({
+        query,
+        data: {
+          users: [
+            { __typename: "User", id: "1", name: "Alice" },
+            { __typename: "User", id: "2", name: null },
+          ],
+        },
+        skipPaths: [["users", 1, "name"]],
+      });
+
+      expect(cache.extract()).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          users: [{ __ref: "User:1" }, { __ref: "User:2" }],
+        },
+        "User:1": { __typename: "User", id: "1", name: "Alice" },
+        "User:2": { __typename: "User", id: "2" },
+      });
+    });
+
+    it("omits a field reached through a fragment", () => {
+      const cache = new InMemoryCache();
+      const query = gql`
+        query {
+          user {
+            __typename
+            id
+            ...UserFields
+          }
+        }
+
+        fragment UserFields on User {
+          name
+          email
+        }
+      `;
+
+      cache.writeQuery({
+        query,
+        data: {
+          user: { __typename: "User", id: "1", name: "Alice", email: null },
+        },
+        skipPaths: [["user", "email"]],
+      });
+
+      expect(cache.extract()["User:1"]).toEqual({
+        __typename: "User",
+        id: "1",
+        name: "Alice",
+      });
+    });
+
+    it("omits a null field whose skipped path continues underneath it", () => {
+      const cache = new InMemoryCache();
+      const query = gql`
+        query {
+          goodField
+          nested {
+            __typename
+            id
+            requiredField
+          }
+        }
+      `;
+
+      cache.writeQuery({
+        query,
+        data: { goodField: "good", nested: null },
+        // A GraphQL error on the non-null `requiredField` nulls out `nested`
+        // in the response, but the error `path` still points at the field
+        // that failed.
+        skipPaths: [["nested", "requiredField"]],
+      });
+
+      expect(cache.extract()).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          goodField: "good",
+        },
+      });
+    });
+
+    it("leaves existing cache data in place for a skipped field", () => {
+      const cache = new InMemoryCache();
+      const query = gql`
+        query {
+          user {
+            __typename
+            id
+            name
+            email
+          }
+        }
+      `;
+      const data = {
+        user: { __typename: "User", id: "1", name: "Alice", email: null },
+      };
+
+      cache.writeQuery({
+        query,
+        data: { ...data, user: { ...data.user, email: "alice@example.com" } },
+      });
+
+      cache.writeQuery({ query, data, skipPaths: [["user", "email"]] });
+
+      expect(cache.extract()["User:1"]).toEqual({
+        __typename: "User",
+        id: "1",
+        name: "Alice",
+        email: "alice@example.com",
+      });
+    });
+
+    it("does not warn about the skipped field being missing from the result", () => {
+      using consoleSpy = spyOnConsole("error");
+      const query = gql`
+        query {
+          goodField
+          badField
+        }
+      `;
+
+      writeQueryToStore({
+        writer,
+        query,
+        result: { goodField: "good", badField: null },
+        skipPaths: [["badField"]],
+      });
+
+      expect(consoleSpy.error).not.toHaveBeenCalled();
+    });
+
+    it("writes the full result when skipPaths is empty", () => {
+      const query = gql`
+        query {
+          goodField
+          badField
+        }
+      `;
+
+      expect(
+        writeQueryToStore({
+          writer,
+          query,
+          result: { goodField: "good", badField: null },
+          skipPaths: [],
+        }).toObject()
+      ).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          goodField: "good",
+          badField: null,
+        },
+      });
+    });
+
+    it("ignores an empty path", () => {
+      const query = gql`
+        query {
+          goodField
+        }
+      `;
+
+      expect(
+        writeQueryToStore({
+          writer,
+          query,
+          result: { goodField: "good" },
+          skipPaths: [[]],
+        }).toObject()
+      ).toEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          goodField: "good",
+        },
+      });
+    });
+
+    it("reads back a skipped field as missing", () => {
+      const cache = new InMemoryCache();
+      const query = gql`
+        query {
+          user {
+            __typename
+            id
+            name
+            email
+          }
+        }
+      `;
+
+      cache.writeQuery({
+        query,
+        data: {
+          user: { __typename: "User", id: "1", name: "Alice", email: null },
+        },
+        skipPaths: [["user", "email"]],
+      });
+
+      const diff = cache.diff({ query, optimistic: false });
+
+      expect(diff.complete).toBe(false);
+    });
+  });
 });

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -131,6 +131,41 @@ interface ProcessSelectionSetOptions {
   context: WriteContext;
   mergeTree: MergeTree;
   path: Array<string | number>;
+  skipNode?: SkipPathNode;
+}
+
+/**
+ * A single node of the tree built from `Cache.WriteOptions.skipPaths`. `skip` is
+ * `true` for a node one of those paths ends at, and `children` holds the
+ * response keys and array indexes that continue deeper into the response.
+ */
+interface SkipPathNode {
+  skip: boolean;
+  children: Map<string | number, SkipPathNode>;
+}
+
+function buildSkipPathTree(
+  skipPaths: ReadonlyArray<ReadonlyArray<string | number>> | undefined
+): SkipPathNode | undefined {
+  if (!skipPaths || !skipPaths.length) return;
+
+  const root: SkipPathNode = { skip: false, children: new Map() };
+
+  for (const path of skipPaths) {
+    let node = root;
+    for (const key of path) {
+      let child = node.children.get(key);
+      if (!child) {
+        node.children.set(key, (child = { skip: false, children: new Map() }));
+      }
+      node = child;
+    }
+    if (node !== root) {
+      node.skip = true;
+    }
+  }
+
+  return root.children.size ? root : undefined;
 }
 
 export class StoreWriter {
@@ -152,6 +187,7 @@ export class StoreWriter {
       variables,
       overwrite,
       extensions,
+      skipPaths,
     }: Cache.WriteOptions<TData, TVariables>
   ): Reference | undefined {
     const operationDefinition = getOperationDefinition(query)!;
@@ -186,6 +222,7 @@ export class StoreWriter {
       mergeTree: { map: new Map() },
       context,
       path: [],
+      skipNode: buildSkipPathTree(skipPaths),
     });
 
     if (!isReference(ref)) {
@@ -275,6 +312,7 @@ export class StoreWriter {
     // to its callers without explicitly returning that information.
     mergeTree,
     path: currentPath,
+    skipNode,
   }: ProcessSelectionSetOptions): StoreObject | Reference {
     const { policies } = this.cache;
 
@@ -343,6 +381,16 @@ export class StoreWriter {
       const resultFieldKey = resultKeyNameFromField(field);
       const value = result[resultFieldKey];
       const path = [...currentPath, field.name.value];
+      const fieldSkipNode = skipNode?.children.get(resultFieldKey);
+
+      // Leave this field out of the write entirely when the caller asked us to
+      // skip it, or when the field is `null` and a skipped path continues
+      // underneath it. The second case covers a GraphQL error on a non-null
+      // field, where the `null` propagates up to this field but the error
+      // `path` still points at the field that failed.
+      if (fieldSkipNode && (fieldSkipNode.skip || value === null)) {
+        return;
+      }
 
       fieldNodeSet.add(field);
 
@@ -365,7 +413,8 @@ export class StoreWriter {
             getContextFlavor(context, false, false)
           : context,
           childTree,
-          path
+          path,
+          fieldSkipNode
         );
 
         // To determine if this field holds a child object with a merge function
@@ -509,7 +558,8 @@ export class StoreWriter {
     field: FieldNode,
     context: WriteContext,
     mergeTree: MergeTree,
-    path: Array<string | number>
+    path: Array<string | number>,
+    skipNode?: SkipPathNode
   ): StoreValue {
     if (!field.selectionSet || value === null) {
       // In development, we need to clone scalar values so that they can be
@@ -525,7 +575,8 @@ export class StoreWriter {
           field,
           context,
           getChildMergeTree(mergeTree, i),
-          [...path, i]
+          [...path, i],
+          skipNode?.children.get(i)
         );
         maybeRecycleChildMergeTree(mergeTree, i);
         return value;
@@ -538,6 +589,7 @@ export class StoreWriter {
       context,
       mergeTree,
       path,
+      skipNode,
     });
   }
 

--- a/src/core/ApolloClient.ts
+++ b/src/core/ApolloClient.ts
@@ -370,6 +370,13 @@ export declare namespace ApolloClient {
       /** {@inheritDoc @apollo/client!MutationResultDocumentation#error:member} */
       error?: never;
     };
+    localized: {
+      /** {@inheritDoc @apollo/client!MutationResultDocumentation#data:member} */
+      data: TData | undefined;
+
+      /** {@inheritDoc @apollo/client!MutationResultDocumentation#error:member} */
+      error?: ErrorLike;
+    };
     // Fallback case via `undefined` for backwards compatibility when the
     // `errorPolicy` is not known at the call site.
     undefined: {
@@ -430,6 +437,13 @@ export declare namespace ApolloClient {
 
       /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
       error?: never;
+    };
+    localized: {
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#data:member} */
+      data: TData | undefined;
+
+      /** {@inheritDoc @apollo/client!QueryResultDocumentation#error:member} */
+      error?: ErrorLike;
     };
     // Fallback case via `undefined` for backwards compatibility. Helps with
     // other APIs such as `ObservableQuery.refetch()` which we don't know the

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -244,6 +244,7 @@ export class QueryInfo<
 
     if (shouldWriteResult(result, errorPolicy)) {
       let written = false;
+      const skipPaths = getSkipPaths(result, errorPolicy);
 
       // Using a transaction here so we have a chance to read the result
       // back from the cache before the watch callback fires as a result
@@ -269,6 +270,7 @@ export class QueryInfo<
               variables,
               overwrite: cacheWriteBehavior === CacheWriteBehavior.OVERWRITE,
               extensions: result.extensions,
+              skipPaths,
             });
 
             written = true;
@@ -335,7 +337,12 @@ export class QueryInfo<
             written &&
             // A result that is still streaming is expected to read back
             // incomplete until the remaining chunks arrive.
-            !this.hasNext
+            !this.hasNext &&
+            // The `localized` error policy deliberately leaves the errored
+            // fields out of the write, so reading back incomplete is the
+            // expected outcome rather than a sign of a faulty `read`/`merge`
+            // function.
+            !skipPaths.length
           ) {
             warnAboutPartialCacheResult(query, result.data, diff);
           }
@@ -416,6 +423,7 @@ export class QueryInfo<
         query: mutation.document,
         variables: mutation.variables,
         extensions: result.extensions,
+        skipPaths: getSkipPaths(result, mutation.errorPolicy),
       });
 
       const { updateQueries } = mutation;
@@ -623,6 +631,7 @@ export class QueryInfo<
           dataId: "ROOT_SUBSCRIPTION",
           variables: variables,
           extensions: result.extensions,
+          skipPaths: getSkipPaths(result, errorPolicy),
         });
       }
 
@@ -662,10 +671,38 @@ function shouldWriteResult<T>(
   result: FormattedExecutionResult<T>,
   errorPolicy: ErrorPolicy = "none"
 ) {
-  const ignoreErrors = errorPolicy === "ignore" || errorPolicy === "all";
+  const ignoreErrors =
+    errorPolicy === "ignore" ||
+    errorPolicy === "all" ||
+    errorPolicy === "localized";
   let writeWithErrors = !graphQLResultHasError(result);
   if (!writeWithErrors && ignoreErrors && result.data) {
     writeWithErrors = true;
   }
   return writeWithErrors;
+}
+
+/**
+ * Collects the response paths that the `localized` error policy keeps out of
+ * the cache. Every other error policy writes the full result, so this returns
+ * an empty array for them.
+ *
+ * Errors without a `path` cannot be attributed to a field, so they don't
+ * restrict the write at all.
+ */
+function getSkipPaths<T>(
+  result: FormattedExecutionResult<T>,
+  errorPolicy: ErrorPolicy = "none"
+): ReadonlyArray<ReadonlyArray<string | number>> {
+  if (errorPolicy !== "localized" || !result.errors) {
+    return [];
+  }
+
+  const skipPaths: Array<ReadonlyArray<string | number>> = [];
+  for (const error of result.errors) {
+    if (error.path && error.path.length) {
+      skipPaths.push(error.path);
+    }
+  }
+  return skipPaths;
 }

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -440,7 +440,7 @@ export class QueryManager {
               return resolve({ data: undefined });
             }
 
-            if (errorPolicy === "all" || errorPolicy === "localized") {
+            if (errorPolicy === "all") {
               return resolve({ data: undefined, error });
             }
 
@@ -1119,7 +1119,13 @@ export class QueryManager {
         return aqr;
       }),
       catchError((error) => {
-        if (errorPolicy === "none") {
+        // `localized` softens errors that belong to a FIELD. An error that reaches
+        // here instead of arriving in the response body failed the whole operation,
+        // so there is no field to localize it to and no response shape to hand back
+        // — it keeps `none`'s behavior. Emitting an empty result here would clear
+        // data the subscriber is already rendering, which is exactly the collateral
+        // damage the policy exists to avoid.
+        if (errorPolicy === "none" || errorPolicy === "localized") {
           queryInfo.resetLastWrite();
           observableQuery?.["resetNotifications"]();
           throw error;

--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -440,7 +440,7 @@ export class QueryManager {
               return resolve({ data: undefined });
             }
 
-            if (errorPolicy === "all") {
+            if (errorPolicy === "all" || errorPolicy === "localized") {
               return resolve({ data: undefined, error });
             }
 

--- a/src/core/__tests__/localizedErrorPolicy.test.ts
+++ b/src/core/__tests__/localizedErrorPolicy.test.ts
@@ -255,15 +255,18 @@ describe("errorPolicy: 'localized'", () => {
       });
     });
 
-    it("resolves with the error on a network error", async () => {
+    it("rejects on a network error, like `none`", async () => {
       const networkError = new Error("Oops");
       const client = createClient([
         { request: { query: profileQuery }, error: networkError },
       ]);
 
+      // A transport failure has no error `path`, so there is no field to localize
+      // it to and no response shape to hand back. Resolving with an empty result
+      // (what `all` does) would clear data the caller is already rendering.
       await expect(
         client.query({ query: profileQuery, errorPolicy: "localized" })
-      ).resolves.toStrictEqualTyped({ data: undefined, error: networkError });
+      ).rejects.toThrow(networkError);
     });
 
     it("omits a field on a single list item", async () => {
@@ -736,7 +739,7 @@ describe("errorPolicy: 'localized'", () => {
       });
     });
 
-    it("resolves with the error on a network error", async () => {
+    it("rejects on a network error, like `none`", async () => {
       const networkError = new Error("Oops");
       const client = createClient([
         { request: { query: mutation }, error: networkError },
@@ -744,7 +747,7 @@ describe("errorPolicy: 'localized'", () => {
 
       await expect(
         client.mutate({ mutation, errorPolicy: "localized" })
-      ).resolves.toStrictEqualTyped({ data: undefined, error: networkError });
+      ).rejects.toThrow(networkError);
     });
   });
 

--- a/src/core/__tests__/localizedErrorPolicy.test.ts
+++ b/src/core/__tests__/localizedErrorPolicy.test.ts
@@ -1,0 +1,797 @@
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { GraphQLError } from "graphql";
+import { gql } from "graphql-tag";
+
+import { ApolloClient, NetworkStatus } from "@apollo/client";
+import { InMemoryCache } from "@apollo/client/cache";
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import { MockLink, MockSubscriptionLink } from "@apollo/client/testing";
+import {
+  ObservableStream,
+  spyOnConsole,
+} from "@apollo/client/testing/internal";
+
+interface ProfileQueryData {
+  profile: {
+    __typename: "Profile";
+    id: string;
+    name: string;
+    bio: string | null;
+  };
+}
+
+const profileQuery: TypedDocumentNode<ProfileQueryData> = gql`
+  query ProfileQuery {
+    profile {
+      __typename
+      id
+      name
+      bio
+    }
+  }
+`;
+
+const bioError = new GraphQLError("Could not load bio", {
+  path: ["profile", "bio"],
+});
+
+const profileResult = {
+  data: {
+    profile: {
+      __typename: "Profile" as const,
+      id: "1",
+      name: "Alice",
+      bio: null,
+    },
+  },
+  errors: [bioError],
+};
+
+function extract(client: ApolloClient) {
+  return (client.cache as InMemoryCache).extract();
+}
+
+function createClient(
+  mocks: ConstructorParameters<typeof MockLink>[0],
+  cache = new InMemoryCache()
+) {
+  return new ApolloClient({ cache, link: new MockLink(mocks) });
+}
+
+describe("errorPolicy: 'localized'", () => {
+  describe("client.query", () => {
+    it("resolves with the full response shape and the errors", async () => {
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      await expect(
+        client.query({ query: profileQuery, errorPolicy: "localized" })
+      ).resolves.toStrictEqualTyped({
+        data: {
+          profile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: null,
+          },
+        },
+        error: new CombinedGraphQLErrors(profileResult),
+      });
+    });
+
+    it("writes only the fields without errors to the cache", async () => {
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+      expect(client.extract()).toStrictEqual({
+        ROOT_QUERY: {
+          __typename: "Query",
+          profile: { __ref: "Profile:1" },
+        },
+        "Profile:1": {
+          __typename: "Profile",
+          id: "1",
+          name: "Alice",
+        },
+      });
+    });
+
+    it("leaves the cache read incomplete for the errored field", async () => {
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+      expect(
+        client.cache.diff({ query: profileQuery, optimistic: false }).complete
+      ).toBe(false);
+    });
+
+    it("does not warn that the written result read back partial", async () => {
+      using _ = spyOnConsole("warn");
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("writes the full result when the response has no errors", async () => {
+      const client = createClient([
+        {
+          request: { query: profileQuery },
+          result: {
+            data: {
+              profile: {
+                __typename: "Profile",
+                id: "1",
+                name: "Alice",
+                bio: "Hello",
+              },
+            },
+          },
+        },
+      ]);
+
+      await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+      expect(extract(client)["Profile:1"]).toStrictEqual({
+        __typename: "Profile",
+        id: "1",
+        name: "Alice",
+        bio: "Hello",
+      });
+    });
+
+    it("writes the full result when the errors carry no path", async () => {
+      const client = createClient([
+        {
+          request: { query: profileQuery },
+          result: {
+            data: {
+              profile: {
+                __typename: "Profile",
+                id: "1",
+                name: "Alice",
+                bio: null,
+              },
+            },
+            errors: [new GraphQLError("Something went wrong")],
+          },
+        },
+      ]);
+
+      await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+      expect(extract(client)["Profile:1"]).toStrictEqual({
+        __typename: "Profile",
+        id: "1",
+        name: "Alice",
+        bio: null,
+      });
+    });
+
+    it("keeps a previously cached value for the errored field", async () => {
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      client.writeQuery({
+        query: profileQuery,
+        data: {
+          profile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: "Cached bio",
+          },
+        },
+      });
+
+      await client.query({
+        query: profileQuery,
+        errorPolicy: "localized",
+        fetchPolicy: "network-only",
+      });
+
+      expect(extract(client)["Profile:1"]).toStrictEqual({
+        __typename: "Profile",
+        id: "1",
+        name: "Alice",
+        bio: "Cached bio",
+      });
+    });
+
+    it("resolves with the cached value for the errored field when the cache read is complete", async () => {
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      client.writeQuery({
+        query: profileQuery,
+        data: {
+          profile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: "Cached bio",
+          },
+        },
+      });
+
+      await expect(
+        client.query({
+          query: profileQuery,
+          errorPolicy: "localized",
+          fetchPolicy: "network-only",
+        })
+      ).resolves.toStrictEqualTyped({
+        data: {
+          profile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: "Cached bio",
+          },
+        },
+        error: new CombinedGraphQLErrors({
+          data: {
+            profile: {
+              __typename: "Profile",
+              id: "1",
+              name: "Alice",
+              bio: "Cached bio",
+            },
+          },
+          errors: [bioError],
+        }),
+      });
+    });
+
+    it("resolves with the error on a network error", async () => {
+      const networkError = new Error("Oops");
+      const client = createClient([
+        { request: { query: profileQuery }, error: networkError },
+      ]);
+
+      await expect(
+        client.query({ query: profileQuery, errorPolicy: "localized" })
+      ).resolves.toStrictEqualTyped({ data: undefined, error: networkError });
+    });
+
+    it("omits a field on a single list item", async () => {
+      const query = gql`
+        query PeopleQuery {
+          people {
+            __typename
+            id
+            name
+          }
+        }
+      `;
+      const errors = [
+        new GraphQLError("Could not load name", {
+          path: ["people", 1, "name"],
+        }),
+      ];
+      const client = createClient([
+        {
+          request: { query },
+          result: {
+            data: {
+              people: [
+                { __typename: "Person", id: "1", name: "Alice" },
+                { __typename: "Person", id: "2", name: null },
+              ],
+            },
+            errors,
+          },
+        },
+      ]);
+
+      await expect(
+        client.query({ query, errorPolicy: "localized" })
+      ).resolves.toStrictEqualTyped({
+        data: {
+          people: [
+            { __typename: "Person", id: "1", name: "Alice" },
+            { __typename: "Person", id: "2", name: null },
+          ],
+        },
+        error: new CombinedGraphQLErrors({
+          data: {
+            people: [
+              { __typename: "Person", id: "1", name: "Alice" },
+              { __typename: "Person", id: "2", name: null },
+            ],
+          },
+          errors,
+        }),
+      });
+
+      expect(extract(client)["Person:1"]).toStrictEqual({
+        __typename: "Person",
+        id: "1",
+        name: "Alice",
+      });
+      expect(extract(client)["Person:2"]).toStrictEqual({
+        __typename: "Person",
+        id: "2",
+      });
+    });
+
+    it("omits the null parent when an error propagates up from a non-null field", async () => {
+      const query = gql`
+        query ProfileQuery {
+          viewer
+          profile {
+            __typename
+            id
+            name
+          }
+        }
+      `;
+      const client = createClient([
+        {
+          request: { query },
+          result: {
+            data: { viewer: "me", profile: null },
+            errors: [
+              new GraphQLError("Could not load name", {
+                path: ["profile", "name"],
+              }),
+            ],
+          },
+        },
+      ]);
+
+      await client.query({ query, errorPolicy: "localized" });
+
+      expect(client.extract()).toStrictEqual({
+        ROOT_QUERY: { __typename: "Query", viewer: "me" },
+      });
+    });
+
+    it("writes the whole result under 'all' for comparison", async () => {
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      await client.query({ query: profileQuery, errorPolicy: "all" });
+
+      expect(extract(client)["Profile:1"]).toStrictEqual({
+        __typename: "Profile",
+        id: "1",
+        name: "Alice",
+        bio: null,
+      });
+    });
+  });
+
+  describe("client.watchQuery", () => {
+    it("emits the full response shape together with the error", async () => {
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      const stream = new ObservableStream(
+        client.watchQuery({ query: profileQuery, errorPolicy: "localized" })
+      );
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
+
+      await expect(stream).toEmitTypedValue({
+        data: {
+          profile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: null,
+          },
+        },
+        dataState: "complete",
+        error: new CombinedGraphQLErrors(profileResult),
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        partial: false,
+      });
+
+      await expect(stream).not.toEmitAnything();
+    });
+
+    it("does not replace the emitted result with the incomplete cache result", async () => {
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      const observable = client.watchQuery({
+        query: profileQuery,
+        errorPolicy: "localized",
+      });
+      const stream = new ObservableStream(observable);
+
+      await expect(stream).toEmitTypedValue({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
+      await expect(stream).toEmitNext();
+
+      // An unrelated cache write triggers a broadcast. The incomplete cache
+      // result must not clobber the response the query already delivered.
+      client.writeQuery({
+        query: gql`
+          query {
+            unrelated
+          }
+        `,
+        data: { unrelated: "value" },
+      });
+
+      await expect(stream).not.toEmitAnything();
+      expect(observable.getCurrentResult()).toStrictEqualTyped({
+        data: {
+          profile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: null,
+          },
+        },
+        dataState: "complete",
+        error: new CombinedGraphQLErrors(profileResult),
+        loading: false,
+        networkStatus: NetworkStatus.error,
+        partial: false,
+      });
+    });
+
+    it("broadcasts the successfully written fields to another watched query", async () => {
+      const nameQuery: TypedDocumentNode<{
+        profile: { __typename: "Profile"; id: string; name: string };
+      }> = gql`
+        query NameQuery {
+          profile {
+            __typename
+            id
+            name
+          }
+        }
+      `;
+
+      const client = createClient([
+        {
+          request: { query: nameQuery },
+          result: {
+            data: {
+              profile: { __typename: "Profile", id: "1", name: "Old name" },
+            },
+          },
+        },
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      const nameStream = new ObservableStream(
+        client.watchQuery({ query: nameQuery })
+      );
+
+      await expect(nameStream).toEmitTypedValue({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
+      await expect(nameStream).toEmitTypedValue({
+        data: { profile: { __typename: "Profile", id: "1", name: "Old name" } },
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+
+      await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+      // `name` was written and broadcast even though `bio` errored.
+      await expect(nameStream).toEmitTypedValue({
+        data: { profile: { __typename: "Profile", id: "1", name: "Alice" } },
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+    });
+
+    it("does not broadcast an errored field to another watched query", async () => {
+      const bioQuery: TypedDocumentNode<{
+        profile: { __typename: "Profile"; id: string; bio: string };
+      }> = gql`
+        query BioQuery {
+          profile {
+            __typename
+            id
+            bio
+          }
+        }
+      `;
+
+      const client = createClient([
+        {
+          request: { query: bioQuery },
+          result: {
+            data: {
+              profile: { __typename: "Profile", id: "1", bio: "Existing bio" },
+            },
+          },
+        },
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      const bioStream = new ObservableStream(
+        client.watchQuery({ query: bioQuery })
+      );
+
+      await expect(bioStream).toEmitTypedValue({
+        data: undefined,
+        dataState: "empty",
+        loading: true,
+        networkStatus: NetworkStatus.loading,
+        partial: true,
+      });
+      await expect(bioStream).toEmitTypedValue({
+        data: {
+          profile: { __typename: "Profile", id: "1", bio: "Existing bio" },
+        },
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+
+      await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+      // `bio` was never written, so this query keeps its value and is not
+      // notified with `null`.
+      await expect(bioStream).not.toEmitAnything();
+      expect(client.readQuery({ query: bioQuery })?.profile.bio).toBe(
+        "Existing bio"
+      );
+    });
+
+    it("clobbers the errored field for another watched query under 'all'", async () => {
+      const bioQuery: TypedDocumentNode<{
+        profile: { __typename: "Profile"; id: string; bio: string | null };
+      }> = gql`
+        query BioQuery {
+          profile {
+            __typename
+            id
+            bio
+          }
+        }
+      `;
+
+      const client = createClient([
+        {
+          request: { query: bioQuery },
+          result: {
+            data: {
+              profile: { __typename: "Profile", id: "1", bio: "Existing bio" },
+            },
+          },
+        },
+        { request: { query: profileQuery }, result: profileResult },
+      ]);
+
+      const bioStream = new ObservableStream(
+        client.watchQuery({ query: bioQuery })
+      );
+
+      await expect(bioStream).toEmitNext();
+      await expect(bioStream).toEmitNext();
+
+      await client.query({ query: profileQuery, errorPolicy: "all" });
+
+      await expect(bioStream).toEmitTypedValue({
+        data: { profile: { __typename: "Profile", id: "1", bio: null } },
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+    });
+
+    it("emits the complete result once another operation supplies the missing field", async () => {
+      const bioQuery: TypedDocumentNode<{
+        profile: { __typename: "Profile"; id: string; bio: string };
+      }> = gql`
+        query BioQuery {
+          profile {
+            __typename
+            id
+            bio
+          }
+        }
+      `;
+
+      const client = createClient([
+        { request: { query: profileQuery }, result: profileResult },
+        {
+          request: { query: bioQuery },
+          result: {
+            data: {
+              profile: { __typename: "Profile", id: "1", bio: "Repaired bio" },
+            },
+          },
+        },
+      ]);
+
+      const stream = new ObservableStream(
+        client.watchQuery({ query: profileQuery, errorPolicy: "localized" })
+      );
+
+      await expect(stream).toEmitNext();
+      await expect(stream).toEmitNext();
+
+      await client.query({ query: bioQuery });
+
+      await expect(stream).toEmitTypedValue({
+        data: {
+          profile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: "Repaired bio",
+          },
+        },
+        dataState: "complete",
+        loading: false,
+        networkStatus: NetworkStatus.ready,
+        partial: false,
+      });
+    });
+  });
+
+  describe("client.mutate", () => {
+    const mutation: TypedDocumentNode<{
+      updateProfile: {
+        __typename: "Profile";
+        id: string;
+        name: string;
+        bio: string | null;
+      };
+    }> = gql`
+      mutation UpdateProfile {
+        updateProfile {
+          __typename
+          id
+          name
+          bio
+        }
+      }
+    `;
+
+    const mutationResult = {
+      data: {
+        updateProfile: {
+          __typename: "Profile" as const,
+          id: "1",
+          name: "Alice",
+          bio: null,
+        },
+      },
+      errors: [
+        new GraphQLError("Could not load bio", {
+          path: ["updateProfile", "bio"],
+        }),
+      ],
+    };
+
+    it("resolves with the full response shape and the errors", async () => {
+      const client = createClient([
+        { request: { query: mutation }, result: mutationResult },
+      ]);
+
+      await expect(
+        client.mutate({ mutation, errorPolicy: "localized" })
+      ).resolves.toStrictEqualTyped({
+        data: {
+          updateProfile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: null,
+          },
+        },
+        error: new CombinedGraphQLErrors(mutationResult),
+      });
+    });
+
+    it("writes only the fields without errors to the cache", async () => {
+      const client = createClient([
+        { request: { query: mutation }, result: mutationResult },
+      ]);
+
+      await client.mutate({ mutation, errorPolicy: "localized" });
+
+      expect(extract(client)["Profile:1"]).toStrictEqual({
+        __typename: "Profile",
+        id: "1",
+        name: "Alice",
+      });
+    });
+
+    it("resolves with the error on a network error", async () => {
+      const networkError = new Error("Oops");
+      const client = createClient([
+        { request: { query: mutation }, error: networkError },
+      ]);
+
+      await expect(
+        client.mutate({ mutation, errorPolicy: "localized" })
+      ).resolves.toStrictEqualTyped({ data: undefined, error: networkError });
+    });
+  });
+
+  describe("client.subscribe", () => {
+    it("writes only the fields without errors to the cache", async () => {
+      const subscription = gql`
+        subscription ProfileUpdated {
+          profileUpdated {
+            __typename
+            id
+            name
+            bio
+          }
+        }
+      `;
+      const link = new MockSubscriptionLink();
+      const client = new ApolloClient({ cache: new InMemoryCache(), link });
+
+      const stream = new ObservableStream(
+        client.subscribe({ query: subscription, errorPolicy: "localized" })
+      );
+
+      link.simulateResult({
+        result: {
+          data: {
+            profileUpdated: {
+              __typename: "Profile",
+              id: "1",
+              name: "Alice",
+              bio: null,
+            },
+          },
+          errors: [
+            new GraphQLError("Could not load bio", {
+              path: ["profileUpdated", "bio"],
+            }),
+          ],
+        },
+      });
+
+      await expect(stream).toEmitNext();
+
+      expect(extract(client)["Profile:1"]).toStrictEqual({
+        __typename: "Profile",
+        id: "1",
+        name: "Alice",
+      });
+    });
+  });
+});

--- a/src/core/__tests__/localizedErrorPolicy.test.ts
+++ b/src/core/__tests__/localizedErrorPolicy.test.ts
@@ -150,6 +150,53 @@ describe("errorPolicy: 'localized'", () => {
       });
     });
 
+    it("still delivers data for a body error with no path, unlike a network error", async () => {
+      const pathless = new GraphQLError("Something went wrong");
+      const client = createClient([
+        {
+          request: { query: profileQuery },
+          result: {
+            data: {
+              profile: {
+                __typename: "Profile",
+                id: "1",
+                name: "Alice",
+                bio: null,
+              },
+            },
+            errors: [pathless],
+          },
+        },
+      ]);
+
+      // The `none` fallback is keyed on HOW the error arrived, not on whether it has
+      // a `path`: an error in the response body still comes with a response shape,
+      // so it resolves like `all` and only forgoes restricting the cache write.
+      await expect(
+        client.query({ query: profileQuery, errorPolicy: "localized" })
+      ).resolves.toStrictEqualTyped({
+        data: {
+          profile: {
+            __typename: "Profile",
+            id: "1",
+            name: "Alice",
+            bio: null,
+          },
+        },
+        error: new CombinedGraphQLErrors({
+          data: {
+            profile: {
+              __typename: "Profile",
+              id: "1",
+              name: "Alice",
+              bio: null,
+            },
+          },
+          errors: [pathless],
+        }),
+      });
+    });
+
     it("writes the full result when the errors carry no path", async () => {
       const client = createClient([
         {

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -40,8 +40,10 @@ export type RefetchWritePolicy = "merge" | "overwrite";
  * - none (default): any errors from the request are treated like runtime errors and the observable is stopped
  * - ignore: errors from the request do not stop the observable, but also don't call `next`
  * - all: errors are treated like data and will notify observables
+ * - localized: errors are treated like data and will notify observables, but the
+ *   fields the errors point at are not written to the cache
  */
-export type ErrorPolicy = "none" | "ignore" | "all";
+export type ErrorPolicy = "none" | "ignore" | "all" | "localized";
 
 export interface NextFetchPolicyContext<
   TData,

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -40,8 +40,10 @@ export type RefetchWritePolicy = "merge" | "overwrite";
  * - none (default): any errors from the request are treated like runtime errors and the observable is stopped
  * - ignore: errors from the request do not stop the observable, but also don't call `next`
  * - all: errors are treated like data and will notify observables
- * - localized: errors are treated like data and will notify observables, but the
- *   fields the errors point at are not written to the cache
+ * - localized: like `all` for errors that name a field `path` — the result and the
+ *   errors both reach observables — but the fields those errors point at are not
+ *   written to the cache. An error with no field to attribute it to (a network or
+ *   transport failure) behaves like `none`.
  */
 export type ErrorPolicy = "none" | "ignore" | "all" | "localized";
 

--- a/src/core/watchQueryOptions.ts
+++ b/src/core/watchQueryOptions.ts
@@ -40,10 +40,10 @@ export type RefetchWritePolicy = "merge" | "overwrite";
  * - none (default): any errors from the request are treated like runtime errors and the observable is stopped
  * - ignore: errors from the request do not stop the observable, but also don't call `next`
  * - all: errors are treated like data and will notify observables
- * - localized: like `all` for errors that name a field `path` — the result and the
- *   errors both reach observables — but the fields those errors point at are not
- *   written to the cache. An error with no field to attribute it to (a network or
- *   transport failure) behaves like `none`.
+ * - localized: like `all` for errors in the response body — the result and the errors
+ *   both reach observables — but the fields those errors name in their `path` are not
+ *   written to the cache. An error that fails the whole operation instead of arriving
+ *   in the body (a network or transport error) behaves like `none`.
  */
 export type ErrorPolicy = "none" | "ignore" | "all" | "localized";
 

--- a/src/react/hooks/__tests__/useQuery/localizedErrorPolicy.test.tsx
+++ b/src/react/hooks/__tests__/useQuery/localizedErrorPolicy.test.tsx
@@ -1,0 +1,288 @@
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import {
+  disableActEnvironment,
+  renderHookToSnapshotStream,
+} from "@testing-library/react-render-stream";
+import { GraphQLError } from "graphql";
+
+import {
+  ApolloClient,
+  CombinedGraphQLErrors,
+  gql,
+  InMemoryCache,
+  NetworkStatus,
+} from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client/react";
+import { MockLink } from "@apollo/client/testing";
+import { createClientWrapper } from "@apollo/client/testing/internal";
+
+interface ProfileQueryData {
+  profile: {
+    __typename: "Profile";
+    id: string;
+    name: string;
+    bio: string | null;
+  };
+}
+
+const profileQuery: TypedDocumentNode<ProfileQueryData> = gql`
+  query ProfileQuery {
+    profile {
+      __typename
+      id
+      name
+      bio
+    }
+  }
+`;
+
+const bioError = new GraphQLError("Could not load bio", {
+  path: ["profile", "bio"],
+});
+
+function extract(client: ApolloClient) {
+  return (client.cache as InMemoryCache).extract();
+}
+
+const profileData = {
+  profile: {
+    __typename: "Profile" as const,
+    id: "1",
+    name: "Alice",
+    bio: null,
+  },
+};
+
+test("useQuery renders the full response shape while the cache holds only the successful fields", async () => {
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query: profileQuery },
+        result: { data: profileData, errors: [bioError] },
+      },
+    ]),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(profileQuery, { errorPolicy: "localized" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: profileData,
+    dataState: "complete",
+    error: new CombinedGraphQLErrors({
+      data: profileData,
+      errors: [bioError],
+    }),
+    loading: false,
+    networkStatus: NetworkStatus.error,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot).not.toRerender();
+
+  expect(extract(client)["Profile:1"]).toStrictEqual({
+    __typename: "Profile",
+    id: "1",
+    name: "Alice",
+  });
+});
+
+test("a component reading only the successful fields is updated", async () => {
+  const nameQuery: TypedDocumentNode<{
+    profile: { __typename: "Profile"; id: string; name: string };
+  }> = gql`
+    query NameQuery {
+      profile {
+        __typename
+        id
+        name
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query: nameQuery },
+        result: {
+          data: {
+            profile: { __typename: "Profile", id: "1", name: "Old name" },
+          },
+        },
+      },
+      {
+        request: { query: profileQuery },
+        result: { data: profileData, errors: [bioError] },
+      },
+    ]),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(nameQuery),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { profile: { __typename: "Profile", id: "1", name: "Old name" } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { profile: { __typename: "Profile", id: "1", name: "Alice" } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: {
+      profile: { __typename: "Profile", id: "1", name: "Old name" },
+    },
+    variables: {},
+  });
+});
+
+test("a component reading an errored field keeps its cached value", async () => {
+  const bioQuery: TypedDocumentNode<{
+    profile: { __typename: "Profile"; id: string; bio: string };
+  }> = gql`
+    query BioQuery {
+      profile {
+        __typename
+        id
+        bio
+      }
+    }
+  `;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query: bioQuery },
+        result: {
+          data: {
+            profile: { __typename: "Profile", id: "1", bio: "Existing bio" },
+          },
+        },
+      },
+      {
+        request: { query: profileQuery },
+        result: { data: profileData, errors: [bioError] },
+      },
+    ]),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useQuery(bioQuery),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: { profile: { __typename: "Profile", id: "1", bio: "Existing bio" } },
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    previousData: undefined,
+    variables: {},
+  });
+
+  await client.query({ query: profileQuery, errorPolicy: "localized" });
+
+  await expect(takeSnapshot).not.toRerender();
+});
+
+test("useMutation returns the full response shape and writes only the successful fields", async () => {
+  const mutation: TypedDocumentNode<{
+    updateProfile: {
+      __typename: "Profile";
+      id: string;
+      name: string;
+      bio: string | null;
+    };
+  }> = gql`
+    mutation UpdateProfile {
+      updateProfile {
+        __typename
+        id
+        name
+        bio
+      }
+    }
+  `;
+  const data = {
+    updateProfile: {
+      __typename: "Profile" as const,
+      id: "1",
+      name: "Alice",
+      bio: null,
+    },
+  };
+  const errors = [
+    new GraphQLError("Could not load bio", { path: ["updateProfile", "bio"] }),
+  ];
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      { request: { query: mutation }, result: { data, errors } },
+    ]),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useMutation(mutation, { errorPolicy: "localized" }),
+    { wrapper: createClientWrapper(client) }
+  );
+
+  const [execute] = await takeSnapshot();
+
+  await expect(execute()).resolves.toStrictEqualTyped({
+    data,
+    error: new CombinedGraphQLErrors({ data, errors }),
+  });
+
+  expect(extract(client)["Profile:1"]).toStrictEqual({
+    __typename: "Profile",
+    id: "1",
+    name: "Alice",
+  });
+});

--- a/src/react/hooks/__tests__/useSuspenseQuery/localizedErrorPolicy.test.tsx
+++ b/src/react/hooks/__tests__/useSuspenseQuery/localizedErrorPolicy.test.tsx
@@ -1,0 +1,93 @@
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import {
+  disableActEnvironment,
+  renderHookToSnapshotStream,
+} from "@testing-library/react-render-stream";
+import { GraphQLError } from "graphql";
+import * as React from "react";
+
+import {
+  ApolloClient,
+  CombinedGraphQLErrors,
+  gql,
+  InMemoryCache,
+  NetworkStatus,
+} from "@apollo/client";
+import { useSuspenseQuery } from "@apollo/client/react";
+import { MockLink } from "@apollo/client/testing";
+import { createClientWrapper } from "@apollo/client/testing/internal";
+
+interface ProfileQueryData {
+  profile: {
+    __typename: "Profile";
+    id: string;
+    name: string;
+    bio: string | null;
+  };
+}
+
+const profileQuery: TypedDocumentNode<ProfileQueryData> = gql`
+  query ProfileQuery {
+    profile {
+      __typename
+      id
+      name
+      bio
+    }
+  }
+`;
+
+const bioError = new GraphQLError("Could not load bio", {
+  path: ["profile", "bio"],
+});
+
+function extract(client: ApolloClient) {
+  return (client.cache as InMemoryCache).extract();
+}
+
+const profileData = {
+  profile: {
+    __typename: "Profile" as const,
+    id: "1",
+    name: "Alice",
+    bio: null,
+  },
+};
+
+test("resolves with the full response shape instead of throwing", async () => {
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new MockLink([
+      {
+        request: { query: profileQuery },
+        result: { data: profileData, errors: [bioError] },
+      },
+    ]),
+  });
+
+  using _disabledAct = disableActEnvironment();
+  const { takeSnapshot } = await renderHookToSnapshotStream(
+    () => useSuspenseQuery(profileQuery, { errorPolicy: "localized" }),
+    {
+      wrapper: createClientWrapper(client, ({ children }) => (
+        <React.Suspense fallback="loading">{children}</React.Suspense>
+      )),
+    }
+  );
+
+  await expect(takeSnapshot()).resolves.toStrictEqualTyped({
+    data: profileData,
+    dataState: "complete",
+    error: new CombinedGraphQLErrors({
+      data: profileData,
+      errors: [bioError],
+    }),
+    networkStatus: NetworkStatus.error,
+  });
+
+  expect(extract(client)["Profile:1"]).toStrictEqual({
+    __typename: "Profile",
+    id: "1",
+    name: "Alice",
+  });
+});

--- a/src/react/hooks/useMutation.ts
+++ b/src/react/hooks/useMutation.ts
@@ -179,6 +179,13 @@ export declare namespace useMutation {
       /** {@inheritDoc @apollo/client!MutationResultDocumentation#error:member} */
       error: undefined;
     };
+    localized: {
+      /** {@inheritDoc @apollo/client!MutationResultDocumentation#data:member} */
+      data: MaybeMasked<TData> | null | undefined;
+
+      /** {@inheritDoc @apollo/client!MutationResultDocumentation#error:member} */
+      error: ErrorLike | undefined;
+    };
     undefined: {
       /** {@inheritDoc @apollo/client!MutationResultDocumentation#data:member} */
       data: MaybeMasked<TData> | null | undefined;

--- a/src/react/types/types.documentation.ts
+++ b/src/react/types/types.documentation.ts
@@ -22,6 +22,9 @@ export interface QueryOptionsDocumentation {
    *
    * The default value is `none`, meaning that the query result includes error details but not partial results.
    *
+   * Use `localized` to receive the full response shape while keeping the fields
+   * the errors point at out of the cache.
+   *
    * @docGroup 1. Operation options
    */
   errorPolicy: unknown;


### PR DESCRIPTION
# Adding a new error policy: `localized`

This PR adds a new error policy which does the following when an error is present on an operation response:
- Provides the full response shape to the calling consumer along with error, like `all` does today. Errored fields come back as the server sent them (`null`) unless the cache already holds a value for that field, in which case the cache read is complete and the consumer sees the last known good value.
- DOES NOT write the error paths to the cache, but does write the rest of the field paths (unlike `all` today).

## The problem

Our web frontend is reliant on Apollo's cache for acting as a data store for any GraphQL calls made to Twitch's API in the app, as well as updating components across the entire app when the underlying data store changes. Because of this reliance, incorrect cache updates can be particularly problematic if the data is unsound.

When our GraphQL API encounters an error resolving a field, that field (or its next nullable parent) become `null` in the response. This means that if you ask for something common for our schema, e.g. a live stream's `User` type, and there's an error returning the result you can end up with a `{ user: null }` response from the API. When using the `all` or `ignore` error policies, this `null` user is written to the cache and dozens of components across the app all update at once with this new information. This can be devastating if you are watching a live stream and suddenly an error response has been written to the cache indicating that user does not exist - goodbye live stream.

## Why a new error policy

The `localized` error policy insulates us from this scenario, letting us have our cake and eat it too. We get all of the benefits of the `all` error policy in building feature experiences that gracefully degrade in the presence of errors. And we isolate errors to the specific querying features instead of sharing the error across the entire user experience.

There are no combinations of fetch policy and error policy that exist today to protect us from the problematic scenario above.

## Production-tested

Twitch has been running a patch of Apollo Client in production since 2020 to solve this issue, serving millions of users watching live content every day.

## Feature Request

In 2021, I opened a [feature request](https://github.com/apollographql/apollo-feature-requests/issues/284) that has gone stale. I am opening the implementation PR to trigger more direct conversation about the implementation and ideally provide an off-ramp for Twitch so we no longer must maintain a patch across version upgrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `localized` error policy for queries, mutations, subscriptions, and React hooks.
  * Responses retain their full shape while fields with GraphQL errors are excluded from cache writes, preserving existing cached values.
  * Network and transport errors continue to behave as fatal errors.
  * Added `skipPaths` options for selectively omitting fields during cache writes.

* **Documentation**
  * Added guidance and comparisons for localized error handling and selective cache writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->