### PR TITLE
Prevent "missing field" error logging for overlapping nested deferred fields. - #13454

### DIFF
--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -10,7 +10,6 @@ import type { AsStoreObject } from '@apollo/client/utilities';
 import { canonicalStringify } from '@apollo/client/utilities';
 import type { DataValue } from '@apollo/client';
 import type { DeepPartial } from '@apollo/client/utilities';
-import type { DeferInfoTrie } from '@apollo/client/utilities/internal';
 import type { DocumentNode } from 'graphql';
 import type { DocumentNode as DocumentNode_2 } from '@apollo/client';
 import type { ExtensionsWithStreamInfo } from '@apollo/client/utilities/internal';
@@ -176,8 +175,14 @@ export abstract class ApolloCache {
     // (undocumented)
     watchFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloCache.WatchFragmentOptions<TData, TVariables>): ApolloCache.ObservableFragment<Unmasked<TData> | null>;
     // (undocumented)
-    abstract write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(write: Cache_2.WriteOptions<TData, TVariables>): Reference | undefined;
+    abstract write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(write: Cache_2.WriteOptions<TData, TVariables> & {
+        [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
+    }): Reference | undefined;
     writeFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: Cache_2.WriteFragmentOptions<TData, TVariables>): Reference | undefined;
+    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteQueryOptions<TData, TVariables> & {
+        [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
+    }): Reference | undefined;
+    // (undocumented)
     writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: Cache_2.WriteQueryOptions<TData, TVariables>): Reference | undefined;
 }
 
@@ -410,7 +415,7 @@ const _deleteModifier: unique symbol;
 // @internal @deprecated (undocumented)
 export interface DiffIncrementalInfo {
     // (undocumented)
-    deferInfo?: DeferInfoTrie;
+    isDeferPending?: (path: Incremental.Path, label: string | undefined) => boolean;
     // (undocumented)
     streamInfo?: StreamInfoTrie;
 }
@@ -711,7 +716,9 @@ export class InMemoryCache extends ApolloCache {
     // (undocumented)
     watch<TData = unknown, TVariables extends OperationVariables = OperationVariables>(watch: Cache_2.WatchOptions<TData, TVariables>): () => void;
     // (undocumented)
-    write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteOptions<TData, TVariables>): Reference | undefined;
+    write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteOptions<TData, TVariables> & {
+        [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
+    }): Reference | undefined;
 }
 
 // @public (undocumented)
@@ -1013,6 +1020,8 @@ export interface ReadMergeModifyContext {
     // (undocumented)
     extensions?: ExtensionsWithStreamInfo;
     // (undocumented)
+    isDeferPending?: (path: Incremental.Path, label: string | undefined) => boolean;
+    // (undocumented)
     store: NormalizedCache;
     // (undocumented)
     variables?: OperationVariables;
@@ -1170,10 +1179,13 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/cache.ts:254:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
-// src/cache/inmemory/inMemoryCache.ts:517:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/core/cache.ts:239:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/core/cache.ts:259:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/core/cache.ts:935:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/inmemory/inMemoryCache.ts:467:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/inmemory/inMemoryCache.ts:521:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
 // src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:147:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:150:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-cache.api.md
+++ b/.api-reports/api-report-cache.api.md
@@ -179,11 +179,9 @@ export abstract class ApolloCache {
         [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
     }): Reference | undefined;
     writeFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: Cache_2.WriteFragmentOptions<TData, TVariables>): Reference | undefined;
-    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteQueryOptions<TData, TVariables> & {
-        [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
-    }): Reference | undefined;
-    // (undocumented)
     writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: Cache_2.WriteQueryOptions<TData, TVariables>): Reference | undefined;
+    // (undocumented)
+    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteQueryOptions.WithIncremental<TData, TVariables>): Reference | undefined;
 }
 
 // @public (undocumented)
@@ -363,6 +361,14 @@ namespace Cache_2 {
         overwrite?: boolean;
         query: DocumentNode_2 | TypedDocumentNode<TData, TVariables>;
         variables?: TVariables;
+    }
+    // (undocumented)
+    namespace WriteQueryOptions {
+        // Warning: (ae-forgotten-export) The symbol "WithHandleIncremental" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
+        interface WithIncremental<TData, TVariables extends OperationVariables> extends WriteQueryOptions<TData, TVariables>, WithHandleIncremental {
+        }
     }
 }
 export { Cache_2 as Cache }
@@ -1148,6 +1154,14 @@ export type WatchFragmentOptions<TData = unknown, TVariables extends OperationVa
 export type WatchFragmentResult<TData> = ApolloCache_2.WatchFragmentResult<TData>;
 
 // @public (undocumented)
+interface WithHandleIncremental {
+    // Warning: (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+    //
+    // (undocumented)
+    [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
+}
+
+// @public (undocumented)
 interface WriteContext extends ReadMergeModifyContext {
     // (undocumented)
     clientOnly: boolean;
@@ -1179,13 +1193,12 @@ interface WriteContext extends ReadMergeModifyContext {
 
 // Warnings were encountered during analysis:
 //
-// src/cache/core/cache.ts:239:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
-// src/cache/core/cache.ts:259:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
-// src/cache/core/cache.ts:935:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/core/cache.ts:238:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
+// src/cache/core/cache.ts:258:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
 // src/cache/inmemory/inMemoryCache.ts:467:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
 // src/cache/inmemory/inMemoryCache.ts:521:7 - (ae-incompatible-release-tags) The symbol "[handleIncrementalSymbol]" is marked as @public, but its signature references "DiffIncrementalInfo" which is marked as @internal
 // src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:150:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:155:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/.api-reports/api-report-incremental.api.md
+++ b/.api-reports/api-report-incremental.api.md
@@ -110,6 +110,8 @@ class DeferRequest<TData extends Record<string, unknown>> implements Incremental
     handle(cacheData: TData | DeepPartial<TData> | null | undefined, chunk: Defer20220824Handler.Chunk<TData>): FormattedExecutionResult<TData>;
     // (undocumented)
     hasNext: boolean;
+    // (undocumented)
+    isDeferPending: () => boolean;
 }
 
 // @public (undocumented)
@@ -278,6 +280,8 @@ export namespace Incremental {
         // (undocumented)
         hasNext: boolean;
         // @internal @deprecated (undocumented)
+        isDeferPending(path: Incremental.Path, label: string | undefined): boolean;
+        // @internal @deprecated (undocumented)
         readonly streamInfo?: StreamInfoTrie;
     }
     // (undocumented)
@@ -343,6 +347,8 @@ class IncrementalRequest<TData> implements Incremental.IncrementalRequest<GraphQ
     handle(cacheData: TData | DeepPartial<TData> | null | undefined, chunk: GraphQL17Alpha9Handler.Chunk<TData>): FormattedExecutionResult<TData>;
     // (undocumented)
     hasNext: boolean;
+    // @internal @deprecated (undocumented)
+    isDeferPending: (path: Incremental.Path, label: string | undefined) => boolean;
     // @internal @deprecated (undocumented)
     get streamInfo(): StreamInfoTrie | undefined;
 }

--- a/.api-reports/api-report-utilities_internal.api.md
+++ b/.api-reports/api-report-utilities_internal.api.md
@@ -179,9 +179,6 @@ type DeepOmitArray<T extends any[], K> = {
 // @public (undocumented)
 type DeepOmitPrimitive = Primitive | Function;
 
-// @internal @deprecated
-export type DeferInfoTrie = Trie<true>;
-
 // @public (undocumented)
 type Directives = {
     [directiveName: string]: {

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -174,11 +174,9 @@ export abstract class ApolloCache {
         [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
     }): Reference | undefined;
     writeFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: Cache_2.WriteFragmentOptions<TData, TVariables>): Reference | undefined;
-    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteQueryOptions<TData, TVariables> & {
-        [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
-    }): Reference | undefined;
-    // (undocumented)
     writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: Cache_2.WriteQueryOptions<TData, TVariables>): Reference | undefined;
+    // (undocumented)
+    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteQueryOptions.WithIncremental<TData, TVariables>): Reference | undefined;
 }
 
 // @public (undocumented)
@@ -967,6 +965,14 @@ namespace Cache_2 {
         overwrite?: boolean;
         query: DocumentNode | TypedDocumentNode<TData, TVariables>;
         variables?: TVariables;
+    }
+    // (undocumented)
+    namespace WriteQueryOptions {
+        // Warning: (ae-forgotten-export) The symbol "WithHandleIncremental" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
+        interface WithIncremental<TData, TVariables extends OperationVariables> extends WriteQueryOptions<TData, TVariables>, WithHandleIncremental {
+        }
     }
 }
 export { Cache_2 as Cache }
@@ -3304,6 +3310,12 @@ export type WatchQueryOptions<TVariables extends OperationVariables = OperationV
 export const windowFocusSource: RefetchEventManager.EventSource<Event>;
 
 // @public (undocumented)
+interface WithHandleIncremental {
+    // (undocumented)
+    [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
+}
+
+// @public (undocumented)
 interface WriteContext extends ReadMergeModifyContext {
     // (undocumented)
     clientOnly: boolean;
@@ -3338,12 +3350,12 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/core/cache.ts:179:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
-// src/cache/core/cache.ts:239:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:238:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:103:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:150:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:165:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:155:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:170:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:406:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts

--- a/.api-reports/api-report.api.md
+++ b/.api-reports/api-report.api.md
@@ -170,8 +170,14 @@ export abstract class ApolloCache {
     // (undocumented)
     watchFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: ApolloCache.WatchFragmentOptions<TData, TVariables>): ApolloCache.ObservableFragment<Unmasked<TData> | null>;
     // (undocumented)
-    abstract write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(write: Cache_2.WriteOptions<TData, TVariables>): Reference | undefined;
+    abstract write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(write: Cache_2.WriteOptions<TData, TVariables> & {
+        [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
+    }): Reference | undefined;
     writeFragment<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: Cache_2.WriteFragmentOptions<TData, TVariables>): Reference | undefined;
+    writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteQueryOptions<TData, TVariables> & {
+        [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
+    }): Reference | undefined;
+    // (undocumented)
     writeQuery<TData = unknown, TVariables extends OperationVariables = OperationVariables>(input: Cache_2.WriteQueryOptions<TData, TVariables>): Reference | undefined;
 }
 
@@ -1162,9 +1168,6 @@ export type DefaultOptions = ApolloClient.DefaultOptions;
 // @public (undocumented)
 export const defaultPrinter: BaseHttpLink.Printer;
 
-// @internal @deprecated
-type DeferInfoTrie = Trie<true>;
-
 // @public (undocumented)
 interface DeleteModifier {
     // (undocumented)
@@ -1179,10 +1182,8 @@ export type DevtoolsOptions = ApolloClient.DevtoolsOptions;
 
 // @internal @deprecated (undocumented)
 interface DiffIncrementalInfo {
-    // Warning: (ae-forgotten-export) The symbol "DeferInfoTrie" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    deferInfo?: DeferInfoTrie;
+    isDeferPending?: (path: Incremental.Path, label: string | undefined) => boolean;
     // Warning: (ae-forgotten-export) The symbol "StreamInfoTrie" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -1639,6 +1640,8 @@ namespace Incremental {
         // (undocumented)
         hasNext: boolean;
         // @internal @deprecated (undocumented)
+        isDeferPending(path: Incremental.Path, label: string | undefined): boolean;
+        // @internal @deprecated (undocumented)
         readonly streamInfo?: StreamInfoTrie;
     }
     // (undocumented)
@@ -1796,7 +1799,9 @@ export class InMemoryCache extends ApolloCache {
     // (undocumented)
     watch<TData = unknown, TVariables extends OperationVariables = OperationVariables>(watch: Cache_2.WatchOptions<TData, TVariables>): () => void;
     // (undocumented)
-    write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteOptions<TData, TVariables>): Reference | undefined;
+    write<TData = unknown, TVariables extends OperationVariables = OperationVariables>(options: Cache_2.WriteOptions<TData, TVariables> & {
+        [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
+    }): Reference | undefined;
 }
 
 // @public (undocumented)
@@ -2817,6 +2822,8 @@ export interface ReadMergeModifyContext {
     // (undocumented)
     extensions?: ExtensionsWithStreamInfo;
     // (undocumented)
+    isDeferPending?: (path: Incremental.Path, label: string | undefined) => boolean;
+    // (undocumented)
     store: NormalizedCache;
     // (undocumented)
     variables?: OperationVariables;
@@ -3331,12 +3338,12 @@ interface WriteContext extends ReadMergeModifyContext {
 // Warnings were encountered during analysis:
 //
 // src/cache/core/cache.ts:179:11 - (ae-forgotten-export) The symbol "MissingTree" needs to be exported by the entry point index.d.ts
-// src/cache/core/cache.ts:254:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
+// src/cache/core/cache.ts:239:7 - (ae-forgotten-export) The symbol "DiffIncrementalInfo" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:103:3 - (ae-forgotten-export) The symbol "FragmentMap" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeySpecifier" needs to be exported by the entry point index.d.ts
 // src/cache/inmemory/policies.ts:175:3 - (ae-forgotten-export) The symbol "KeyArgsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:147:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
-// src/cache/inmemory/types.ts:162:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:150:3 - (ae-forgotten-export) The symbol "KeyFieldsFunction" needs to be exported by the entry point index.d.ts
+// src/cache/inmemory/types.ts:165:3 - (ae-forgotten-export) The symbol "FragmentRegistryAPI" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:202:5 - (ae-forgotten-export) The symbol "IgnoreModifier" needs to be exported by the entry point index.d.ts
 // src/core/ApolloClient.ts:673:5 - (ae-forgotten-export) The symbol "NextFetchPolicyContext" needs to be exported by the entry point index.d.ts
 // src/core/ObservableQuery.ts:406:5 - (ae-forgotten-export) The symbol "QueryManager" needs to be exported by the entry point index.d.ts

--- a/.changeset/quick-keys-search.md
+++ b/.changeset/quick-keys-search.md
@@ -1,0 +1,6 @@
+---
+"@apollo/client": patch
+---
+
+Fixed a bug where `streamFieldInfo` might not have been passed into custom merge functions for
+`@stream` directives that had an aliased field in the path.

--- a/.changeset/quiet-defer-nested-fields.md
+++ b/.changeset/quiet-defer-nested-fields.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client": patch
+---
+
+Fix `Missing field` errors being logged when writing `@defer` results where a field is selected both inside and outside of a deferred fragment. Fields whose `@defer` boundary has not arrived yet are no longer reported as missing.

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -230,10 +230,15 @@ export abstract class ApolloCache {
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
   >(query: Cache.ReadOptions<TData, TVariables>): Unmasked<TData> | null;
+
   public abstract write<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-  >(write: Cache.WriteOptions<TData, TVariables>): Reference | undefined;
+  >(
+    write: Cache.WriteOptions<TData, TVariables> & {
+      [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
+    }
+  ): Reference | undefined;
 
   /**
    * Returns data read from the cache for a given query along with information
@@ -922,6 +927,14 @@ export abstract class ApolloCache {
    * the shape of the data you’re writing to the cache is the same as the shape of
    * the data required by the query. Great for prepping the cache with initial data.
    */
+  public writeQuery<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(
+    options: Cache.WriteQueryOptions<TData, TVariables> & {
+      [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
+    }
+  ): Reference | undefined;
   public writeQuery<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,

--- a/src/cache/core/cache.ts
+++ b/src/cache/core/cache.ts
@@ -230,7 +230,6 @@ export abstract class ApolloCache {
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
   >(query: Cache.ReadOptions<TData, TVariables>): Unmasked<TData> | null;
-
   public abstract write<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
@@ -930,14 +929,6 @@ export abstract class ApolloCache {
   public writeQuery<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-  >(
-    options: Cache.WriteQueryOptions<TData, TVariables> & {
-      [handleIncrementalSymbol]: DiffIncrementalInfo | undefined;
-    }
-  ): Reference | undefined;
-  public writeQuery<
-    TData = unknown,
-    TVariables extends OperationVariables = OperationVariables,
   >({
     // spread in type definitions for discoverability in the docs
     data,
@@ -947,6 +938,12 @@ export abstract class ApolloCache {
     id,
     broadcast,
   }: Cache.WriteQueryOptions<TData, TVariables>): Reference | undefined;
+  public writeQuery<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(
+    options: Cache.WriteQueryOptions.WithIncremental<TData, TVariables>
+  ): Reference | undefined;
   public writeQuery<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,

--- a/src/cache/core/types/Cache.ts
+++ b/src/cache/core/types/Cache.ts
@@ -8,6 +8,7 @@ import type {
 import type { Unmasked } from "@apollo/client/masking";
 import type { ExtensionsWithStreamInfo } from "@apollo/client/utilities/internal";
 
+import type { WithHandleIncremental } from "../../inmemory/types.js";
 import type { ApolloCache } from "../cache.js";
 
 import type {
@@ -300,6 +301,12 @@ export declare namespace Cache {
      * are available in `merge` functions.
      */
     extensions?: ExtensionsWithStreamInfo;
+  }
+
+  namespace WriteQueryOptions {
+    interface WithIncremental<TData, TVariables extends OperationVariables>
+      extends WriteQueryOptions<TData, TVariables>,
+        WithHandleIncremental {}
   }
 
   export type WriteFragmentOptions<

--- a/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
+++ b/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
@@ -14,16 +14,6 @@ import {
   makeStreamInfoTrie,
 } from "@apollo/client/utilities/internal";
 
-function pendingDefers(
-  ...entries: Array<[path: Array<string | number>, label?: string]>
-) {
-  return (path: ReadonlyArray<string | number>, label: string | undefined) =>
-    entries.some(
-      ([entryPath, entryLabel]) =>
-        equal(entryPath, path) && entryLabel === label
-    );
-}
-
 test('returns dataState "complete" when the cache fully satisfies the query', () => {
   const cache = new InMemoryCache();
   const query = gql`
@@ -9261,7 +9251,7 @@ test("prunes a complete cached @defer boundary when isDeferPending marks it as p
     },
   });
 
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -9316,7 +9306,7 @@ test("keeps a cached @defer boundary that isDeferPending does not mark as pendin
     },
   });
 
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -9369,7 +9359,7 @@ test("keeps a non-deferred fragment's fields at a path that isDeferPending marks
     },
   });
 
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -9422,7 +9412,10 @@ test("prunes only the labeled @defer boundary that isDeferPending marks as pendi
     },
   });
 
-  const isDeferPending = pendingDefers([["greeting"], "ac_1"]);
+  const isDeferPending = getIsDeferPending({
+    path: ["greeting"],
+    label: "ac_1",
+  });
 
   expect(
     cache.diff({
@@ -9473,7 +9466,10 @@ test("prunes a labeled @defer boundary on a fragment spread that isDeferPending 
     },
   });
 
-  const isDeferPending = pendingDefers([["greeting"], "ac_0"]);
+  const isDeferPending = getIsDeferPending({
+    path: ["greeting"],
+    label: "ac_0",
+  });
 
   expect(
     cache.diff({
@@ -9531,7 +9527,10 @@ test("prunes only the labeled @defer boundary that isDeferPending marks as pendi
     },
   });
 
-  const isDeferPending = pendingDefers([["greeting"], "ac_1"]);
+  const isDeferPending = getIsDeferPending({
+    path: ["greeting"],
+    label: "ac_1",
+  });
 
   expect(
     cache.diff({
@@ -9580,7 +9579,7 @@ test("does not apply isDeferPending pruning when returnPartialData is true", () 
     },
   });
 
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -9633,9 +9632,9 @@ test("prunes cached @defer boundaries for list items marked pending in isDeferPe
     },
   });
 
-  const isDeferPending = pendingDefers(
-    [["person", "friends", 0]],
-    [["person", "friends", 1]]
+  const isDeferPending = getIsDeferPending(
+    { path: ["person", "friends", 0] },
+    { path: ["person", "friends", 1] }
   );
 
   expect(
@@ -9692,7 +9691,7 @@ test("keeps a delivered list item's @defer boundary while pruning a still-pendin
     },
   });
 
-  const isDeferPending = pendingDefers([["person", "friends", 1]]);
+  const isDeferPending = getIsDeferPending({ path: ["person", "friends", 1] });
 
   expect(
     cache.diff({
@@ -9744,9 +9743,7 @@ test("does not reuse an isDeferPending-pruned result when isDeferPending is late
     },
   });
 
-  // A fresh callback identity per call, just like a fresh Trie was, since the
-  // callback participates in the diff's memoization key.
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -9822,9 +9819,10 @@ test("does not reuse an isDeferPending-pruned result when a sibling boundary is 
   });
 
   {
-    // A fresh callback identity per call, just like a fresh Trie was, since
-    // the callback participates in the diff's memoization key.
-    const isDeferPending = pendingDefers([["greeting"]], [["hero"]]);
+    const isDeferPending = getIsDeferPending(
+      { path: ["greeting"] },
+      { path: ["hero"] }
+    );
 
     expect(
       cache.diff({
@@ -9848,7 +9846,7 @@ test("does not reuse an isDeferPending-pruned result when a sibling boundary is 
   }
 
   {
-    const isDeferPending = pendingDefers([["hero"]]);
+    const isDeferPending = getIsDeferPending({ path: ["hero"] });
 
     expect(
       cache.diff({
@@ -9910,7 +9908,7 @@ test("strips a partial pending @defer boundary while keeping a complete delivere
     });
   }
 
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -9970,7 +9968,10 @@ test("strips both a partial pending @defer boundary and a complete pending sibli
     });
   }
 
-  const isDeferPending = pendingDefers([["greeting"]], [["hero"]]);
+  const isDeferPending = getIsDeferPending(
+    { path: ["greeting"] },
+    { path: ["hero"] }
+  );
 
   expect(
     cache.diff({
@@ -10024,7 +10025,7 @@ test("keeps fields shared with a delivered @defer boundary while pruning a pendi
     },
   });
 
-  const isDeferPending = pendingDefers([["hero"]]);
+  const isDeferPending = getIsDeferPending({ path: ["hero"] });
 
   expect(
     cache.diff({
@@ -10077,7 +10078,7 @@ test('returns dataState "partial" when a non-deferred field is missing and isDef
   const missingObject = { __typename: "Greeting", message: "Hello world" };
   const missingRoot = { __ref: "ROOT_QUERY" };
 
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -10140,7 +10141,7 @@ test('returns dataState "empty" when a non-deferred field is missing and isDefer
   const missingObject = { __typename: "Greeting", message: "Hello world" };
   const missingRoot = { __ref: "ROOT_QUERY" };
 
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -10184,7 +10185,7 @@ test('returns dataState "empty" when the cache is empty and isDeferPending marks
 
   const missingRoot = { __ref: "ROOT_QUERY" };
 
-  const isDeferPending = pendingDefers([["greeting"]]);
+  const isDeferPending = getIsDeferPending({ path: ["greeting"] });
 
   expect(
     cache.diff({
@@ -10212,4 +10213,11 @@ function getMissingMessage(fieldName: string, obj: Record<string, unknown>) {
       obj.__ref + " object"
     : "object " + JSON.stringify(obj, null, 2)
   }`;
+}
+
+function getIsDeferPending(
+  ...entries: Array<{ path: Array<string | number>; label?: string }>
+) {
+  return (path: ReadonlyArray<string | number>, label: string | undefined) =>
+    entries.some((entry) => equal(entry.path, path) && entry.label === label);
 }

--- a/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
+++ b/src/cache/inmemory/__tests__/cache.diff/incremental.test.ts
@@ -1,4 +1,4 @@
-import { Trie } from "@wry/trie";
+import { equal } from "@wry/equality";
 
 import { gql } from "@apollo/client";
 import {
@@ -9,11 +9,20 @@ import {
 } from "@apollo/client/cache";
 import { markAsStreaming, spyOnConsole } from "@apollo/client/testing/internal";
 import { addTypenameToDocument } from "@apollo/client/utilities";
-import type { DeferInfoTrie } from "@apollo/client/utilities/internal";
 import {
   handleIncrementalSymbol,
   makeStreamInfoTrie,
 } from "@apollo/client/utilities/internal";
+
+function pendingDefers(
+  ...entries: Array<[path: Array<string | number>, label?: string]>
+) {
+  return (path: ReadonlyArray<string | number>, label: string | undefined) =>
+    entries.some(
+      ([entryPath, entryLabel]) =>
+        equal(entryPath, path) && entryLabel === label
+    );
+}
 
 test('returns dataState "complete" when the cache fully satisfies the query', () => {
   const cache = new InMemoryCache();
@@ -9226,7 +9235,7 @@ test("without handleIncrementalSymbol, a fully satisfied deferred query is compl
   });
 });
 
-test("prunes a complete cached @defer boundary when deferInfo marks it as pending", () => {
+test("prunes a complete cached @defer boundary when isDeferPending marks it as pending", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9252,15 +9261,14 @@ test("prunes a complete cached @defer boundary when deferInfo marks it as pendin
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9275,7 +9283,7 @@ test("prunes a complete cached @defer boundary when deferInfo marks it as pendin
   });
 });
 
-test("keeps a cached @defer boundary that deferInfo does not mark as pending while pruning a sibling boundary that it does", () => {
+test("keeps a cached @defer boundary that isDeferPending does not mark as pending while pruning a sibling boundary that it does", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9308,15 +9316,14 @@ test("keeps a cached @defer boundary that deferInfo does not mark as pending whi
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9332,7 +9339,7 @@ test("keeps a cached @defer boundary that deferInfo does not mark as pending whi
   });
 });
 
-test("keeps a non-deferred fragment's fields at a path that deferInfo marks as pending", () => {
+test("keeps a non-deferred fragment's fields at a path that isDeferPending marks as pending", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9362,15 +9369,14 @@ test("keeps a non-deferred fragment's fields at a path that deferInfo marks as p
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9386,7 +9392,7 @@ test("keeps a non-deferred fragment's fields at a path that deferInfo marks as p
   });
 });
 
-test("prunes only the labeled @defer boundary that deferInfo marks as pending when siblings share a path", () => {
+test("prunes only the labeled @defer boundary that isDeferPending marks as pending when siblings share a path", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9416,15 +9422,14 @@ test("prunes only the labeled @defer boundary that deferInfo marks as pending wh
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting", "ac_1");
+  const isDeferPending = pendingDefers([["greeting"], "ac_1"]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9440,7 +9445,7 @@ test("prunes only the labeled @defer boundary that deferInfo marks as pending wh
   });
 });
 
-test("prunes a labeled @defer boundary on a fragment spread that deferInfo marks as pending", () => {
+test("prunes a labeled @defer boundary on a fragment spread that isDeferPending marks as pending", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9468,15 +9473,14 @@ test("prunes a labeled @defer boundary on a fragment spread that deferInfo marks
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting", "ac_0");
+  const isDeferPending = pendingDefers([["greeting"], "ac_0"]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9491,7 +9495,7 @@ test("prunes a labeled @defer boundary on a fragment spread that deferInfo marks
   });
 });
 
-test("prunes only the labeled @defer boundary that deferInfo marks as pending when sibling fragment spreads share a path", () => {
+test("prunes only the labeled @defer boundary that isDeferPending marks as pending when sibling fragment spreads share a path", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9527,15 +9531,14 @@ test("prunes only the labeled @defer boundary that deferInfo marks as pending wh
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting", "ac_1");
+  const isDeferPending = pendingDefers([["greeting"], "ac_1"]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9551,7 +9554,7 @@ test("prunes only the labeled @defer boundary that deferInfo marks as pending wh
   });
 });
 
-test("does not apply deferInfo pruning when returnPartialData is true", () => {
+test("does not apply isDeferPending pruning when returnPartialData is true", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9577,15 +9580,14 @@ test("does not apply deferInfo pruning when returnPartialData is true", () => {
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: true,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: {
@@ -9601,7 +9603,7 @@ test("does not apply deferInfo pruning when returnPartialData is true", () => {
   });
 });
 
-test("prunes cached @defer boundaries for list items marked pending in deferInfo", () => {
+test("prunes cached @defer boundaries for list items marked pending in isDeferPending", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9631,16 +9633,17 @@ test("prunes cached @defer boundaries for list items marked pending in deferInfo
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("person", "friends", 0);
-  deferInfo.lookup("person", "friends", 1);
+  const isDeferPending = pendingDefers(
+    [["person", "friends", 0]],
+    [["person", "friends", 1]]
+  );
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9689,15 +9692,14 @@ test("keeps a delivered list item's @defer boundary while pruning a still-pendin
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("person", "friends", 1);
+  const isDeferPending = pendingDefers([["person", "friends", 1]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9716,7 +9718,7 @@ test("keeps a delivered list item's @defer boundary while pruning a still-pendin
   });
 });
 
-test("does not reuse a deferInfo-pruned result when deferInfo is later omitted", () => {
+test("does not reuse an isDeferPending-pruned result when isDeferPending is later omitted", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9742,15 +9744,16 @@ test("does not reuse a deferInfo-pruned result when deferInfo is later omitted",
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  // A fresh callback identity per call, just like a fresh Trie was, since the
+  // callback participates in the diff's memoization key.
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9785,7 +9788,7 @@ test("does not reuse a deferInfo-pruned result when deferInfo is later omitted",
   });
 });
 
-test("does not reuse a deferInfo-pruned result when a sibling boundary is delivered on a later read", () => {
+test("does not reuse an isDeferPending-pruned result when a sibling boundary is delivered on a later read", () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -9819,16 +9822,16 @@ test("does not reuse a deferInfo-pruned result when a sibling boundary is delive
   });
 
   {
-    const deferInfo: DeferInfoTrie = new Trie();
-    deferInfo.lookup("greeting");
-    deferInfo.lookup("hero");
+    // A fresh callback identity per call, just like a fresh Trie was, since
+    // the callback participates in the diff's memoization key.
+    const isDeferPending = pendingDefers([["greeting"]], [["hero"]]);
 
     expect(
       cache.diff({
         query,
         optimistic: true,
         returnPartialData: false,
-        [handleIncrementalSymbol]: { deferInfo },
+        [handleIncrementalSymbol]: { isDeferPending },
       })
     ).toStrictEqualTyped({
       result: markAsStreaming({
@@ -9845,15 +9848,14 @@ test("does not reuse a deferInfo-pruned result when a sibling boundary is delive
   }
 
   {
-    const deferInfo: DeferInfoTrie = new Trie();
-    deferInfo.lookup("hero");
+    const isDeferPending = pendingDefers([["hero"]]);
 
     expect(
       cache.diff({
         query,
         optimistic: true,
         returnPartialData: false,
-        [handleIncrementalSymbol]: { deferInfo },
+        [handleIncrementalSymbol]: { isDeferPending },
       })
     ).toStrictEqualTyped({
       result: markAsStreaming({
@@ -9908,15 +9910,14 @@ test("strips a partial pending @defer boundary while keeping a complete delivere
     });
   }
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -9969,16 +9970,14 @@ test("strips both a partial pending @defer boundary and a complete pending sibli
     });
   }
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
-  deferInfo.lookup("hero");
+  const isDeferPending = pendingDefers([["greeting"]], [["hero"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -10025,15 +10024,14 @@ test("keeps fields shared with a delivered @defer boundary while pruning a pendi
     },
   });
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("hero");
+  const isDeferPending = pendingDefers([["hero"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: markAsStreaming({
@@ -10045,7 +10043,7 @@ test("keeps fields shared with a delivered @defer boundary while pruning a pendi
   });
 });
 
-test('returns dataState "partial" when a non-deferred field is missing and deferInfo marks a boundary as pending with returnPartialData: true', () => {
+test('returns dataState "partial" when a non-deferred field is missing and isDeferPending marks a boundary as pending with returnPartialData: true', () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -10079,15 +10077,14 @@ test('returns dataState "partial" when a non-deferred field is missing and defer
   const missingObject = { __typename: "Greeting", message: "Hello world" };
   const missingRoot = { __ref: "ROOT_QUERY" };
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: true,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: {
@@ -10109,7 +10106,7 @@ test('returns dataState "partial" when a non-deferred field is missing and defer
   });
 });
 
-test('returns dataState "empty" when a non-deferred field is missing and deferInfo marks a boundary as pending with returnPartialData: false', () => {
+test('returns dataState "empty" when a non-deferred field is missing and isDeferPending marks a boundary as pending with returnPartialData: false', () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -10143,15 +10140,14 @@ test('returns dataState "empty" when a non-deferred field is missing and deferIn
   const missingObject = { __typename: "Greeting", message: "Hello world" };
   const missingRoot = { __ref: "ROOT_QUERY" };
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: false,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: null,
@@ -10171,7 +10167,7 @@ test('returns dataState "empty" when a non-deferred field is missing and deferIn
   });
 });
 
-test('returns dataState "empty" when the cache is empty and deferInfo marks a boundary as pending', () => {
+test('returns dataState "empty" when the cache is empty and isDeferPending marks a boundary as pending', () => {
   const cache = new InMemoryCache();
   const query = gql`
     query {
@@ -10188,15 +10184,14 @@ test('returns dataState "empty" when the cache is empty and deferInfo marks a bo
 
   const missingRoot = { __ref: "ROOT_QUERY" };
 
-  const deferInfo: DeferInfoTrie = new Trie();
-  deferInfo.lookup("greeting");
+  const isDeferPending = pendingDefers([["greeting"]]);
 
   expect(
     cache.diff({
       query,
       optimistic: true,
       returnPartialData: true,
-      [handleIncrementalSymbol]: { deferInfo },
+      [handleIncrementalSymbol]: { isDeferPending },
     })
   ).toStrictEqualTyped({
     result: null,

--- a/src/cache/inmemory/__tests__/writeToStore.ts
+++ b/src/cache/inmemory/__tests__/writeToStore.ts
@@ -3233,7 +3233,8 @@ describe("writing to the store", () => {
             true: true,
             false: false,
           },
-        }
+        },
+        []
       );
 
       expect(flat.size).toBe(3);

--- a/src/cache/inmemory/inMemoryCache.ts
+++ b/src/cache/inmemory/inMemoryCache.ts
@@ -462,7 +462,11 @@ export class InMemoryCache extends ApolloCache {
   public write<
     TData = unknown,
     TVariables extends OperationVariables = OperationVariables,
-  >(options: Cache.WriteOptions<TData, TVariables>): Reference | undefined {
+  >(
+    options: Cache.WriteOptions<TData, TVariables> & {
+      [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
+    }
+  ): Reference | undefined {
     const { query, variables } = options;
 
     try {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -899,7 +899,7 @@ export class StoreReader {
         const label =
           directive && getDirectiveArgValue(directive, "label", Kind.STRING);
 
-        prune = context.isDeferPending(path, label || undefined);
+        prune = context.isDeferPending(path, label);
       }
 
       if (fragment && policies.fragmentMatches(fragment, data.__typename)) {

--- a/src/cache/inmemory/readFromStore.ts
+++ b/src/cache/inmemory/readFromStore.ts
@@ -19,7 +19,6 @@ import {
 } from "@apollo/client/utilities";
 import { __DEV__ } from "@apollo/client/utilities/environment";
 import type {
-  DeferInfoTrie,
   FragmentMap,
   FragmentMapFunction,
   StreamInfoTrie,
@@ -93,7 +92,6 @@ interface ReadContext extends ReadMergeModifyContext {
   fragmentMap: FragmentMap;
   lookupFragment: FragmentMapFunction;
   streamInfo?: StreamInfoTrie;
-  deferInfo?: DeferInfoTrie;
 }
 
 type ExecResult<R = any> = {
@@ -268,7 +266,7 @@ export class StoreReader {
               selectionSet,
               boundaries,
               context.streamInfo,
-              context.deferInfo
+              context.isDeferPending
             );
           }
         },
@@ -295,7 +293,7 @@ export class StoreReader {
               field,
               boundaries,
               context.streamInfo,
-              context.deferInfo
+              context.isDeferPending
             );
           }
         },
@@ -894,14 +892,14 @@ export class StoreReader {
       const fragment = getFragmentFromSelection(selection, lookupFragment);
       let prune = false;
 
-      if (context.deferInfo && isDeferredFragment(selection, variables)) {
+      if (context.isDeferPending && isDeferredFragment(selection, variables)) {
         const directive = selection.directives?.find(
           (d) => d.name.value === "defer"
         );
         const label =
           directive && getDirectiveArgValue(directive, "label", Kind.STRING);
 
-        prune = !!context.deferInfo.peekArray(path.concat(label || []));
+        prune = context.isDeferPending(path, label || undefined);
       }
 
       if (fragment && policies.fragmentMatches(fragment, data.__typename)) {
@@ -1103,7 +1101,7 @@ function shouldPrune({ dataState }: ExecResult<any>, context: ReadContext) {
         context.streamInfo ||
         // The network hasn't delivered these @defer boundaries yet, so prune
         // the (possibly complete) cached data sitting at them.
-        context.deferInfo
+        context.isDeferPending
       )
     );
   }

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -1,13 +1,13 @@
 import type { DocumentNode, FieldNode } from "graphql";
 
 import type { OperationVariables } from "@apollo/client";
+import type { Incremental } from "@apollo/client/incremental";
 import type {
   Reference,
   StoreObject,
   StoreValue,
 } from "@apollo/client/utilities";
 import type {
-  DeferInfoTrie,
   ExtensionsWithStreamInfo,
   RemoveIndexSignature,
   StreamInfoTrie,
@@ -136,7 +136,10 @@ export type ReadQueryOptions = {
 /** @internal */
 export interface DiffIncrementalInfo {
   streamInfo?: StreamInfoTrie;
-  deferInfo?: DeferInfoTrie;
+  isDeferPending?: (
+    path: Incremental.Path,
+    label: string | undefined
+  ) => boolean;
 }
 
 export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {
@@ -190,6 +193,10 @@ export interface ReadMergeModifyContext {
   // A JSON.stringify-serialized version of context.variables.
   varString?: string;
   extensions?: ExtensionsWithStreamInfo;
+  isDeferPending?: (
+    path: Incremental.Path,
+    label: string | undefined
+  ) => boolean;
 }
 
 type ListOf<T extends string> = `[${T}]`;

--- a/src/cache/inmemory/types.ts
+++ b/src/cache/inmemory/types.ts
@@ -9,6 +9,7 @@ import type {
 } from "@apollo/client/utilities";
 import type {
   ExtensionsWithStreamInfo,
+  handleIncrementalSymbol,
   RemoveIndexSignature,
   StreamInfoTrie,
 } from "@apollo/client/utilities/internal";
@@ -140,6 +141,10 @@ export interface DiffIncrementalInfo {
     path: Incremental.Path,
     label: string | undefined
   ) => boolean;
+}
+
+export interface WithHandleIncremental {
+  [handleIncrementalSymbol]?: DiffIncrementalInfo | undefined;
 }
 
 export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -30,6 +30,7 @@ import {
   getDefaultValues,
   getFragmentFromSelection,
   getOperationDefinition,
+  handleIncrementalSymbol,
   isArray,
   isField,
   isNonEmptyArray,
@@ -60,6 +61,7 @@ import {
 } from "./policies.js";
 import type { StoreReader } from "./readFromStore.js";
 import type {
+  DiffIncrementalInfo,
   InMemoryCacheConfig,
   MergeTree,
   NormalizedCache,
@@ -153,7 +155,10 @@ export class StoreWriter {
       variables,
       overwrite,
       extensions,
-    }: Cache.WriteOptions<TData, TVariables>
+      [handleIncrementalSymbol]: incrementalInfo,
+    }: Cache.WriteOptions<TData, TVariables> & {
+      [handleIncrementalSymbol]?: DiffIncrementalInfo;
+    }
   ): Reference | undefined {
     const operationDefinition = getOperationDefinition(query)!;
     const merger = makeProcessedFieldsMerger();
@@ -178,6 +183,7 @@ export class StoreWriter {
       deferred: false,
       flavors: new Map(),
       extensions,
+      isDeferPending: incrementalInfo?.isDeferPending,
     };
 
     const ref = this.processSelectionSet({
@@ -339,11 +345,16 @@ export class StoreWriter {
       // by the flattenFields method, but some fields may be assigned a modified
       // context, depending on the presence of @client and other directives.
       context,
+      currentPath,
       typename
     ).forEach((context, field) => {
       const resultFieldKey = resultKeyNameFromField(field);
       const value = result[resultFieldKey];
-      const path = [...currentPath, field.name.value];
+      // Use the response key (which accounts for aliases), not
+      // field.name.value, so that @defer/@stream path lookups (and
+      // context.isDeferPending) resolve to the correct boundary for
+      // aliased fields.
+      const path = [...currentPath, resultFieldKey];
 
       fieldNodeSet.add(field);
 
@@ -360,10 +371,15 @@ export class StoreWriter {
         let incomingValue = this.processFieldValue(
           value,
           field,
-          // Reset context.clientOnly and context.deferred to their default
-          // values before processing nested selection sets.
+          // Reset context.clientOnly to its default value before processing
+          // nested selection sets, but inherit context.deferred: a resolved
+          // parent field must not erase the fact that an ancestor @defer
+          // boundary is still pending, or nested fields reached only through
+          // that ancestor will incorrectly be treated as complete and report
+          // spurious "Missing field" errors when their own boundary hasn't
+          // arrived yet.
           field.selectionSet ?
-            getContextFlavor(context, false, false)
+            getContextFlavor(context, false, context.deferred)
           : context,
           childTree,
           path
@@ -551,6 +567,7 @@ export class StoreWriter {
       | "deferred"
       | "flavors"
       | "fragmentMap"
+      | "isDeferPending"
       | "lookupFragment"
       | "variables"
     >,
@@ -558,6 +575,7 @@ export class StoreWriter {
     selectionSet: SelectionSetNode,
     result: Record<string, any>,
     context: TContext,
+    path: Array<string | number>,
     typename = getTypenameFromResult(result, selectionSet, context.fragmentMap)
   ): Map<FieldNode, TContext> {
     const fieldMap = new Map<FieldNode, TContext>();
@@ -613,10 +631,22 @@ export class StoreWriter {
               // @defer(if: false) does not make context.deferred false, but
               // instead behaves as if there was no @defer directive.
               if (!args || (args as { if?: boolean }).if !== false) {
-                deferred = true;
+                // If we know (via context.isDeferPending) that this specific
+                // boundary has already been delivered, we don't need to mark
+                // it deferred, which allows fields under it to be validated
+                // normally instead of being silently exempted from the
+                // "Missing field" check below. When we can't determine
+                // whether the boundary is still pending (no callback, or the
+                // handler can't identify individual boundaries),
+                // conservatively assume it's still pending (`?? true`).
+                // `||=` (rather than `=`) preserves `deferred` if it was
+                // already true from an ancestor boundary.
+                deferred ||=
+                  context.isDeferPending?.(
+                    path,
+                    (args as { label?: string } | null)?.label
+                  ) ?? true;
               }
-              // TODO In the future, we may want to record args.label using
-              // context.deferred, if a label is specified.
             }
           });
         }

--- a/src/cache/inmemory/writeToStore.ts
+++ b/src/cache/inmemory/writeToStore.ts
@@ -350,10 +350,6 @@ export class StoreWriter {
     ).forEach((context, field) => {
       const resultFieldKey = resultKeyNameFromField(field);
       const value = result[resultFieldKey];
-      // Use the response key (which accounts for aliases), not
-      // field.name.value, so that @defer/@stream path lookups (and
-      // context.isDeferPending) resolve to the correct boundary for
-      // aliased fields.
       const path = [...currentPath, resultFieldKey];
 
       fieldNodeSet.add(field);

--- a/src/core/QueryInfo.ts
+++ b/src/core/QueryInfo.ts
@@ -1,4 +1,3 @@
-import { Trie } from "@wry/trie";
 import type { DocumentNode, FormattedExecutionResult } from "graphql";
 
 import type {
@@ -259,6 +258,9 @@ export class QueryInfo<
           variables,
           overwrite: cacheWriteBehavior === CacheWriteBehavior.OVERWRITE,
           extensions: result.extensions,
+          [handleIncrementalSymbol]: {
+            isDeferPending: this.incremental?.isDeferPending,
+          },
         });
 
         const { dataState, result: diffResult } = this.getDiff(
@@ -312,10 +314,19 @@ export class QueryInfo<
     if (prune) {
       for (const item of pending) {
         if (item.type === "defer" && !item.delivered) {
-          incrementalInfo.deferInfo ||= new Trie(true, () => true);
-          incrementalInfo.deferInfo.lookupArray(
-            item.path.concat(item.label || [])
-          );
+          // Deliberately a new closure on every call, NOT
+          // `this.incremental.isDeferPending` itself. `context.isDeferPending`
+          // is part of the memoization key of
+          // `prunePartialBoundaries`/`prunePartialStreamArray` in
+          // readFromStore.ts. A stable function reference would let a prune
+          // result computed while a boundary was pending be served again
+          // after it was delivered. A fresh identity per read (like the
+          // fresh Trie it replaces) keeps those results from being reused
+          // across chunks, while `undefined` (nothing pending) still allows
+          // reuse. Do not "optimize" this into a cached reference.
+          const isDeferPending = this.incremental!.isDeferPending;
+          incrementalInfo.isDeferPending ||= (path, label) =>
+            isDeferPending(path, label);
         } else if (streamInfo && item.type === "stream") {
           streamInfo.lookupArray(item.path as any[]).state.truncate = true;
         }

--- a/src/core/__tests__/client.watchQuery/defer20220824.test.ts
+++ b/src/core/__tests__/client.watchQuery/defer20220824.test.ts
@@ -739,10 +739,5 @@ test("deeply nested defer doesn't cause cache to log errors about missing fields
     partial: false,
   });
 
-  // this should not log errors, but currently does:
-  /*
-    1: "Missing field '%s' while writing result %o", "likes", {"__typename": "Comment", "author": {"__typename": "Author", "id": "a1", "name": "x"}, "id": "c1", "text": "first!"}
-    2: "Missing field '%s' while writing result %o", "badge", {"__typename": "Author", "id": "a1", "name": "x"}
-  */
   expect(spy.error).not.toHaveBeenCalled();
 });

--- a/src/core/__tests__/client.watchQuery/defer20220824.test.ts
+++ b/src/core/__tests__/client.watchQuery/defer20220824.test.ts
@@ -9,6 +9,7 @@ import {
   markAsStreaming,
   mockDefer20220824,
   ObservableStream,
+  spyOnConsole,
 } from "@apollo/client/testing/internal";
 
 test("deduplicates queries as long as a query still has deferred chunks", async () => {
@@ -577,4 +578,171 @@ test("delivers cache updates written while a deferred response is still streamin
 
   await expect(stream).not.toEmitAnything();
   expect(outgoingRequestSpy).toHaveBeenCalledTimes(1);
+});
+
+test("deeply nested defer doesn't cause cache to log errors about missing fields", async () => {
+  const query = gql`
+    query Q {
+      post {
+        id
+        __typename
+        comments {
+          id
+          __typename
+          text
+          author {
+            id
+            __typename
+            name
+          }
+        }
+        ...CommentDetails @defer
+      }
+    }
+    fragment CommentDetails on Post {
+      id
+      __typename
+      comments {
+        id
+        __typename
+        likes
+        author {
+          id
+          __typename
+          badge {
+            id
+            __typename
+          }
+        }
+      }
+    }
+  `;
+
+  using spy = spyOnConsole("error");
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDefer20220824();
+
+  const client = new ApolloClient({
+    link: httpLink,
+    cache: new InMemoryCache(),
+    incrementalHandler: new Defer20220824Handler(),
+  });
+  const stream = new ObservableStream(client.watchQuery({ query }));
+
+  enqueueInitialChunk({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "p1",
+        comments: [
+          {
+            __typename: "Comment",
+            id: "c1",
+            text: "first!",
+            author: {
+              __typename: "Author",
+              id: "a1",
+              name: "x",
+            },
+          },
+        ],
+      },
+    },
+    hasNext: true,
+  });
+  enqueueSubsequentChunk({
+    hasNext: false,
+    incremental: [
+      {
+        path: ["post"],
+        data: {
+          __typename: "Post",
+          id: "p1",
+          comments: [
+            {
+              __typename: "Comment",
+              id: "c1",
+              likes: 42,
+              author: {
+                __typename: "Author",
+                id: "a1",
+                badge: { __typename: "Badge", id: "b1" },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: {
+        __typename: "Post",
+        id: "p1",
+        comments: [
+          {
+            __typename: "Comment",
+            author: {
+              __typename: "Author",
+              id: "a1",
+              name: "x",
+            },
+            id: "c1",
+            text: "first!",
+          },
+        ],
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: {
+        __typename: "Post",
+        id: "p1",
+        comments: [
+          {
+            __typename: "Comment",
+            author: {
+              __typename: "Author",
+              id: "a1",
+              badge: {
+                __typename: "Badge",
+                id: "b1",
+              },
+              name: "x",
+            },
+            id: "c1",
+            likes: 42,
+            text: "first!",
+          },
+        ],
+      },
+    }),
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  // this should not log errors, but currently does:
+  /*
+    1: "Missing field '%s' while writing result %o", "likes", {"__typename": "Comment", "author": {"__typename": "Author", "id": "a1", "name": "x"}, "id": "c1", "text": "first!"}
+    2: "Missing field '%s' while writing result %o", "badge", {"__typename": "Author", "id": "a1", "name": "x"}
+  */
+  expect(spy.error).not.toHaveBeenCalled();
 });

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10926,7 +10926,7 @@ test("deeply nested defer doesn't cause cache to log errors about missing fields
         ],
       },
     },
-    pending: [{ id: "0", path: ["post"] }],
+    pending: [{ id: "0", path: ["post"], label: "ac_0" }],
     hasNext: true,
   });
   enqueueSubsequentChunk({
@@ -11089,7 +11089,7 @@ test("deeply nested defer still logs errors about missing non-deferred fields un
         ],
       },
     },
-    pending: [{ id: "0", path: ["post"] }],
+    pending: [{ id: "0", path: ["post"], label: "ac_0" }],
     hasNext: true,
   });
 

--- a/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
+++ b/src/core/__tests__/client.watchQuery/deferGraphQL17Alpha9.test.ts
@@ -10857,3 +10857,293 @@ test.failing(
     await expect(stream).not.toEmitAnything();
   }
 );
+test("deeply nested defer doesn't cause cache to log errors about missing fields", async () => {
+  const query = gql`
+    query Q {
+      post {
+        id
+        __typename
+        comments {
+          id
+          __typename
+          text
+          author {
+            id
+            __typename
+            name
+          }
+        }
+        ...CommentDetails @defer
+      }
+    }
+    fragment CommentDetails on Post {
+      id
+      __typename
+      comments {
+        id
+        __typename
+        likes
+        author {
+          id
+          __typename
+          badge {
+            id
+            __typename
+          }
+        }
+      }
+    }
+  `;
+
+  using spy = spyOnConsole("error");
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+
+  const client = new ApolloClient({
+    link: httpLink,
+    cache: new InMemoryCache(),
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const stream = new ObservableStream(client.watchQuery({ query }));
+
+  enqueueInitialChunk({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "p1",
+        comments: [
+          {
+            __typename: "Comment",
+            id: "c1",
+            text: "first!",
+            author: {
+              __typename: "Author",
+              id: "a1",
+              name: "x",
+            },
+          },
+        ],
+      },
+    },
+    pending: [{ id: "0", path: ["post"] }],
+    hasNext: true,
+  });
+  enqueueSubsequentChunk({
+    hasNext: false,
+    incremental: [
+      {
+        id: "0",
+        data: {
+          __typename: "Post",
+          id: "p1",
+          comments: [
+            {
+              __typename: "Comment",
+              id: "c1",
+              likes: 42,
+              author: {
+                __typename: "Author",
+                id: "a1",
+                badge: { __typename: "Badge", id: "b1" },
+              },
+            },
+          ],
+        },
+      },
+    ],
+    completed: [{ id: "0" }],
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: undefined,
+    dataState: "empty",
+    loading: true,
+    networkStatus: NetworkStatus.loading,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: {
+        __typename: "Post",
+        id: "p1",
+        comments: [
+          {
+            __typename: "Comment",
+            author: {
+              __typename: "Author",
+              id: "a1",
+              name: "x",
+            },
+            id: "c1",
+            text: "first!",
+          },
+        ],
+      },
+    }),
+    dataState: "streaming",
+    loading: true,
+    networkStatus: NetworkStatus.streaming,
+    partial: true,
+  });
+
+  await expect(stream).toEmitTypedValue({
+    data: markAsStreaming({
+      post: {
+        __typename: "Post",
+        id: "p1",
+        comments: [
+          {
+            __typename: "Comment",
+            author: {
+              __typename: "Author",
+              id: "a1",
+              badge: {
+                __typename: "Badge",
+                id: "b1",
+              },
+              name: "x",
+            },
+            id: "c1",
+            likes: 42,
+            text: "first!",
+          },
+        ],
+      },
+    }),
+    dataState: "complete",
+    loading: false,
+    networkStatus: NetworkStatus.ready,
+    partial: false,
+  });
+
+  expect(spy.error).not.toHaveBeenCalled();
+});
+
+test("deeply nested defer still logs errors about missing non-deferred fields under shared parents", async () => {
+  const query = gql`
+    query Q {
+      post {
+        id
+        __typename
+        comments {
+          id
+          __typename
+          text
+          author {
+            id
+            __typename
+            name
+          }
+        }
+        ...CommentDetails @defer
+      }
+    }
+    fragment CommentDetails on Post {
+      id
+      __typename
+      comments {
+        id
+        __typename
+        likes
+        author {
+          id
+          __typename
+          badge {
+            id
+            __typename
+          }
+        }
+      }
+    }
+  `;
+
+  using spy = spyOnConsole("error");
+
+  const { httpLink, enqueueInitialChunk, enqueueSubsequentChunk } =
+    mockDeferStreamGraphQL17Alpha9();
+
+  const client = new ApolloClient({
+    link: httpLink,
+    cache: new InMemoryCache(),
+    incrementalHandler: new GraphQL17Alpha9Handler(),
+  });
+  const stream = new ObservableStream(client.watchQuery({ query }));
+
+  // `text` and `name` are missing, but not deferred
+  enqueueInitialChunk({
+    data: {
+      post: {
+        __typename: "Post",
+        id: "p1",
+        comments: [
+          {
+            __typename: "Comment",
+            id: "c1",
+            author: {
+              __typename: "Author",
+              id: "a1",
+            },
+          },
+        ],
+      },
+    },
+    pending: [{ id: "0", path: ["post"] }],
+    hasNext: true,
+  });
+
+  await stream.takeNext();
+  await stream.takeNext();
+
+  expect(spy.error).toHaveBeenCalledTimes(2);
+  expect(spy.error).toHaveBeenCalledWith(
+    expect.stringContaining("Missing field"),
+    "text",
+    expect.anything()
+  );
+  expect(spy.error).toHaveBeenCalledWith(
+    expect.stringContaining("Missing field"),
+    "name",
+    expect.anything()
+  );
+
+  enqueueSubsequentChunk({
+    hasNext: false,
+    incremental: [
+      {
+        id: "0",
+        data: {
+          __typename: "Post",
+          id: "p1",
+          comments: [
+            {
+              __typename: "Comment",
+              id: "c1",
+              likes: 42,
+              author: {
+                __typename: "Author",
+                id: "a1",
+                badge: { __typename: "Badge", id: "b1" },
+              },
+            },
+          ],
+        },
+      },
+    ],
+    completed: [{ id: "0" }],
+  });
+
+  await stream.takeNext();
+
+  expect(spy.error).not.toHaveBeenCalledWith(
+    expect.anything(),
+    "likes",
+    expect.anything()
+  );
+  expect(spy.error).not.toHaveBeenCalledWith(
+    expect.anything(),
+    "badge",
+    expect.anything()
+  );
+});

--- a/src/incremental/handlers/defer20220824.ts
+++ b/src/incremental/handlers/defer20220824.ts
@@ -63,15 +63,13 @@ class DeferRequest<TData extends Record<string, unknown>>
   implements
     Incremental.IncrementalRequest<Defer20220824Handler.Chunk<TData>, TData>
 {
+  private hasDefer: boolean;
   public hasNext = true;
-
-  // This protocol has no `pending`/`completed` bookkeeping, so we can't tell
-  // which `@defer` boundary (if any) a given `path`/`label` refers to - only
-  // whether *something* is still in flight (`hasNext`) or a boundary failed
-  // outright and will never deliver (`hasFailedDefer`). `isDeferPending`
-  // below is intentionally coarse-grained: it treats every path as pending
-  // as long as either is true.
   private hasFailedDefer = false;
+
+  constructor({ query }: Incremental.StartRequestOptions) {
+    this.hasDefer = hasDirectives(["defer"], query);
+  }
 
   private errors: Array<GraphQLFormattedError> = [];
   private extensions: Record<string, any> = {};
@@ -129,10 +127,6 @@ class DeferRequest<TData extends Record<string, unknown>>
         }
 
         if ("data" in incremental && incremental.data === null) {
-          // A `null` `data` on a `@defer` incremental chunk means that
-          // boundary failed and will never deliver its data. We can't tell
-          // which boundary failed, so treat any boundary as potentially
-          // still pending until the whole request finishes.
           this.hasFailedDefer = true;
         }
 
@@ -178,7 +172,7 @@ class DeferRequest<TData extends Record<string, unknown>>
   // `path`/`label`, so we can't answer whether a *specific* boundary is
   // pending - only whether *anything* might still be coming (`hasNext`), or
   // whether a boundary failed and will never arrive (`hasFailedDefer`).
-  isDeferPending = () => this.hasNext || this.hasFailedDefer;
+  isDeferPending = () => this.hasDefer && (this.hasNext || this.hasFailedDefer);
 }
 
 /**
@@ -233,9 +227,9 @@ export class Defer20220824Handler
     return request;
   }
   startRequest<TData extends Record<string, unknown>>(
-    _: Incremental.StartRequestOptions
+    opts: Incremental.StartRequestOptions
   ) {
-    return new DeferRequest<TData>();
+    return new DeferRequest<TData>(opts);
   }
 }
 

--- a/src/incremental/handlers/defer20220824.ts
+++ b/src/incremental/handlers/defer20220824.ts
@@ -65,6 +65,14 @@ class DeferRequest<TData extends Record<string, unknown>>
 {
   public hasNext = true;
 
+  // This protocol has no `pending`/`completed` bookkeeping, so we can't tell
+  // which `@defer` boundary (if any) a given `path`/`label` refers to - only
+  // whether *something* is still in flight (`hasNext`) or a boundary failed
+  // outright and will never deliver (`hasFailedDefer`). `isDeferPending`
+  // below is intentionally coarse-grained: it treats every path as pending
+  // as long as either is true.
+  private hasFailedDefer = false;
+
   private errors: Array<GraphQLFormattedError> = [];
   private extensions: Record<string, any> = {};
   private data: any = {};
@@ -120,6 +128,14 @@ class DeferRequest<TData extends Record<string, unknown>>
           }
         }
 
+        if ("data" in incremental && incremental.data === null) {
+          // A `null` `data` on a `@defer` incremental chunk means that
+          // boundary failed and will never deliver its data. We can't tell
+          // which boundary failed, so treat any boundary as potentially
+          // still pending until the whole request finishes.
+          this.hasFailedDefer = true;
+        }
+
         let data: any =
           "items" in incremental ? incremental.items
             // Ensure `data: null` isn't merged for `@defer` responses by
@@ -157,6 +173,12 @@ class DeferRequest<TData extends Record<string, unknown>>
 
     return result;
   }
+
+  // This protocol can't identify individual `@defer`/`@stream` boundaries by
+  // `path`/`label`, so we can't answer whether a *specific* boundary is
+  // pending - only whether *anything* might still be coming (`hasNext`), or
+  // whether a boundary failed and will never arrive (`hasFailedDefer`).
+  isDeferPending = () => this.hasNext || this.hasFailedDefer;
 }
 
 /**

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -1,3 +1,4 @@
+import { equal } from "@wry/equality";
 import type { FormattedExecutionResult, GraphQLFormattedError } from "graphql";
 
 import type { ApolloLink } from "@apollo/client/link";
@@ -123,6 +124,24 @@ class IncrementalRequest<TData>
       };
     });
   }
+
+  /** @internal */
+  isDeferPending = (
+    path: Incremental.Path,
+    label: string | undefined
+  ): boolean => {
+    for (const pending of this.pendingMap.values()) {
+      if (pending.id in this.streamPositions) {
+        continue;
+      }
+
+      if (pending.label === label && equal(pending.path, path)) {
+        return this.completedMap.get(pending.id) !== true;
+      }
+    }
+
+    return false;
+  };
 
   handle(
     cacheData: TData | DeepPartial<TData> | null | undefined = this.data,

--- a/src/incremental/handlers/graphql17Alpha9.ts
+++ b/src/incremental/handlers/graphql17Alpha9.ts
@@ -125,7 +125,12 @@ class IncrementalRequest<TData>
     });
   }
 
-  /** @internal */
+  /**
+   * @internal
+   * Important: this function is used as a reactivity dependency in the `readFromStore.prune*` methods.
+   * It needs to be a different instance for each instance of `IncrementalRequest`,
+   * so it cannot be a normal class/prototype method, but it has to be an instance property.
+   */
   isDeferPending = (
     path: Incremental.Path,
     label: string | undefined

--- a/src/incremental/types.ts
+++ b/src/incremental/types.ts
@@ -47,6 +47,8 @@ export declare namespace Incremental {
     readonly streamInfo?: StreamInfoTrie;
     /** @internal */
     getPendingWithInfo?: () => Array<PendingItemWithInfo>;
+    /** @internal */
+    isDeferPending(path: Incremental.Path, label: string | undefined): boolean;
 
     handle: (
       cacheData: TData | DeepPartial<TData> | undefined | null,

--- a/src/utilities/internal/index.ts
+++ b/src/utilities/internal/index.ts
@@ -14,7 +14,6 @@ export type { Primitive } from "./types/Primitive.js";
 export type { RejectedPromise } from "./types/RejectedPromise.js";
 export type { RemoveIndexSignature } from "./types/RemoveIndexSignature.js";
 export type { StreamInfoTrie } from "./types/StreamInfoTrie.js";
-export type { DeferInfoTrie } from "./types/DeferInfo.js";
 export type { VariablesOption } from "./types/VariablesOption.js";
 export type { DocumentationTypes } from "./types/DocumentationTypes.js";
 export type { LazyType } from "./LazyType.js";

--- a/src/utilities/internal/types/DeferInfo.ts
+++ b/src/utilities/internal/types/DeferInfo.ts
@@ -1,8 +1,0 @@
-import type { Trie } from "@wry/trie";
-
-/**
- * @internal
- * For use in InMemoryCache only. This should not be used in userland
- * code.
- */
-export type DeferInfoTrie = Trie<true>;


### PR DESCRIPTION
Supersedes #13454, based on release-4.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed incorrect “Missing field” errors when deferred fragments contain fields selected both inside and outside the fragment.
  - Improved handling of nested and failed `@defer` responses so pending fields are not reported prematurely.
  - Preserved missing-field warnings for fields that are not part of deferred content.

- **API Updates**
  - Added APIs for checking whether deferred content is still pending during incremental requests and cache operations.
  - Added typed support for passing incremental delivery information through cache writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->