### PR TITLE
Unregister the watch when an immediate `cache.watch` broadcast throws

### DIFF
--- a/.changeset/thick-pots-repeat.md
+++ b/.changeset/thick-pots-repeat.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Unregister the watch when an immediate `cache.watch` broadcast throws. Previously the watch was added to the cache before its first read, and a read that threw left the watch registered while the caller never received the unsubscribe function, so it could not be removed and every later broadcast ran into the same failing read.

--- a/src/cache/inmemory/__tests__/cache.ts
+++ b/src/cache/inmemory/__tests__/cache.ts
@@ -2395,6 +2395,55 @@ describe("resultCacheMaxSize", () => {
   });
 });
 
+describe("InMemoryCache#watch", () => {
+  it("does not leave the watch registered when an immediate broadcast throws", () => {
+    const unreadable = gql`
+      query {
+        unreadable
+      }
+    `;
+    const readable = gql`
+      query {
+        readable
+      }
+    `;
+
+    const cache = new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            unreadable: {
+              read() {
+                throw new Error("read failed");
+              },
+            },
+          },
+        },
+      },
+    });
+
+    cache.writeQuery({ query: readable, data: { readable: "hello" } });
+
+    expect(() =>
+      cache.watch({
+        query: unreadable,
+        optimistic: false,
+        immediate: true,
+        callback() {},
+      })
+    ).toThrow("read failed");
+
+    // `watch` threw before it could return its unsubscribe function, so anything left in the set here can
+    // never be removed by the caller.
+    expect(cache["watches"].size).toBe(0);
+
+    // ...and every later broadcast would run into the same failing read.
+    expect(() =>
+      cache.writeQuery({ query: readable, data: { readable: "goodbye" } })
+    ).not.toThrow();
+  });
+});
+
 describe("InMemoryCache#broadcastWatches", function () {
   it("should keep distinct consumers distinct (issue #5733)", function () {
     const cache = new InMemoryCache();

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -276,10 +276,8 @@ export class InMemoryCache extends ApolloCache {
       recallCache(this);
     }
     this.watches.add(watch);
-    if (watch.immediate) {
-      this.maybeBroadcastWatch(watch);
-    }
-    return () => {
+
+    const removeWatch = () => {
       // Once we remove the last watch from this.watches, cache.broadcastWatches
       // no longer does anything, so we preemptively tell the reactive variable
       // system to exclude this cache from future broadcasts.
@@ -291,6 +289,20 @@ export class InMemoryCache extends ApolloCache {
       // leaks involving the closure of watch.callback.
       this.maybeBroadcastWatch.forget(watch);
     };
+
+    if (watch.immediate) {
+      try {
+        this.maybeBroadcastWatch(watch);
+      } catch (error) {
+        // The caller never receives removeWatch when this throws, so without
+        // this the watch would stay registered with nothing able to remove it,
+        // and every later broadcast would run into the same failing read.
+        removeWatch();
+        throw error;
+      }
+    }
+
+    return removeWatch;
   }
 
   public gc(options?: {


### PR DESCRIPTION
Came across this while working with the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache watch cleanup when an immediate broadcast encounters an error.
  * Prevented failed watches from remaining registered and causing errors during subsequent cache writes.
* **Tests**
  * Added coverage verifying watch cleanup and continued cache operation after a broadcast failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->